### PR TITLE
Update release instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ To create a new release:
 
 1. Adjust the version in `package.json`.
     Some of our dependents rely on this version being correct.
-1. Commit the changes to `master`.
+1. Submit the changes to `master` via a PR.
 1. Create a tag for the version.
     ```sh
     $ git tag $NEW_VERSION


### PR DESCRIPTION
## What does this pull request do?

`master` is now a protected branch, so commits directly to it are no longer allowed. We update the wording in our instructions for cutting a new release to reflect that.

## Other Notes:

Are we okay with adding this extra step to our release process in order to prevent code from accidentally being committed straight to `master`?

