### PR TITLE
Add helper for test attributes

### DIFF
--- a/src/Core/Utils/Utils.purs
+++ b/src/Core/Utils/Utils.purs
@@ -18,6 +18,12 @@ import Unsafe.Coerce (unsafeCoerce)
 
 type IProp r i = HH.IProp ("class" :: String | r) i
 
+testId
+  :: ∀ r i
+   . String
+  -> IProp r i
+testId = HP.attr (HH.AttrName "data-testid")
+
 css
   :: ∀ r i
    . String


### PR DESCRIPTION
This adds a function `testId` which will create a data attribute with the provided string:

```purescript
testId "myId" -> data-testid=myId
```

With this, we can add a persistent ID for testing purposes.