### PR TITLE
Creates a more general tab control

### DIFF
--- a/src/Blocks/NavigationTab.purs
+++ b/src/Blocks/NavigationTab.purs
@@ -6,6 +6,7 @@ import DOM.HTML.Indexed (HTMLdiv)
 import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
 import Ocelot.Block.Icon as Icon
+import Ocelot.Block.TabControl as TabControl
 import Ocelot.HTML.Properties ((<&>))
 
 type Tab page =
@@ -20,68 +21,6 @@ type TabConfig page =
   , activePage :: page
   }
 
-type IsActive = Boolean
-
-outerClasses :: Array HH.ClassName
-outerClasses = HH.ClassName <$>
-  [ "bg-black-10"
-  , "w-full"
-  ]
-
-innerClasses :: Array HH.ClassName
-innerClasses = HH.ClassName <$>
-  [ "container"
-  , "items-end"
-  , "mx-auto"
-  , "flex"
-  , "h-16"
-  , "list-reset"
-  ]
-
-tabClasses :: Array HH.ClassName
-tabClasses = HH.ClassName <$>
-  [ "pt-5"
-  , "pb-6"
-  , "inline-flex"
-  , "no-underline"
-  ]
-
-activeTabClasses :: Array HH.ClassName
-activeTabClasses = HH.ClassName <$>
-  [ "border-b-2"
-  , "border-blue-88"
-  , "text-white"
-  ]
-
-inactiveTabClasses :: Array HH.ClassName
-inactiveTabClasses = HH.ClassName <$>
-  [ "border-b-2"
-  , "border-black-10"
-  , "hover:border-blue-88"
-  , "hover:text-white"
-  , "text-grey-70"
-  ]
-
-tabTextClasses :: Array HH.ClassName
-tabTextClasses = HH.ClassName <$>
-  [ "text-sm"
-  , "tracking-wide"
-  , "uppercase"
-  , "bold"
-  , "inline-flex"
-  , "self-end"
-  ]
-
-errorIconClasses :: Array HH.ClassName
-errorIconClasses = HH.ClassName <$>
-  [ "text-2xl"
-  , "text-red"
-  , "mr-1"
-  , "inline-flex"
-  , "align-bottom"
-  , "my-px"
-  ]
-
 navigationTabs
   :: ∀ p i page
    . Eq page
@@ -89,12 +28,17 @@ navigationTabs
   -> Array (HH.IProp HTMLdiv i)
   -> HH.HTML p i
 navigationTabs { tabs, activePage } props =
-  HH.div
-    [ HP.classes outerClasses ]
-    [ HH.ul
-      ( [ HP.classes innerClasses ] <&> props )
-      $ navigationTab activePage <$> tabs
-    ]
+  TabControl.tabControl config props
+  where
+    config =
+      { tabs: toGeneric <$> tabs, activePage }
+
+    toGeneric tab =
+      { name: tab.name
+      , props: [ HP.href tab.link ]
+      , page: tab.page
+      , errors: tab.errors
+      }
 
 navigationTabs_
   :: ∀ p i page
@@ -102,41 +46,3 @@ navigationTabs_
   => TabConfig page
   -> HH.HTML p i
 navigationTabs_ config = navigationTabs config []
-
-
-navigationTab
-  :: ∀ p i page
-   . Eq page
-  => page
-  -> Tab page
-  -> HH.HTML p i
-navigationTab activePage tab =
-  HH.li
-    [ HP.class_ $ HH.ClassName "mr-12" ]
-    [ HH.a
-      [ HP.href tab.link
-      , HP.classes $ tabClasses <> conditionalTabClasses isActive
-      ]
-      ( errorIcon
-        <>
-        [ HH.span
-          [ HP.classes tabTextClasses ]
-          [ HH.text tab.name ]
-        ]
-      )
-    ]
-  where
-    isActive :: Boolean
-    isActive = tab.page == activePage
-
-    errorIcon :: Array (HH.HTML p i)
-    errorIcon
-      | tab.errors > 0 && isActive == false =
-        [ Icon.error
-          [ HP.classes $ errorIconClasses ]
-        ]
-      | otherwise = []
-
-    conditionalTabClasses :: IsActive -> Array HH.ClassName
-    conditionalTabClasses true = activeTabClasses
-    conditionalTabClasses false = inactiveTabClasses

