### PR TITLE
Dropdown Interop

### DIFF
--- a/src/Components/Dropdown/Component.purs
+++ b/src/Components/Dropdown/Component.purs
@@ -8,8 +8,8 @@ import Data.Maybe (Maybe(..))
 import Effect.Aff.Class (class MonadAff)
 import Halogen as H
 import Halogen.HTML as HH
-import Select as Select
 import Renderless.State (updateStore)
+import Select as Select
 
 data Query o item m a
   = HandleSelect (Select.Message o item) a

--- a/src/Components/Typeahead/Render.purs
+++ b/src/Components/Typeahead/Render.purs
@@ -3,15 +3,17 @@ module Ocelot.Component.Typeahead.Render where
 import Prelude
 
 import DOM.HTML.Indexed (HTMLinput)
-import Data.Array (foldr, null)
+import Data.Array (foldr, null, (:))
 import Data.Fuzzy (Fuzzy)
-import Data.Maybe (Maybe, isJust, maybe)
+import Data.Maybe (Maybe(..), isJust, isNothing, maybe)
+import Data.Newtype (unwrap)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Core (Prop(..), PropValue)
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Network.RemoteData (isFailure, isLoading)
+import Ocelot.Block.Button as Button
 import Ocelot.Block.Conditional (conditional)
 import Ocelot.Block.Format as Format
 import Ocelot.Block.Icon as Icon
@@ -157,6 +159,61 @@ defRenderContainer
 defRenderContainer renderFuzzy cst =
   IC.itemContainer cst.highlightedIndex (renderFuzzy <$> cst.items) []
 
+
+renderSearchDropdown
+  :: ∀ pq item m
+   . Eq item
+  => String
+  -> String
+  -> (item -> HH.PlainHTML)
+  -> (Fuzzy item -> HH.PlainHTML)
+  -> TA.State Maybe item m
+  -> Select.State (Fuzzy item)
+  -> Select.ComponentHTML (TA.Query pq Maybe item m) (Fuzzy item)
+renderSearchDropdown label resetLabel renderItem renderFuzzy pst cst =
+  HH.label
+    [ css "relative" ]
+    [ IC.dropdownButton
+      HH.span
+      [ HP.classes
+        $ HH.ClassName "whitespace-no-wrap" :
+          Button.buttonMainClasses <> Button.buttonClearClasses
+      ]
+      [ maybe (HH.text label) (HH.fromPlainHTML <<< renderItem) pst.selected ]
+    , HH.div
+      [ HP.classes
+        $ HH.ClassName "min-w-80" :
+          if cst.visibility == Select.Off
+            then [ HH.ClassName "offscreen" ]
+            else []
+      ]
+      [ IC.dropdownContainer
+        [ renderInput, renderReset ]
+        renderFuzzy
+        ((==) pst.selected <<< Just <<< _.original <<< unwrap)
+        cst.items
+        cst.highlightedIndex
+      ]
+    ]
+  where
+    renderInput =
+      HH.div
+        [ css "m-4 border-b-2 border-blue-88 pb-2 flex" ]
+        [ Icon.search [ css "mr-4 text-xl text-grey-70" ]
+        , HH.input
+          $ inputProps false [ css "no-outline w-full", HP.placeholder "Search" ]
+        ]
+
+    renderReset =
+      IC.dropdownItem
+        HH.div
+        [ HE.onClick \_ -> Just do
+          Select.raise $ TA.RemoveAll unit
+          Select.setVisibility Select.Off
+        ]
+        [ HH.text resetLabel ]
+        ( isNothing pst.selected )
+        false
 ----------
 -- Shared Helpers
 

--- a/src/Components/Typeahead/Render.purs
+++ b/src/Components/Typeahead/Render.purs
@@ -159,8 +159,7 @@ defRenderContainer
 defRenderContainer renderFuzzy cst =
   IC.itemContainer cst.highlightedIndex (renderFuzzy <$> cst.items) []
 
