### PR TITLE
Added query to set selection by a find/filter function

### DIFF
--- a/src/Components/Typeahead/Base.purs
+++ b/src/Components/Typeahead/Base.purs
@@ -94,6 +94,7 @@ data Query pq f item m a
   | HandleSelect (Select.Message (Query pq f item m) (Fuzzy item)) a
   | GetSelected (f item -> a)
   | ReplaceSelected (f item) a
+  | ReplaceSelectedBy (Array item -> f item) a
   | ReplaceItems (RemoteData String (Array item)) a
   | Reset a
   | AndThen (Query pq f item m Unit) (Query pq f item m Unit) a
@@ -270,6 +271,12 @@ base ops =
         st <- modifyState _ { selected = selected }
         H.raise $ SelectionChanged ReplacementQuery st.selected
         eval $ Synchronize a
+
+      ReplaceSelectedBy f a -> do
+        { items } <- getState
+        case items of
+          Success items' -> eval $ ReplaceSelected (f items') a
+          _ -> pure a
 
       Reset a -> do
         st <- modifyState _ { selected = empty :: f item, items = NotAsked }


### PR DESCRIPTION
## What does this pull request do?

Added ability to change selection for typeaheads via a function, so that the parent doesn't need to hold onto the list of selectable items on the state.

E.g., a typeahead with the item type of `User { id :: UserId | r }`, if the parent has a `UserId` it wishes to use to update the typeahead's selection, instead of needing to hold a copy of the array of available `User`s on state and searching through it for the one with a matching `UserId`, instead it can provide a function to the typeahead component from `Array User -> Maybe User`, and let the typeahead handle the search.