### PR TITLE
Render Container Refactor

### DIFF
--- a/src/Blocks/ItemContainer.purs
+++ b/src/Blocks/ItemContainer.purs
@@ -74,30 +74,36 @@ buttonClasses = HH.ClassName <$>
   , "text-grey"
   ]
 
--- Provided an array of items, renders them in a container.
+-- Provided an array of items and any additional HTML, renders the container
 -- Items should have already been treated with `boldMatches` by this point.
 itemContainer
   :: ∀ t o item eff
    . Maybe Int
   -> Array HH.PlainHTML
+  -> Array (H.HTML t (Select.Query o item eff))
   -> H.HTML t (Select.Query o item eff)
-itemContainer highlightIndex html =
+itemContainer highlightIndex itemsHTML addlHTML =
   HH.div
-  (Setters.setContainerProps [ HP.classes itemContainerClasses ])
-  [ HH.ul
-    [ HP.classes ulClasses ]
-    $ mapWithIndex
-      ( \i h ->
-          HH.li
-            ( Setters.setItemProps i
-              [ HP.classes (HH.ClassName "py-3" : liClasses <> hover i) ]
-            )
-            [ HH.fromPlainHTML h ]
-      )
-      html
-  ]
+    ( Setters.setContainerProps [ HP.classes itemContainerClasses ] )
+    ( renderItems <> addlHTML )
   where
+    hover :: Int -> Array HH.ClassName
     hover i = if highlightIndex == Just i then HH.ClassName <$> [ "bg-grey-lighter" ] else mempty
+
+    renderItems :: Array (H.HTML t (Select.Query o item eff))
+    renderItems =
+      [ HH.ul
+        [ HP.classes ulClasses ]
+        $ mapWithIndex
+          ( \i h ->
+              HH.li
+                ( Setters.setItemProps i
+                  [ HP.classes (HH.ClassName "py-3" : liClasses <> hover i) ]
+                )
+                [ HH.fromPlainHTML h ]
+          )
+          itemsHTML
+      ]
 
 
 -- Provided an array of selection items, renders them in a container

--- a/src/Components/Typeahead/Typeahead.purs
+++ b/src/Components/Typeahead/Typeahead.purs
@@ -14,7 +14,7 @@ import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
-import Network.RemoteData (RemoteData(..))
+import Network.RemoteData (RemoteData(..), isSuccess)
 import Ocelot.Block.Input as Input
 import Ocelot.Block.ItemContainer as ItemContainer
 import Ocelot.Block.Type as Type
@@ -34,7 +34,7 @@ type RenderTypeaheadItem o item eff
 renderItemString :: ∀ o eff. RenderTypeaheadItem o String eff
 renderItemString =
   { toStrMap: singleton "name"
-  , renderContainer: defRenderContainer defRenderFuzzy
+  , renderContainer: defRenderContainer_ defRenderFuzzy
   , renderItem: HH.text }
 
 ----------
@@ -51,15 +51,16 @@ defRenderFuzzy = HH.span_ <<< ItemContainer.boldMatches "name"
 defRenderItem :: ∀ r. { name :: String | r } -> HH.PlainHTML
 defRenderItem { name } = HH.text name
 
-type RenderContainer o item eff =
-  Select.State (Fuzzy item) (TA.Effects eff)
+type RenderContainer o item eff
+  = Select.State (Fuzzy item) (TA.Effects eff)
   -> H.ComponentHTML (Select.Query o (Fuzzy item) (TA.Effects eff))
 
 defRenderContainer
   :: ∀ o item eff
    . (Fuzzy item -> HH.PlainHTML)
+  -> Array (H.HTML Void (Select.Query o (Fuzzy item) (TA.Effects eff)))
   -> RenderContainer o item eff
-defRenderContainer renderFuzzy selectState =
+defRenderContainer renderFuzzy addlHTML selectState =
   HH.div
     [ HP.class_ $ HH.ClassName "relative" ]
     if selectState.visibility == Select.Off then []
@@ -67,7 +68,15 @@ defRenderContainer renderFuzzy selectState =
     [ ItemContainer.itemContainer
         selectState.highlightedIndex
         (renderFuzzy <$> selectState.items)
+        addlHTML
     ]
