### PR TITLE
Improve Currency API

### DIFF
--- a/src/Data/Currency.purs
+++ b/src/Data/Currency.purs
@@ -2,10 +2,12 @@ module Ocelot.Data.Currency where
 
 import Prelude
 
+import Data.Argonaut (class DecodeJson, decodeJson)
 import Data.Argonaut.Encode (class EncodeJson, encodeJson)
 import Data.Array (all, drop, head, (:))
 import Data.BigInt (BigInt)
 import Data.BigInt as BigInt
+import Data.Either (note
 import Data.Foldable (foldr)
 import Data.Int (fromString) as Int
 import Data.Maybe (Maybe(..), fromMaybe, isJust)
@@ -13,6 +15,7 @@ import Data.Newtype (class Newtype, unwrap)
 import Data.String (Pattern(..), Replacement(..), length, replaceAll, split, take, null)
 import Data.String.CodeUnits (toCharArray, fromCharArray)
 import Data.Tuple (Tuple(..), snd)
+import Prim.TypeError (class Warn, Text)
 
 ----------
 -- CENTS
@@ -23,20 +26,48 @@ derive instance newtypeCents :: Newtype Cents _
 derive newtype instance eqCents :: Eq Cents
 
 instance encodeJsonCents :: EncodeJson Cents where
-  encodeJson = encodeJson <<< BigInt.toNumber <<< unwrap
+  encodeJson = encodeJson <<< centsToNumber
+
+instance decodeJsonCents :: DecodeJson Cents where
+  decodeJson json = do
+    num <- decodeJson json
+    note ("Could not convert value to `Cents`: " <> show num) (parseCentsFromNumber num)
 
 instance showCents :: Show Cents where
-  show (Cents n) = "Cents " <> BigInt.toString n
+  show (Cents n) = "(Cents " <> BigInt.toString n <> ")"
 
--- | Will parse cents from a 32bit int
-parseCentsFromNumber :: Number -> Maybe Cents
-parseCentsFromNumber = map Cents <<< BigInt.fromNumber
-
-parseCentsFromMicroDollars :: Number -> Maybe Cents
-parseCentsFromMicroDollars = parseCentsFromNumber <<< flip (/) 10000.0
+----------
+-- FROM CENTS
 
 centsToMaybeInt :: Cents -> Maybe Int
 centsToMaybeInt = Int.fromString <<< BigInt.toString <<< unwrap
+
+centsToNumber :: Cents -> Number
+centsToNumber = BigInt.toNumber <<< unwrap
+
+centsToString :: Cents -> String
+centsToString = BigInt.toString <<< unwrap
+
+----------
+-- TO CENTS
+
+centsFromInt :: Int -> Cents
+centsFromInt = Cents <<< BigInt.fromInt
+
+parseCentsFromNumber :: Number -> Maybe Cents
+parseCentsFromNumber = map Cents <<< BigInt.fromNumber
+
+parseCentsFromString :: String -> Maybe Cents
+parseCentsFromString = map Cents <<< BigInt.fromString
+
+parseCentsFromMicroDollars
+  :: Warn (Text "parseCentsFromMicroDollars is deprecated and will be removed in a future release")
+  => Number
+  -> Maybe Cents
+parseCentsFromMicroDollars = parseCentsFromNumber <<< (_ / 10000.0)
+
+-----------
+-- STRING FORMATTING
 
 -- | Will attempt to parse cents from a string representing a dollar amount. It will
 -- strip any trailing cents beyond the hundredths place. WARNING: Do not use this on

--- a/src/Data/Currency.purs
+++ b/src/Data/Currency.purs
@@ -7,7 +7,7 @@ import Data.Argonaut.Encode (class EncodeJson, encodeJson)
 import Data.Array (all, drop, head, (:))
 import Data.BigInt (BigInt)
 import Data.BigInt as BigInt
-import Data.Either (note
+import Data.Either (note)
 import Data.Foldable (foldr)
 import Data.Int (fromString) as Int
 import Data.Maybe (Maybe(..), fromMaybe, isJust)


### PR DESCRIPTION
## What does this pull request do?

Our Currency module was missing some basic functions for converting to and from various types. This meant that consumers were writing their own functions to convert between Cents and other types, which required knowledge of and coupling to the underlying implementation for Cents (Data.BigInt). That meant that if we wanted to switch out that underlying implementation for another, we would cause a breaking change because our consumers then need to update their functions as well.

This PR attempts to offer a better API for Cents so that consumers shouldn't
have to know what's under the hood.