-
-renderSearchDropdown
+renderToolbarSearchDropdown
   :: ∀ pq item m
    . Eq item
   => String
@@ -170,16 +169,50 @@ renderSearchDropdown
   -> TA.State Maybe item m
   -> Select.State (Fuzzy item)
   -> Select.ComponentHTML (TA.Query pq Maybe item m) (Fuzzy item)
-renderSearchDropdown label resetLabel renderItem renderFuzzy pst cst =
-  HH.label
-    [ css "relative" ]
-    [ IC.dropdownButton
+renderToolbarSearchDropdown defaultLabel resetLabel renderItem renderFuzzy pst cst =
+  renderSearchDropdown resetLabel label renderFuzzy pst cst
+  where
+    label = IC.dropdownButton
       HH.span
       [ HP.classes
-        $ HH.ClassName "whitespace-no-wrap" :
-          Button.buttonMainClasses <> Button.buttonClearClasses
+        $ HH.ClassName "whitespace-no-wrap"
+        : Button.buttonMainClasses
+        <> Button.buttonClearClasses
       ]
-      [ maybe (HH.text label) (HH.fromPlainHTML <<< renderItem) pst.selected ]
+      [ maybe (HH.text defaultLabel) (HH.fromPlainHTML <<< renderItem) pst.selected ]
+
+renderHeaderSearchDropdown
+  :: ∀ pq item m
+   . Eq item
+  => String
+  -> String
+  -> (item -> HH.PlainHTML)
+  -> (Fuzzy item -> HH.PlainHTML)
+  -> TA.State Maybe item m
+  -> Select.State (Fuzzy item)
+  -> Select.ComponentHTML (TA.Query pq Maybe item m) (Fuzzy item)
+renderHeaderSearchDropdown defaultLabel resetLabel renderItem renderFuzzy pst cst =
+  renderSearchDropdown resetLabel label renderFuzzy pst cst
+  where
+    label = HH.span
+      [ css "text-white text-3xl font-thin cursor-pointer whitespace-no-wrap" ]
+      [ maybe (HH.text defaultLabel) (HH.fromPlainHTML <<< renderItem) pst.selected
+      , Icon.collapse [ css "ml-3 text-xl text-grey-50 align-middle" ]
+      ]
+
+renderSearchDropdown
+  :: ∀ pq item m
+   . Eq item
+  => String
+  -> HH.PlainHTML
+  -> (Fuzzy item -> HH.PlainHTML)
+  -> TA.State Maybe item m
+  -> Select.State (Fuzzy item)
+  -> Select.ComponentHTML (TA.Query pq Maybe item m) (Fuzzy item)
+renderSearchDropdown resetLabel label renderFuzzy pst cst =
+  HH.label
+    [ css "relative" ]
+    [ HH.fromPlainHTML label
     , HH.div
       [ HP.classes
         $ HH.ClassName "min-w-80" :

--- a/src/Interfaces/Dropdown/Interface.purs
+++ b/src/Interfaces/Dropdown/Interface.purs
@@ -1,0 +1,74 @@
+module Ocelot.Interface.Dropdown where
+
+import Prelude
+
+import Control.Promise (Promise, fromAff)
+import Data.Array (head)
+import Data.Maybe (fromMaybe, maybe)
+import Data.Symbol (SProxy(..))
+import Data.Variant (Variant, inj)
+import Effect.AVar (empty) as AVar
+import Effect.Aff (launchAff_)
+import Effect.Aff.AVar (put, read) as AffAVar
+import Effect.Aff.Class (class MonadAff)
+import Effect.Aff.Compat (EffectFn1, EffectFn2, mkEffectFn1, mkEffectFn2)
+import Foreign.Object (Object, lookup)
+import Halogen.VDom.Driver (runUI)
+import Ocelot.Block.Button (button)
+import Ocelot.Component.Dropdown (Input, Message(..), Query(..), component)
+import Ocelot.Component.Dropdown.Render (defDropdown, render)
+import Ocelot.Interface.Utilities (mkSubscription, WithHalogen, Interface)
+import Select (Visibility(..)) as Select
+import Web.HTML (HTMLElement)
+
+type QueryRow =
+  ( setItems :: EffectFn1 (Array (Object String)) (Promise Unit)
+  , setSelection :: EffectFn1 (Array (Object String)) (Promise Unit)
+  )
+
+type MessageVariant = Variant
+  ( selected :: Object String
+  , visibilityChanged :: Boolean
+  , emit :: String
+  )
+
+convertMessageToVariant :: ∀ pq. Message pq (Object String) -> MessageVariant
+convertMessageToVariant = case _ of
+  Selected obj -> inj (SProxy :: SProxy "selected") obj
+  VisibilityChanged vis -> inj (SProxy :: SProxy "visibilityChanged") (vis == Select.On)
+  Emit _ -> inj (SProxy :: SProxy "emit") "emitted"
+
+type ExternalInput =
+  { selectedItem :: Array (Object String)
+  , items :: Array (Object String)
+  , placeholder :: String
+  , key :: String
+  }
+
+
+externalInputToInput
+  :: ∀ pq m
+   . MonadAff m
+  => ExternalInput
+  -> Input pq (Object String) m
+externalInputToInput { items, selectedItem, key, placeholder } =
+  { items
+  , selectedItem: head selectedItem
+  , render: render $ defDropdown button [] (fromMaybe placeholder <<< (lookup key)) placeholder
+  }
+
+mountDropdown :: EffectFn2 HTMLElement ExternalInput (Interface MessageVariant QueryRow)
+mountDropdown = mkEffectFn2 \el ext -> do
+  ioVar <- AVar.empty
+  launchAff_ do
+    io <- runUI component (externalInputToInput ext) el
+    AffAVar.put io ioVar
+  pure
+    { subscribe: mkSubscription ioVar convertMessageToVariant
+    , setItems: mkEffectFn1 \arr -> fromAff do
+       io <- AffAVar.read ioVar
+       io.query $ SetItems arr unit
+    , setSelection: mkEffectFn1 \arr -> fromAff do
+       io <- AffAVar.read ioVar
+       io.query $ SetSelection (head arr) unit
+    }

--- a/src/Interfaces/Dropdown/Interface.purs
+++ b/src/Interfaces/Dropdown/Interface.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Control.Promise (Promise, fromAff)
 import Data.Array (head)
-import Data.Maybe (fromMaybe, maybe)
+import Data.Maybe (fromMaybe)
 import Data.Symbol (SProxy(..))
 import Data.Variant (Variant, inj)
 import Effect.AVar (empty) as AVar
@@ -17,7 +17,7 @@ import Halogen.VDom.Driver (runUI)
 import Ocelot.Block.Button (button)
 import Ocelot.Component.Dropdown (Input, Message(..), Query(..), component)
 import Ocelot.Component.Dropdown.Render (defDropdown, render)
-import Ocelot.Interface.Utilities (mkSubscription, WithHalogen, Interface)
+import Ocelot.Interface.Utilities (mkSubscription, Interface)
 import Select (Visibility(..)) as Select
 import Web.HTML (HTMLElement)
 

--- a/src/Interfaces/Typeahead/Interface.purs
+++ b/src/Interfaces/Typeahead/Interface.purs
@@ -4,7 +4,6 @@ module Ocelot.Interface.Typeahead where
 
 import Prelude
 
-import Control.Coroutine (consumer)
 import Control.Promise (Promise)
 import Control.Promise as Promise
 import Data.Array (head)
@@ -16,20 +15,18 @@ import Data.Time.Duration (Milliseconds(..))
 import Data.Variant (Variant, inj)
 import Effect (Effect)
 import Effect.AVar as AVar
-import Effect.Aff (Aff, error, killFiber, launchAff, launchAff_)
+import Effect.Aff (launchAff_)
 import Effect.Aff.AVar as AffAVar
-import Effect.Aff.Compat (EffectFn1, EffectFn2, mkEffectFn1, mkEffectFn2, runEffectFn1)
-import Effect.Class (liftEffect)
+import Effect.Aff.Compat (EffectFn1, EffectFn2, mkEffectFn1, mkEffectFn2)
 import Foreign.Object (Object)
 import Foreign.Object as Object
-import Halogen (HalogenIO)
 import Halogen.HTML (span_)
 import Halogen.HTML.Properties as HP
 import Halogen.VDom.Driver (runUI)
 import Network.RemoteData (RemoteData(..))
 import Ocelot.Block.ItemContainer (boldMatches)
 import Ocelot.Component.Typeahead (Input, Insertable(..), Message(..), Query(..), defRenderContainer, multi, renderMulti, renderSingle, single)
-import Ocelot.Interface.Utilities (mkSubscription, WithHalogen, Interface)
+import Ocelot.Interface.Utilities (Interface, mkSubscription)
 import Partial.Unsafe (unsafePartial)
 import Web.HTML (HTMLElement)
 

--- a/src/Interfaces/Utilities.purs
+++ b/src/Interfaces/Utilities.purs
@@ -1,0 +1,40 @@
+module Ocelot.Interface.Utilities where
+
+import Prelude
+
+import Control.Coroutine (consumer)
+import Data.Maybe (Maybe(..))
+import Effect (Effect)
+import Effect.Aff (Aff, error, killFiber, launchAff, launchAff_)
+import Effect.Aff.AVar (AVar, read) as AffAVar
+import Effect.Aff.Compat (EffectFn1, mkEffectFn1, runEffectFn1)
+import Effect.Class (liftEffect)
+import Halogen (HalogenIO)
+
+-- | A row containing the 'subscribe' function from Halogen so it
+-- | may be used to subscribe to the message variant in JS.
+type WithHalogen out r =
+  ( subscribe :: EffectFn1 (EffectFn1 out Unit) (Effect Unit) | r )
+
+-- | A record containing the various queries available to be
+-- | triggered in JS and the various messages that may be passed
+-- | via the subscribe() function.
+type Interface messages queries =
+  { | WithHalogen messages queries }
+
+-- | A helper to construct a coroutine for the `subscribe` function, allowing
+-- | JS callers to consume a stream of outputs from the component. For now this
+-- | is specialized to Aff.
+mkSubscription
+  :: ∀ f o o'
+   . AffAVar.AVar (HalogenIO f o Aff)
+  -> (o -> o')
+  -> EffectFn1 (EffectFn1 o' Unit) (Effect Unit)
+mkSubscription ioVar convertMessage = mkEffectFn1 \cb -> do
+  fiber <- launchAff do
+    io <- AffAVar.read ioVar
+    io.subscribe $ consumer \msg -> do
+      let msgVariant = convertMessage msg
+      liftEffect $ runEffectFn1 cb msgVariant
+      pure Nothing
+  pure $ launchAff_ $ killFiber (error "unsubscribed") fiber

--- a/test/Interop/src/index.js
+++ b/test/Interop/src/index.js
@@ -1,4 +1,5 @@
 import { mountSingleTypeahead } from '../../../output/Ocelot.Interface.Typeahead/index.js';
+import { mountDropdown } from '../../../output/Ocelot.Interface.Dropdown/index.js';
 
 // Create a div to hold the Halogen component
 function mkElement(id) {


### PR DESCRIPTION
## What does this pull request do?

Adds several new default render implementations for the typeahead (corresponding to our header and toolbar searchable dropdowns), and adds JS usable interfaces for those and the standard dropdown.

