### PR TITLE
CircleCI speed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@ defaults: &defaults
   working_directory: ~/ocelot
   docker:
     - image: circleci/node:10.8-browsers
+  environment:
+    RTS_ARGS: +RTS -N2 -RTS
 
 jobs:
   test:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build-all": "yarn run build-ui && yarn run build-css",
     "postinstall": "bower i --silent",
     "clean": "rm -rf output bower_components node_modules && cd css && rm -rf node_modules",
-    "build-ui": "yarn run pulp build -I ui-guide --to dist/example.js",
+    "build-ui": "yarn run pulp build -I ui-guide --to dist/example.js $(RTS_ARGS)",
     "watch-ui": "yarn run pulp -w --then 'yarn run build-css' build -I ui-guide --to dist/example.js",
     "install-css": "cd css && yarn install",
     "build-css": "cd css && yarn run build-all"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build-all": "yarn run build-ui && yarn run build-css",
     "postinstall": "bower i --silent",
     "clean": "rm -rf output bower_components node_modules && cd css && rm -rf node_modules",
-    "build-ui": "yarn run pulp build -I ui-guide --to dist/example.js $(RTS_ARGS)",
+    "build-ui": "yarn run pulp build -I ui-guide --to dist/example.js $RTS_ARGS",
     "watch-ui": "yarn run pulp -w --then 'yarn run build-css' build -I ui-guide --to dist/example.js",
     "install-css": "cd css && yarn install",
     "build-css": "cd css && yarn run build-all"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build-all": "yarn run build-ui && yarn run build-css",
     "postinstall": "bower i --silent",
     "clean": "rm -rf output bower_components node_modules && cd css && rm -rf node_modules",
-    "build-ui": "yarn run pulp build -I ui-guide --to dist/example.js $RTS_ARGS",
+    "build-ui": "yarn run pulp -- build -I ui-guide --to dist/example.js -- $RTS_ARGS",
     "watch-ui": "yarn run pulp -w --then 'yarn run build-css' build -I ui-guide --to dist/example.js",
     "install-css": "cd css && yarn install",
     "build-css": "cd css && yarn run build-all"


### PR DESCRIPTION
## What does this pull request do?

Speeds up Circle CI build

## How should this be manually tested?

You can see the compiling step from the [latest test](https://circleci.com/gh/citizennet/purescript-ocelot/871) took 00:16, whereas the [build before](https://circleci.com/gh/citizennet/purescript-ocelot/869) took 13:22 to compile. Quite a bit faster. 
