### PR TITLE
Dropdown DatePicker Receive Query

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-ocelot",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "private": true,
   "scripts": {
     "build-all": "yarn run build-ui && yarn run build-css",

--- a/src/Components/DatePicker/Component.purs
+++ b/src/Components/DatePicker/Component.purs
@@ -47,6 +47,7 @@ data Query a
   | ToggleYear  Direction a
   | ToggleMonth Direction a
   | Initialize a
+  | Receive Input a
   | TriggerFocus a
   | Synchronize a
   | GetSelection (Maybe Date -> a)
@@ -105,7 +106,7 @@ component =
     { initialState
     , render
     , eval
-    , receiver: const Nothing
+    , receiver: HE.input Receive
     , initializer: Just $ H.action Initialize
     , finalizer: Nothing
     }
@@ -188,6 +189,10 @@ component =
         let d' = fromMaybe d selection
         H.modify_ _ { targetDate = Tuple (year d') (month d') }
         eval $ Synchronize a
+
+      Receive i a -> do
+        H.put $ initialState i
+        eval $ Initialize a
 
       TriggerFocus a -> a <$ H.query unit Select.triggerFocus
 

--- a/src/Components/Dropdown/Component.purs
+++ b/src/Components/Dropdown/Component.purs
@@ -8,7 +8,7 @@ import Data.Maybe (Maybe(..))
 import Effect.Aff.Class (class MonadAff)
 import Halogen as H
 import Halogen.HTML as HH
-import Renderless.State (updateStore)
+import Halogen.HTML.Events as HE
 import Select as Select
 
 data Query o item m a
@@ -49,7 +49,7 @@ component =
     { initialState
     , render: extract
     , eval
-    , receiver: const Nothing
+    , receiver: HE.input Receive
     }
 
   where
@@ -86,6 +86,6 @@ component =
         H.modify_ $ seeks _ { selectedItem = item }
         pure a
       Receive input a -> do
-        H.modify_ $ updateStore input.render identity
+        H.put $ initialState input
         pure a
 


### PR DESCRIPTION
## What does this pull request do?
Adds a `Receive` query to the dropdown and date picker components. 

## How should this be manually tested?
Setting the input of these controls to some externally controlled state -- the components display values should update when the external state changes

## Other Notes
I opted to just using H.put to update the state. These components have their state set entirely by input so this shouldn't break anything, but let me know if I'm off base on something here.
