### PR TITLE
PS-2957 Re-add `Currency`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,8 @@
     "purescript-read": "^1.0.1",
     "purescript-halogen-renderless": "^0.0.3",
     "purescript-aff-promise": "^2.0.0",
-    "purescript-html-parser-halogen": "^0.3.0"
+    "purescript-html-parser-halogen": "^0.3.0",
+    "purescript-bigints": "^4.0.0"
   },
   "devDependencies": {
     "purescript-affjax": "^6.0.0",

--- a/src/Data/Currency.purs
+++ b/src/Data/Currency.purs
@@ -1,0 +1,128 @@
+module Ocelot.Data.Currency where
+
+import Prelude
+
+import Data.Argonaut.Encode (class EncodeJson, encodeJson)
+import Data.Array (all, drop, head, (:))
+import Data.BigInt (BigInt)
+import Data.BigInt as BigInt
+import Data.Foldable (foldr)
+import Data.Int (fromString) as Int
+import Data.Maybe (Maybe(..), fromMaybe, isJust)
+import Data.Newtype (class Newtype, unwrap)
+import Data.String (Pattern(..), Replacement(..), length, replaceAll, split, take, null)
+import Data.String.CodeUnits (toCharArray, fromCharArray)
+import Data.Tuple (Tuple(..), snd)
+
+----------
+-- CENTS
+
+-- | Cents represent USD as a BigInt
+newtype Cents = Cents BigInt
+derive instance newtypeCents :: Newtype Cents _
+derive newtype instance eqCents :: Eq Cents
+
+instance encodeJsonCents :: EncodeJson Cents where
+  encodeJson = encodeJson <<< BigInt.toNumber <<< unwrap
+
+instance showCents :: Show Cents where
+  show (Cents n) = "Cents " <> BigInt.toString n
+
+-- | Will parse cents from a 32bit int
+parseCentsFromNumber :: Number -> Maybe Cents
+parseCentsFromNumber = map Cents <<< BigInt.fromNumber
+
+parseCentsFromMicroDollars :: Number -> Maybe Cents
+parseCentsFromMicroDollars = parseCentsFromNumber <<< flip (/) 10000.0
+
+centsToMaybeInt :: Cents -> Maybe Int
+centsToMaybeInt = Int.fromString <<< BigInt.toString <<< unwrap
+
+-- | Will attempt to parse cents from a string representing a dollar amount. It will
+-- strip any trailing cents beyond the hundredths place. WARNING: Do not use this on
+-- a string meant to represent cents! It will overstate by 100x.
+parseCentsFromDollarStr :: String -> Maybe Cents
+parseCentsFromDollarStr str = Cents <$> case split (Pattern ".") str of
+  -- There is no decimal; treat as a full dollar string
+  [ dollars ] -> bigIntIs64Bit =<< dollarsPlace dollars
+
+  -- There is one decimal; truncate the cents to 2 places and
+  -- add them to the dollars
+  [ dollars, cents ] ->
+    bigIntIs64Bit
+    =<< (+) <$> dollarsPlace dollars <*> BigInt.fromString (take 2 $ cents <> "0")
+
+  -- Unable to parse
+  otherwise -> Nothing
+
+  where
+    -- Expects only the dollars place, no cents. Cents will overstate
+    -- by 100x! Verifies within 64 bit bounds.
+    dollarsPlace :: String -> Maybe BigInt
+    dollarsPlace s
+      | null s = Nothing
+      | otherwise = pure
+          <<< (*) (BigInt.fromInt 100)
+          =<< BigInt.fromString
+          =<< cleanDollars s
+
+    cleanDollars :: String -> Maybe String
+    cleanDollars s =
+      let split = splitCommas s
+          verified = noCommas s || checkHead split && checkTail split
+       in if verified then Just (stripCommas s) else Nothing
+
+    noCommas s = s == stripCommas s
+    splitCommas = split (Pattern ",")
+    stripCommas = replaceAll (Pattern ",") (Replacement "")
+    checkHead = fromMaybe false <<< map ((_ <= 3) <<< length) <<< head
+    checkTail = all (_ == 3) <<< map length <<< drop 1
+
+-- Given some cents, format a string representation
+-- in dollars.
+formatCentsToStrDollars :: Cents -> String
+formatCentsToStrDollars (Cents n)
+  | BigInt.toNumber n < 10.0  = "0.0" <> BigInt.toString n
+  | BigInt.toNumber n < 100.0 = "0." <> BigInt.toString n
+  | otherwise = fromCharArray <<< snd $ foldr formatCentsToDollars' (Tuple 0 []) (chars n)
+    where
+      chars :: BigInt -> Array Char
+      chars = toCharArray <<< BigInt.toString
+
+      formatCentsToDollars' :: Char -> Tuple Int (Array Char) -> Tuple Int (Array Char)
+      formatCentsToDollars' d (Tuple i acc)
+        | i == 2 = next i (d : '.' : acc)
+        | (i - 2) `mod` 3 == 0 = next i (d : ',' : acc)
+        | otherwise = next i (d : acc)
+
+      next :: Int -> Array Char -> Tuple Int (Array Char)
+      next i = Tuple (i + 1)
+
+-- | Simple test to ensure a string can be parsed to a BigInt before
+-- other steps are taken, or for validation purposes.
+canParseToBigInt :: String -> Boolean
+canParseToBigInt = isJust <<< BigInt.fromString
+
+-- | Verify cents are within 64 bit bounds
+bigIntIs64Bit :: BigInt -> Maybe BigInt
+bigIntIs64Bit n = do
+  max <- BigInt.fromString "9223372036854775807"
+  if n <= max
+    then pure n
+    else Nothing
+
+-- | Simple check to see if the parsed int would fit within
+-- 64 bits (9,223,372,036,854,775,807)
+canParseTo64Bit :: String -> Boolean
+canParseTo64Bit str = isJust $ do
+  max <- BigInt.fromString "9223372036854775807"
+  cmp <- BigInt.fromString str
+  if cmp <= max then Just str else Nothing
+
+-- | Simple check to see if the parsed int would fit within
+-- 32 bits (2,147,483,647)
+canParseTo32Bit :: String -> Boolean
+canParseTo32Bit str = isJust $ do
+  max <- BigInt.fromString "2147483647"
+  cmp <- BigInt.fromString str
+  if cmp <= max then Just str else Nothing

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,14 +2,15 @@ module Test.Main where
 
 import Prelude
 
-import Effect (Effect)
-import Effect.Class (liftEffect)
-import Effect.Now (now)
 import Data.DateTime.Instant (unInstant)
 import Data.Set as Set
 import Data.Time.Duration (Milliseconds(..))
 import Data.Tuple (Tuple(..))
+import Effect (Effect)
+import Effect.Class (liftEffect)
+import Effect.Now (now)
 import Ocelot.HTML.Properties (appendIProps, css, extract)
+import Test.Currency (currencyCheck)
 import Test.Unit (suite, test)
 import Test.Unit.Assert (equal)
 import Test.Unit.Console (log)
@@ -17,6 +18,7 @@ import Test.Unit.Main (runTest)
 
 main :: Effect Unit
 main = runTest do
+  suite "Currency" currencyCheck
   suite "HTML.Properties" do
     test "appendIProps" do
       let ipropsA = [ css "m-10 p-10 px-5 pb-12 min-w-80 w-full shadow overflow-hidden" ]

--- a/test/Test/Currency.purs
+++ b/test/Test/Currency.purs
@@ -1,0 +1,73 @@
+module Test.Currency where
+
+import Prelude
+
+import Ocelot.Data.Currency (Cents(..), formatCentsToStrDollars, parseCentsFromDollarStr, parseCentsFromMicroDollars)
+import Data.BigInt as BigInt
+import Data.Maybe (Maybe(..))
+import Test.Unit (TestSuite, suite, test)
+import Test.Unit.Assert as Assert
+
+currencyCheck :: TestSuite
+currencyCheck = do
+  suite "parsers" do
+    test "parseCentsFromMicroDollars" do
+      let expect = Just $ Cents $ BigInt.fromInt 1234
+          result = parseCentsFromMicroDollars 12340000.0
+      Assert.equal expect result
+
+    test "parseCentsFromDollarStr NULL" do
+      let expect = Nothing
+          result = parseCentsFromDollarStr "NULL"
+      Assert.equal expect result
+
+    test "parseCentsFromDollarStr 12.34" do
+      let expect = Just $ Cents $ BigInt.fromInt 1234
+          result = parseCentsFromDollarStr "12.34"
+      Assert.equal expect result
+
+    test "parseCentsFromDollarStr 1234" do
+      let expect = Just $ Cents $ BigInt.fromInt 123400
+          result = parseCentsFromDollarStr "1234"
+      Assert.equal expect result
+
+    test "parseCentsFromDollarStr 1234.00" do
+      let expect = Just $ Cents $ BigInt.fromInt 123400
+          result = parseCentsFromDollarStr "1234.00"
+      Assert.equal expect result
+
+    test "parseCentsFromDollarStr 123.4" do
+      let expect = Just $ Cents $ BigInt.fromInt 12340
+          result = parseCentsFromDollarStr "123.4"
+      Assert.equal expect result
+
+    test "parseCentsFromDollarStr 1,234" do
+      let expect = Just $ Cents $ BigInt.fromInt 123400
+          result = parseCentsFromDollarStr "1,234"
+      Assert.equal expect result
+
+    test "parseCentsFromDollarStr 1,234.00" do
+      let expect = Just $ Cents $ BigInt.fromInt 123400
+          result = parseCentsFromDollarStr "1,234.00"
+      Assert.equal expect result
+
+    test "parseCentsFromDollarStr 1,234." do
+      let expect = Just $ Cents $ BigInt.fromInt 123400
+          result = parseCentsFromDollarStr "1,234."
+      Assert.equal expect result
+
+    test "formatCentsToStrDollars 0.00" do
+      let result = formatCentsToStrDollars $ Cents $ BigInt.fromInt 0
+      Assert.equal "0.00" result
+
+    test "formatCentsToStrDollars 12.34" do
+      let result = formatCentsToStrDollars $ Cents $ BigInt.fromInt 1234
+      Assert.equal "12.34" result
+
+    test "formatCentsToStrDollars 123.40" do
+      let result = formatCentsToStrDollars $ Cents $ BigInt.fromInt 12340
+      Assert.equal "123.40" result
+
+    test "formatCentsToStrDollars 1,234.00" do
+      let result = formatCentsToStrDollars $ Cents $ BigInt.fromInt 123400
+      Assert.equal "1,234.00" result


### PR DESCRIPTION
## What does this pull request do?

We now need `Currency` in https://github.com/citizennet/purescript-lynx/.
We're moving it back out of our private repo to here so we can use it in both without needing to pull in `lynx` right now.

The only difference from the original module is the name. This is the full diff for `src/Data/Currency.purs`:
```diff
1c1
< module CN.Data.Currency where
---
> module Ocelot.Data.Currency where
129d128
<
```
And for `test/Test/Currency.purs`:
```diff
5c5
< import CN.Data.Currency (Cents(..), formatCentsToStrDollars, parseCentsFromDollarStr, parseCentsFromMicroDollars)
---
> import Ocelot.Data.Currency (Cents(..), formatCentsToStrDollars, parseCentsFromDollarStr, parseCentsFromMicroDollars)
```

## Where should the reviewer start?

There's no behavioral changes, just relocating some code. There's not really much to review. Maybe validate that the module names are what we want and stuff like that.

## How should this be manually tested?

We haven't touched this code since November of 2018. There should be no need to test anything manually.

## Other Notes:

We'll need to cut a release after merging this so we can use it in our private repo.
