### PR TITLE
Added conversions for microdollars.

### DIFF
--- a/test/Test/Currency.purs
+++ b/test/Test/Currency.purs
@@ -2,9 +2,9 @@ module Test.Currency where
 
 import Prelude
 
-import Ocelot.Data.Currency (Cents(..), formatCentsToStrDollars, parseCentsFromDollarStr, parseCentsFromMicroDollars)
 import Data.BigInt as BigInt
 import Data.Maybe (Maybe(..))
+import Ocelot.Data.Currency (Cents(..), MicroDollars(..), formatCentsToStrDollars, parseCentsFromDollarStr, parseCentsFromMicroDollars, parseMicroDollarsFromDollarStr)
 import Test.Unit (TestSuite, suite, test)
 import Test.Unit.Assert as Assert
 
@@ -15,6 +15,9 @@ currencyCheck = do
       let expect = Just $ Cents $ BigInt.fromInt 1234
           result = parseCentsFromMicroDollars 12340000.0
       Assert.equal expect result
+
+    -----------------------
+    -- Parse Cents Tests
 
     test "parseCentsFromDollarStr NULL" do
       let expect = Nothing
@@ -55,6 +58,51 @@ currencyCheck = do
       let expect = Just $ Cents $ BigInt.fromInt 123400
           result = parseCentsFromDollarStr "1,234."
       Assert.equal expect result
+
+    -----------------------
+    -- Parse MicroDollars Tests
+
+    test "parseMicroDollarsFromDollarStr NULL" do
+      let expect = Nothing
+          result = parseMicroDollarsFromDollarStr "NULL"
+      Assert.equal expect result
+
+    test "parseMicroDollarsFromDollarStr 12.34" do
+      let expect = Just $ MicroDollars $ BigInt.fromInt 12340000
+          result = parseMicroDollarsFromDollarStr "12.34"
+      Assert.equal expect result
+
+    test "parseMicroDollarsFromDollarStr 1234" do
+      let expect = Just $ MicroDollars $ BigInt.fromInt 1234000000
+          result = parseMicroDollarsFromDollarStr "1234"
+      Assert.equal expect result
+
+    test "parseMicroDollarsFromDollarStr 1234.00" do
+      let expect = Just $ MicroDollars $ BigInt.fromInt 1234000000
+          result = parseMicroDollarsFromDollarStr "1234.00"
+      Assert.equal expect result
+
+    test "parseMicroDollarsFromDollarStr 123.4" do
+      let expect = Just $ MicroDollars $ BigInt.fromInt 123400000
+          result = parseMicroDollarsFromDollarStr "123.4"
+      Assert.equal expect result
+
+    test "parseMicroDollarsFromDollarStr 1,234" do
+      let expect = Just $ MicroDollars $ BigInt.fromInt 1234000000
+          result = parseMicroDollarsFromDollarStr "1,234"
+      Assert.equal expect result
+
+
+    test "parseMicroDollarsFromDollarStr 1,234.00" do
+      let expect = Just $ MicroDollars $ BigInt.fromInt 1234000000
+          result = parseMicroDollarsFromDollarStr "1,234.00"
+      Assert.equal expect result
+
+    test "parseMicroDollarsFromDollarStr 1,234." do
+      let expect = Just $ MicroDollars $ BigInt.fromInt 1234000000
+          result = parseMicroDollarsFromDollarStr "1,234."
+      Assert.equal expect result
+
 
     test "formatCentsToStrDollars 0.00" do
       let result = formatCentsToStrDollars $ Cents $ BigInt.fromInt 0


### PR DESCRIPTION
Changed parseCentsFromDollarsStr into parseCurrencyFromDollarStr to
allow for other conversions to be applied. Rewrote parseCurrencyFromDollarsStr
to be a little simpler

## What does this pull request do?

Adds support for parsing `MicroDollars` from dollar strings 

## Where should the reviewer start?

Data/Currency.purs

## How should this be manually tested?
Don't think it needs any manual testing

## Other Notes:
I changed `parseCentsFromDollarStr` to `parseCurrencyFromDollarStr` giving it the ability to take a conversion factor so we can convert to other things besides cents. This didn't work correctly with other conversion factors besides cents though, so I had to rewrite the function. I didn't 100% understand the code for it but I think this new version is a little more straight forward. If I've missed something here that is terribly wrong, just let me know and I'll fix it. 

