### PR TITLE
Bump version to 0.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-ocelot",
-  "version": "0.16.10",
+  "version": "0.17.0",
   "private": true,
   "scripts": {
     "build-all": "yarn run build-ui && yarn run build-css",


### PR DESCRIPTION
## What does this pull request do?

We did #101 so QS could use it. We make a new version so QS can actually refer to the version like it usually does.

## Where should the reviewer start?

* Although we use SemVer, we've been making breaking changes in patch versions. We're still on 0.x.x which means there's no rules, but the reality is that this will break something not just on the JS side. Anyone using `Ocelot.Typeahead.Interface` (transitively) will be broken from this change. I don't particularly care what the version is (if we'd prefer to do 0.16.11, I'll change to that), but I'm defaulting to moving the minor version because of what I laid out above.
* Requesting a review from both Dave and Vance as I think y'all have the most context on our versioning process. Would appreciate if you both could review this one before merging.