### PR TITLE
Support Custom Toggle Rendering in Typeahead Interface

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,8 @@
     "purescript-formatters": "^4.0.0",
     "purescript-read": "^1.0.1",
     "purescript-halogen-renderless": "^0.0.3",
-    "purescript-aff-promise": "^2.0.0"
+    "purescript-aff-promise": "^2.0.0",
+    "purescript-html-parser-halogen": "^0.3.0"
   },
   "devDependencies": {
     "purescript-affjax": "^6.0.0",

--- a/src/Interfaces/Typeahead/Interface.purs
+++ b/src/Interfaces/Typeahead/Interface.purs
@@ -24,10 +24,11 @@ import Halogen.HTML (span_)
 import Halogen.HTML (text) as HH
 import Halogen.HTML.Properties as HP
 import Halogen.VDom.Driver (runUI)
+import Html.Parser.Halogen as Parser
 import Network.RemoteData (RemoteData(..))
 import Ocelot.Block.ItemContainer (boldMatches)
 import Ocelot.Component.Typeahead (Component, Input, Insertable(..), Message(..), Query(..), defRenderContainer, multi, renderMulti, renderSingle, single, base)
-import Ocelot.Component.Typeahead.Render (renderHeaderSearchDropdown, renderToolbarSearchDropdown)
+import Ocelot.Component.Typeahead.Render (renderHeaderSearchDropdown, renderSearchDropdown, renderToolbarSearchDropdown)
 import Ocelot.Interface.Utilities (Interface, mkSubscription)
 import Partial.Unsafe (unsafePartial)
 import Web.HTML (HTMLElement)
@@ -78,7 +79,7 @@ convertSingleToMessageVariant = case _ of
 -- | - placeholder: placeholder text to set in the field
 -- | - key: the name of the field in the object that should be displayed in the list
 -- | - keepOpen: whether the typeahead should stay open or close on selection
-type ExternalInput =
+type TypeaheadInput =
   { items :: Array (Object String)
   , debounceTime :: Int
   , placeholder :: String
@@ -87,20 +88,29 @@ type ExternalInput =
   , insertable :: Boolean
   }
 
-type SearchDropdownInput =
+-- | Another subset of the input available to the typeahead, for the dropdown variant
+-- | Provide:
+-- | - items: an array of objects, where all keys and values are strings
+-- | - labelHTML: a function that takes a String (the selected item) and returns a string of HTML
+-- |   (the toggling element)
+-- | - key: the name of the field in the object that should be displayed in the list
+-- | - defaultLabel: the string to display when no item is selected
+-- | - resetLabel: the name of the container element which resets the selection to Nothing
+type DropdownInput =
   { items :: Array (Object String)
-  , placeholder :: String
-  , resetLabel :: String
+  , labelHTML :: (String -> String)
   , key :: String
+  , defaultLabel :: String
+  , resetLabel :: String
   }
 
 -- | An adapter to simplify types necessary in JS to control the typeahead
 -- | component. Items are specialized to Object String.
-externalInputToSingleInput
+typeaheadInputToSingleInput
   :: ∀ pq m
-   . ExternalInput
+   . TypeaheadInput
   -> Input pq Maybe (Object String) m
-externalInputToSingleInput r =
+typeaheadInputToSingleInput r =
   { items: Success r.items
   , insertable: if r.insertable then Insertable (Object.singleton r.key) else NotInsertable
   , keepOpen: r.keepOpen
@@ -115,11 +125,11 @@ externalInputToSingleInput r =
   where
     renderFuzzy = span_ <<< boldMatches r.key
 
-externalInputToMultiInput
+typeaheadInputToMultiInput
   :: ∀ pq m
-   . ExternalInput
+   . TypeaheadInput
   -> Input pq Array (Object String) m
-externalInputToMultiInput r =
+typeaheadInputToMultiInput r =
   { items: Success r.items
   , insertable: if r.insertable then Insertable (Object.singleton r.key) else NotInsertable
   , keepOpen: r.keepOpen
@@ -134,57 +144,33 @@ externalInputToMultiInput r =
   where
     renderFuzzy = span_ <<< boldMatches r.key
 
-searchDropdownInputToHeaderSingleInput
+dropdownInputToSingleInput
   :: ∀ pq m
-   . SearchDropdownInput
+   . DropdownInput
   -> Input pq Maybe (Object String) m
-searchDropdownInputToHeaderSingleInput r =
+dropdownInputToSingleInput r =
   { items: Success r.items
   , insertable: NotInsertable
   , keepOpen: false
   , itemToObject: \a -> Object.singleton r.key (unsafePartial (fromJust (Object.lookup r.key a)))
   , debounceTime: Nothing
   , async: Nothing
-  , render: renderHeaderSearchDropdown
-      r.placeholder
-      r.resetLabel
-      renderLabel
-      renderFuzzy
+  , render
   }
   where
     renderFuzzy = span_ <<< boldMatches r.key
 
-    renderLabel item =
-      HH.text (fromMaybe "" $ Object.lookup r.key item)
-
-searchDropdownInputToToolbarSingleInput
-  :: ∀ pq m
-   . SearchDropdownInput
-  -> Input pq Maybe (Object String) m
-searchDropdownInputToToolbarSingleInput r =
-  { items: Success r.items
-  , insertable: NotInsertable
-  , keepOpen: false
-  , itemToObject: \a -> Object.singleton r.key (unsafePartial (fromJust (Object.lookup r.key a)))
-  , debounceTime: Nothing
-  , async: Nothing
-  , render: renderToolbarSearchDropdown
-      r.placeholder
+    render pst = renderSearchDropdown
       r.resetLabel
-      renderLabel
+      (Parser.render $ r.labelHTML (fromMaybe r.defaultLabel (Object.lookup r.key =<< pst.selected)))
       renderFuzzy
-  }
-  where
-    renderFuzzy = span_ <<< boldMatches r.key
+      pst
 
-    renderLabel item =
-      HH.text (fromMaybe "" $ Object.lookup r.key item)
-
-mountMultiTypeahead :: EffectFn2 HTMLElement ExternalInput (Interface MessageVariant QueryRow)
+mountMultiTypeahead :: EffectFn2 HTMLElement TypeaheadInput (Interface MessageVariant QueryRow)
 mountMultiTypeahead = mkEffectFn2 \el ext -> do
   ioVar <- AVar.empty
   launchAff_ do
-    io <- runUI multi (externalInputToMultiInput ext) el
+    io <- runUI multi (typeaheadInputToMultiInput ext) el
     AffAVar.put io ioVar
   pure
     { subscribe: mkSubscription ioVar convertMultiToMessageVariant
@@ -222,6 +208,12 @@ mountMultiTypeahead = mkEffectFn2 \el ext -> do
         io <- AffAVar.read ioVar
         io.query $ Reset unit
     }
+
+mountSingleTypeahead :: EffectFn2 HTMLElement TypeaheadInput (Interface MessageVariant QueryRow)
+mountSingleTypeahead = mkSingleTypeaheadMounter single typeaheadInputToSingleInput
+
+mountDropdownTypeahead :: EffectFn2 HTMLElement DropdownInput (Interface MessageVariant QueryRow)
+mountDropdownTypeahead = mkSingleTypeaheadMounter single' dropdownInputToSingleInput
 
 mkSingleTypeaheadMounter
   :: ∀ input pq
@@ -269,18 +261,71 @@ mkSingleTypeaheadMounter component inputTransformer = mkEffectFn2 \el ext -> do
         io.query $ Reset unit
     }
 
-mountSingleTypeahead :: EffectFn2 HTMLElement ExternalInput (Interface MessageVariant QueryRow)
-mountSingleTypeahead = mkSingleTypeaheadMounter single externalInputToSingleInput
-
-mountHeaderTypeahead :: EffectFn2 HTMLElement SearchDropdownInput (Interface MessageVariant QueryRow)
-mountHeaderTypeahead = mkSingleTypeaheadMounter single' searchDropdownInputToHeaderSingleInput
-
-mountToolbarTypeahead :: EffectFn2 HTMLElement SearchDropdownInput (Interface MessageVariant QueryRow)
-mountToolbarTypeahead = mkSingleTypeaheadMounter single' searchDropdownInputToToolbarSingleInput
-
 single' :: ∀ pq item. Eq item => Component pq Maybe item Aff
 single' = base
   { runSelect: const <<< Just
   , runRemove: const (const Nothing)
   , runFilter: const
   }
+
+-- DEPRECATED
+-- Use DropdownInput with dropdownInputToSingleInput
+type SearchDropdownInput =
+  { items :: Array (Object String)
+  , placeholder :: String
+  , resetLabel :: String
+  , key :: String
+  }
+
+searchDropdownInputToHeaderSingleInput
+  :: ∀ pq m
+   . SearchDropdownInput
+  -> Input pq Maybe (Object String) m
+searchDropdownInputToHeaderSingleInput r =
+  { items: Success r.items
+  , insertable: NotInsertable
+  , keepOpen: false
+  , itemToObject: \a -> Object.singleton r.key (unsafePartial (fromJust (Object.lookup r.key a)))
+  , debounceTime: Nothing
+  , async: Nothing
+  , render: renderHeaderSearchDropdown
+      r.placeholder
+      r.resetLabel
+      renderLabel
+      renderFuzzy
+  }
+  where
+    renderFuzzy = span_ <<< boldMatches r.key
+
+    renderLabel item =
+      HH.text (fromMaybe "" $ Object.lookup r.key item)
+
+searchDropdownInputToToolbarSingleInput
+  :: ∀ pq m
+   . SearchDropdownInput
+  -> Input pq Maybe (Object String) m
+searchDropdownInputToToolbarSingleInput r =
+  { items: Success r.items
+  , insertable: NotInsertable
+  , keepOpen: false
+  , itemToObject: \a -> Object.singleton r.key (unsafePartial (fromJust (Object.lookup r.key a)))
+  , debounceTime: Nothing
+  , async: Nothing
+  , render: renderToolbarSearchDropdown
+      r.placeholder
+      r.resetLabel
+      renderLabel
+      renderFuzzy
+  }
+  where
+    renderFuzzy = span_ <<< boldMatches r.key
+
+    renderLabel item =
+      HH.text (fromMaybe "" $ Object.lookup r.key item)
+
+
+mountHeaderTypeahead :: EffectFn2 HTMLElement SearchDropdownInput (Interface MessageVariant QueryRow)
+mountHeaderTypeahead = mkSingleTypeaheadMounter single' searchDropdownInputToHeaderSingleInput
+
+mountToolbarTypeahead :: EffectFn2 HTMLElement SearchDropdownInput (Interface MessageVariant QueryRow)
+mountToolbarTypeahead = mkSingleTypeaheadMounter single' searchDropdownInputToToolbarSingleInput

--- a/src/Interfaces/Typeahead/Interface.purs
+++ b/src/Interfaces/Typeahead/Interface.purs
@@ -31,6 +31,7 @@ import Ocelot.Component.Typeahead (Component, Input, Insertable(..), Message(..)
 import Ocelot.Component.Typeahead.Render (renderHeaderSearchDropdown, renderSearchDropdown, renderToolbarSearchDropdown)
 import Ocelot.Interface.Utilities (Interface, mkSubscription)
 import Partial.Unsafe (unsafePartial)
+import Prim.TypeError (class Warn, Text)
 import Web.HTML (HTMLElement)
 
 -- | A subset of the queries available to the typeahead, restricted
@@ -279,7 +280,8 @@ type SearchDropdownInput =
 
 searchDropdownInputToHeaderSingleInput
   :: ∀ pq m
-   . SearchDropdownInput
+   . Warn (Text "This function is deprecated")
+  => SearchDropdownInput
   -> Input pq Maybe (Object String) m
 searchDropdownInputToHeaderSingleInput r =
   { items: Success r.items
@@ -302,7 +304,8 @@ searchDropdownInputToHeaderSingleInput r =
 
 searchDropdownInputToToolbarSingleInput
   :: ∀ pq m
-   . SearchDropdownInput
+   . Warn (Text "This function is deprecated")
+  => SearchDropdownInput
   -> Input pq Maybe (Object String) m
 searchDropdownInputToToolbarSingleInput r =
   { items: Success r.items

--- a/test/Interop/package.json
+++ b/test/Interop/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "webpack": "^4.17.1",
-    "webpack-cli": "^3.1.0"
+    "webpack": "^4.28.4",
+    "webpack-cli": "^3.2.1"
   }
 }

--- a/test/Interop/src/index.js
+++ b/test/Interop/src/index.js
@@ -1,6 +1,5 @@
 import { mountSingleTypeahead } from '../../../output/Ocelot.Interface.Typeahead/index.js';
-import { mountHeaderTypeahead } from '../../../output/Ocelot.Interface.Typeahead/index.js';
-import { mountToolbarTypeahead } from '../../../output/Ocelot.Interface.Typeahead/index.js';
+import { mountDropdownTypeahead } from '../../../output/Ocelot.Interface.Typeahead/index.js';
 import { mountDropdown } from '../../../output/Ocelot.Interface.Dropdown/index.js';
 
 // Create a div to hold the Halogen component
@@ -70,6 +69,69 @@ component.setLoading().then(() => {
 
     // Example: imperatively set status
     component.setItems(items).then(() => {
+      console.log("Items set to: ", items);
+    });
+  }, 3000);
+});
+
+
+// Example: Dropdown Typeahead
+// This component supports passing the HTML to be rendered as the toggling element
+// The labelHTML key must be a function (String -> String), where the output string
+// should be valid HTML. (Usually it will include the input string, which will be the
+// currently selected element)
+
+const dropdownTAInput =
+  { items,
+    defaultLabel: "All The Things",
+    resetLabel: "Use All The Things",
+    key: "name",
+    labelHTML: (item) => `
+      <span class="text-black text-3xl font-thin cursor-pointer whitespace-no-wrap">
+        ${item}
+        <span class="icon-collapse text-2xl"></span>
+      </span>`
+  }
+
+const dropdownTAComponent = mountDropdownTypeahead(mkElement("dropdown-ta"), dropdownTAInput);
+
+// It supports all of the same operations as the standard typeaheads
+
+const dropdownTAsubscription = dropdownTAComponent.subscribe((out) => {
+  switch (out.type) {
+    case "searched":
+      console.log("The user performed a search: ", out.value);
+      break;
+
+    case "selected":
+      console.log("The user selected an item: ", out.value);
+      break;
+
+    case "selectionChanged":
+      console.log("The selections have changed: ", out.value);
+      break;
+
+    case "emit":
+      console.log("Something was emitted, which I'll likely ignore: ", out.value);
+      break;
+  }
+});
+
+dropdownTAComponent.setLoading().then(() => {
+  console.log("Now in loading status...");
+  setTimeout(() => {
+    // Example: imperatively set selections
+    dropdownTAComponent.setSelected([{ name: "Thomas" }]).then(() => {
+      console.log("New selections set");
+    });
+
+    // Example: imperatively get selections
+    dropdownTAComponent.getSelected().then((selections) => {
+      console.log("These are the selections: ", selections);
+    });
+
+    // Example: imperatively set status
+    dropdownTAComponent.setItems(items).then(() => {
       console.log("Items set to: ", items);
     });
   }, 3000);


### PR DESCRIPTION
## What does this pull request do?

Adds the ability to pass an HTML template function as part of the input to the Dropdown Typeahead interface, so that those consuming the component in JavaScript can have some more control over its appearance.