+
+defRenderContainer_
+  :: ∀ o item eff
+   . (Fuzzy item -> HH.PlainHTML)
+  -> RenderContainer o item eff
+defRenderContainer_ renderFuzzy = defRenderContainer renderFuzzy []
+
 
 ----------
 -- Default typeahead configurations
@@ -221,7 +230,7 @@ renderTA props renderContainer renderSelectionItem st =
       , debounceTime: case st.config.syncMethod of
           TA.Async { debounceTime } -> Just debounceTime
           TA.Sync -> Nothing
-      , render: \selectState -> HH.div_ [ renderSearch, renderContainer selectState ]
+      , render: \selectState -> HH.div_ [ renderSearch, renderContainer_ selectState ]
       }
 
     itemProps item = [ HE.onClick (HE.input_ (TA.Remove item)) ]
@@ -255,3 +264,7 @@ renderTA props renderContainer renderSelectionItem st =
           [ HP.classes $ Input.inputRightBorderClasses <> Type.linkClasses ]
           [ HH.text "Browse" ]
         ]
+
+    renderContainer_
+      | isSuccess st.items = renderContainer
+      | otherwise = const $ HH.div_ []

--- a/src/Core/Typeahead.purs
+++ b/src/Core/Typeahead.purs
@@ -293,7 +293,8 @@ component =
           NotAsked -> do
             _ <- H.query unit $ H.action $ Select.SetVisibility Select.Off
             H.query unit $ H.action $ Select.ReplaceItems []
-          Loading -> pure (pure unit)
+          Loading -> do
+            H.query unit $ H.action $ Select.ReplaceItems []
 
         pure a
 

--- a/ui-guide/Components/Validation.purs
+++ b/ui-guide/Components/Validation.purs
@@ -392,7 +392,7 @@ derive instance newtypeTestRecord :: Newtype TestRecord _
 renderItemTestRecord :: ∀ o eff. TA.RenderTypeaheadItem o TestRecord eff
 renderItemTestRecord =
   { toStrMap: testToStrMap
-  , renderContainer: TA.defRenderContainer TA.defRenderFuzzy
+  , renderContainer: TA.defRenderContainer_ TA.defRenderFuzzy
   , renderItem: (TA.defRenderItem <<< unwrap)
   }
 

--- a/ui-guide/Utilities/Async.purs
+++ b/ui-guide/Utilities/Async.purs
@@ -15,7 +15,6 @@ import Halogen.HTML as HH
 import Network.HTTP.Affjax (get, AJAX)
 import Network.RemoteData (RemoteData, fromEither)
 import Ocelot.Block.ItemContainer as ItemContainer
-import Ocelot.Components.Typeahead (defRenderContainer)
 import Ocelot.Components.Typeahead as TA
 
 
@@ -110,7 +109,7 @@ renderItemTodo :: ∀ o eff. TA.RenderTypeaheadItem o Todo eff
 renderItemTodo =
   { toStrMap: todoToStrMap
   , renderItem: HH.text <<< _.title <<< unwrap
-  , renderContainer: TA.defRenderContainer (HH.span_ <<< ItemContainer.boldMatches "title")
+  , renderContainer: TA.defRenderContainer_ (HH.span_ <<< ItemContainer.boldMatches "title")
   }
 
 
@@ -138,7 +137,7 @@ renderItemUser :: ∀ o eff. TA.RenderTypeaheadItem o User eff
 renderItemUser =
   { toStrMap: userToStrMap
   , renderItem: TA.defRenderItem <<< unwrap
-  , renderContainer: TA.defRenderContainer TA.defRenderFuzzy
+  , renderContainer: TA.defRenderContainer_ TA.defRenderFuzzy
   }
 
 userToStrMap :: User -> StrMap String


### PR DESCRIPTION
This refactor updates our render container functions to allow for passing additional HTML to render inside the container beyond just the list of selectable items.

I also hide the container if the items are in a state other than `Success`, and reset the items inside the Select component to empty when we synchronize in a `Loading` state. The next step here I think would be to display some error version of the container when we're in an error state.