### PR TITLE
Fix bower resolution errors

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,7 @@
     "purescript-halogen-select": "^4.0.0",
     "purescript-fuzzy": "^0.2.1",
     "purescript-polyform": "^0.7.0",
-    "purescript-remotedata": "^4.0.0",
+    "purescript-remotedata": "4.1.0",
     "purescript-formatters": "^4.0.0",
     "purescript-read": "^1.0.1",
     "purescript-halogen-renderless": "^0.0.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build-all": "yarn run build-ui && yarn run build-css",
-    "postinstall": "bower i",
+    "postinstall": "bower install",
     "clean": "rm -rf output bower_components node_modules && cd css && rm -rf node_modules",
     "build-ui": "yarn run pulp -- build -I ui-guide --to dist/example.js -- $RTS_ARGS",
     "watch-ui": "yarn run pulp -w --then 'yarn run build-css' build -I ui-guide --to dist/example.js",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "purescript-ocelot",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "private": true,
   "scripts": {
     "build-all": "yarn run build-ui && yarn run build-css",
-    "postinstall": "bower i --silent",
+    "postinstall": "bower i",
     "clean": "rm -rf output bower_components node_modules && cd css && rm -rf node_modules",
     "build-ui": "yarn run pulp -- build -I ui-guide --to dist/example.js -- $RTS_ARGS",
     "watch-ui": "yarn run pulp -w --then 'yarn run build-css' build -I ui-guide --to dist/example.js",


### PR DESCRIPTION
## What does this pull request do?

`purescript-remotedata` was bumped from `4.1.0` to `4.2.0`, which included a major bump to one of its dependencies, which resulted in a cascade of resolution conflicts in bower. I've fixed the version to `4.1.0`, and `bower install` now resolves all packages without issue.

I've also removed the `--silent` flag from the `bower install` script, so that's it's easier for builds that rely on `Ocelot` to see what went wrong.

## How should this be manually tested?

```sh
rm -rf bower_components
yarn install
yarn run build-all
```