### PR TITLE
Fixes slow performance in tree component

### DIFF
--- a/src/Components/Tree/Component.purs
+++ b/src/Components/Tree/Component.purs
@@ -106,13 +106,15 @@ component =
               ]
             ]
           ] <>
-          [ HH.div
-            [ css $ if expanded then "" else "hidden" ]
-            ( A.concat
-              $ A.mapWithIndex
-                (renderRow (depth + 1) (A.cons ix indexPath) (A.snoc itemPath value))
-                children )
-          ]
+          ( if not expanded then [] else
+            [ HH.div_
+              ( A.concat
+                $ A.mapWithIndex
+                  (renderRow (depth + 1) (A.cons ix indexPath) (A.snoc itemPath value))
+                  children
+              )
+            ]
+          )
 
         renderCarat children expanded path =
           carat


### PR DESCRIPTION
## What does this pull request do?
This PR changes the tree component so that child items are only rendered if the dropdown is expanded. I noticed whenever the `ToggleItem` query was called, the modifying of the checked item seemed to cause the entire component to re-render. This re-rendering was pretty expensive and would take a couple of seconds to update the UI. By only rendering the parent items and child items of expanded parents, it cuts down this re-rendering by a huge amount, and since the checkbox state is saved in the trees component state anyways, there's no dis-advantage to skipping the rendering of unexpanded child items. 