### PR TITLE
PS-3138 Allow setting the image next to an item

### DIFF
--- a/src/Interfaces/Typeahead/Interface.purs
+++ b/src/Interfaces/Typeahead/Interface.purs
@@ -29,6 +29,7 @@ import Network.RemoteData (RemoteData(..))
 import Ocelot.Block.ItemContainer (boldMatches)
 import Ocelot.Component.Typeahead (Component, Input, Insertable(..), Message(..), Query(..), defRenderContainer, multi, renderMulti, renderSingle, single, base)
 import Ocelot.Component.Typeahead.Render (renderHeaderSearchDropdown, renderSearchDropdown, renderToolbarSearchDropdown)
+import Ocelot.HTML.Properties (css)
 import Ocelot.Interface.Utilities (Interface, mkSubscription)
 import Partial.Unsafe (unsafePartial)
 import Prim.TypeError (class Warn, Text)
@@ -127,7 +128,7 @@ typeaheadInputToSingleInput r =
   }
   where
     renderFuzzy item@(Fuzzy x) = case Object.lookup r.imageSource x.original of
-      Just src -> span_ ([ img [HP.src src, HP.width 10] ] <> boldMatches r.key item)
+      Just src -> span_ ([ img [HP.src src, css "align-text-top h-5 mr-1"] ] <> boldMatches r.key item)
       Nothing -> span_ (boldMatches r.key item)
 
 typeaheadInputToMultiInput
@@ -148,7 +149,7 @@ typeaheadInputToMultiInput r =
   }
   where
     renderFuzzy item@(Fuzzy x) = case Object.lookup r.imageSource x.original of
-      Just src -> span_ ([ img [HP.src src, HP.width 10] ] <> boldMatches r.key item)
+      Just src -> span_ ([ img [HP.src src, css "align-text-top h-5 mr-1"] ] <> boldMatches r.key item)
       Nothing -> span_ (boldMatches r.key item)
 
 dropdownInputToSingleInput

--- a/src/Interfaces/Typeahead/Interface.purs
+++ b/src/Interfaces/Typeahead/Interface.purs
@@ -7,7 +7,7 @@ import Prelude
 import Control.Promise (Promise)
 import Control.Promise as Promise
 import Data.Array (head)
-import Data.Fuzzy (match)
+import Data.Fuzzy (Fuzzy(..), match)
 import Data.Int (toNumber)
 import Data.Maybe (Maybe(..), fromJust, fromMaybe, maybe)
 import Data.Symbol (SProxy(..))
@@ -20,7 +20,7 @@ import Effect.Aff.AVar as AffAVar
 import Effect.Aff.Compat (EffectFn1, EffectFn2, mkEffectFn1, mkEffectFn2)
 import Foreign.Object (Object)
 import Foreign.Object as Object
-import Halogen.HTML (span_)
+import Halogen.HTML (img, span_)
 import Halogen.HTML (text) as HH
 import Halogen.HTML.Properties as HP
 import Halogen.VDom.Driver (runUI)
@@ -80,6 +80,7 @@ convertSingleToMessageVariant = case _ of
 -- | - placeholder: placeholder text to set in the field
 -- | - key: the name of the field in the object that should be displayed in the list
 -- | - keepOpen: whether the typeahead should stay open or close on selection
+-- | - imageSource: the name of the field in the object that displays an image next to the key
 type TypeaheadInput =
   { items :: Array (Object String)
   , debounceTime :: Int
@@ -87,6 +88,7 @@ type TypeaheadInput =
   , key :: String
   , keepOpen :: Boolean
   , insertable :: Boolean
+  , imageSource :: String
   }
 
 -- | Another subset of the input available to the typeahead, for the dropdown variant
@@ -124,7 +126,9 @@ typeaheadInputToSingleInput r =
       (defRenderContainer renderFuzzy)
   }
   where
-    renderFuzzy = span_ <<< boldMatches r.key
+    renderFuzzy item@(Fuzzy x) = case Object.lookup r.imageSource x.original of
+      Just src -> span_ ([ img [HP.src src, HP.width 10] ] <> boldMatches r.key item)
+      Nothing -> span_ (boldMatches r.key item)
 
 typeaheadInputToMultiInput
   :: ∀ pq m
@@ -143,7 +147,9 @@ typeaheadInputToMultiInput r =
       (defRenderContainer renderFuzzy)
   }
   where
-    renderFuzzy = span_ <<< boldMatches r.key
+    renderFuzzy item@(Fuzzy x) = case Object.lookup r.imageSource x.original of
+      Just src -> span_ ([ img [HP.src src, HP.width 10] ] <> boldMatches r.key item)
+      Nothing -> span_ (boldMatches r.key item)
 
 dropdownInputToSingleInput
   :: ∀ pq m

--- a/test/Interop/src/index.js
+++ b/test/Interop/src/index.js
@@ -17,7 +17,7 @@ function mkElement(id) {
 }
 
 // Create a valid input
-const items = [ { name: "Thomas" }, { name: "Chris" }, { name: "Qian", email: "qian@cn.com" }, { name: "Jeff" } ]
+const items = [ { name: "Thomas" }, { name: "Chris" }, { name: "Qian", email: "qian@cn.com", icon: "https://www.citizennet.com/hubfs/images/website/icons/icn-facebook-glyph.svg" }, { name: "Jeff" } ]
 const input =
   { items: [] // empty to start
   , debounceTime: 300
@@ -25,6 +25,7 @@ const input =
   , key: "name"
   , keepOpen: false
   , insertable: true
+  , imageSource: "icon"
   }
 
 // Mount the component at the given element


### PR DESCRIPTION
## What does this pull request do?

Per [PS-3138](https://citizennet.atlassian.net/browse/PS-3138), we need to let QuickSight set images for some of their Typeaheads. They want to differentiate between Facebook and Twitter. We let them tell us which image to display, and we do it.

## Where should the reviewer start?

* Having gone through the implementation of this approach, it doesn't seem right. We have to now manage image sources and resize them. It's not great. I'm making a PR to get a second opinion. I might be overthinking it, but it seems like we might want to instead restrict to just the  icons we support. Would that be better? I think from QS's perspective, there shouldn't be much change.

## How should this be manually tested?

1. [x] Follow the instructions in for setting up the [interop](https://github.com/citizennet/purescript-ocelot/blob/3041c2085e8d4a6f5c88fa20574ac1c7b15e69f1/src/Interfaces/readme.md).
1. [x] Should see an icon next to Qian in the top Typeahead.