--- a/src/Blocks/TabControl.purs
+++ b/src/Blocks/TabControl.purs
@@ -1,0 +1,141 @@
+module Ocelot.Block.TabControl where
+
+import Prelude
+
+import DOM.HTML.Indexed (HTMLdiv, HTMLa)
+import Halogen.HTML as HH
+import Halogen.HTML.Properties as HP
+import Ocelot.Block.Icon as Icon
+import Ocelot.HTML.Properties ((<&>))
+
+type Tab i page =
+  { name :: String
+  , props :: Array (HH.IProp HTMLa i)
+  , page :: page
+  , errors :: Int
+  }
+
+type TabConfig tabType page =
+  { tabs :: Array (tabType page)
+  , activePage :: page
+  }
+
+type IsActive = Boolean
+
+outerClasses :: Array HH.ClassName
+outerClasses = HH.ClassName <$>
+  [ "bg-black-10"
+  , "w-full"
+  ]
+
+innerClasses :: Array HH.ClassName
+innerClasses = HH.ClassName <$>
+  [ "container"
+  , "items-end"
+  , "mx-auto"
+  , "flex"
+  , "h-16"
+  , "list-reset"
+  ]
+
+tabClasses :: Array HH.ClassName
+tabClasses = HH.ClassName <$>
+  [ "pt-5"
+  , "pb-6"
+  , "inline-flex"
+  , "no-underline"
+  ]
+
+activeTabClasses :: Array HH.ClassName
+activeTabClasses = HH.ClassName <$>
+  [ "border-b-2"
+  , "border-blue-88"
+  , "text-white"
+  ]
+
+inactiveTabClasses :: Array HH.ClassName
+inactiveTabClasses = HH.ClassName <$>
+  [ "border-b-2"
+  , "border-black-10"
+  , "hover:border-blue-88"
+  , "hover:text-white"
+  , "text-grey-70"
+  ]
+
+tabTextClasses :: Array HH.ClassName
+tabTextClasses = HH.ClassName <$>
+  [ "text-sm"
+  , "tracking-wide"
+  , "uppercase"
+  , "bold"
+  , "inline-flex"
+  , "self-end"
+  ]
+
+errorIconClasses :: Array HH.ClassName
+errorIconClasses = HH.ClassName <$>
+  [ "text-2xl"
+  , "text-red"
+  , "mr-1"
+  , "inline-flex"
+  , "align-bottom"
+  , "my-px"
+  ]
+
+tabControl
+  :: ∀ p i page
+   . Eq page
+  => TabConfig (Tab i) page
+  -> Array (HH.IProp HTMLdiv i)
+  -> HH.HTML p i
+tabControl { tabs, activePage } props =
+  HH.div
+    [ HP.classes outerClasses ]
+    [ HH.ul
+      ( [ HP.classes innerClasses ] <&> props )
+      $ singleTab activePage <$> tabs
+    ]
+
+tabControl_
+  :: ∀ p i page
+   . Eq page
+  => TabConfig (Tab i) page
+  -> HH.HTML p i
+tabControl_ config = tabControl config []
+
+singleTab
+  :: ∀ p i page
+   . Eq page
+  => page
+  -> Tab i page
+  -> HH.HTML p i
+singleTab activePage tab =
+  HH.li
+    [ HP.class_ $ HH.ClassName "mr-12" ]
+    [ HH.a
+      ( tab.props
+        <> [ HP.classes $ tabClasses <> conditionalTabClasses isActive ]
+      )
+      ( errorIcon
+        <>
+        [ HH.span
+          [ HP.classes tabTextClasses ]
+          [ HH.text tab.name ]
+        ]
+      )
+    ]
+  where
+    isActive :: Boolean
+    isActive = tab.page == activePage
+
+    errorIcon :: Array (HH.HTML p i)
+    errorIcon
+      | tab.errors > 0 && isActive == false =
+        [ Icon.error
+          [ HP.classes $ errorIconClasses ]
+        ]
+      | otherwise = []
+
+    conditionalTabClasses :: IsActive -> Array HH.ClassName
+    conditionalTabClasses true = activeTabClasses
+    conditionalTabClasses false = inactiveTabClasses


### PR DESCRIPTION
## What does this pull request do?
Adds a more general tab control which takes an `Array IProp` instead of navigation links for it's tab config. This is basically just a copy paste from navigationTabs. I thought to maybe make `navigationTabs`  use this tab implementation, just translating links to iProps, but I wasn't sure if that might introduce some bad coupling in case these two UI controls end up evolving in different ways later on or something. It's certainly an option though if you guys think that seems like a good idea. 
