### PR TITLE
PS-3166 Use white text for dark buttons

### DIFF
--- a/src/Blocks/Button.purs
+++ b/src/Blocks/Button.purs
@@ -50,7 +50,7 @@ buttonDarkClasses = HH.ClassName <$>
   , "border-grey-70-a30"
   , "hover:!disabled:bg-grey-70-a40"
   , "focus:bg-grey-70-a40"
-  , "text-grey-70"
+  , "text-white"
   ]
 
 buttonClearClasses :: Array HH.ClassName


### PR DESCRIPTION
## What does this pull request do?

This makes the text on dark buttons white, per Product feedback.

<details>
<summary>Old and busted</summary>

<img width="336" alt="Screen Shot 2020-01-03 at 2 19 37 PM" src="https://user-images.githubusercontent.com/47793030/71752504-290b3980-2e34-11ea-9607-2fa4543ea99c.png">
</details>

<details>
<summary>New hotness</summary>

<img width="340" alt="Screen Shot 2020-01-03 at 2 18 44 PM" src="https://user-images.githubusercontent.com/47793030/71752513-30324780-2e34-11ea-98cf-f9628e0c52dc.png">
</details>

## Where should the reviewer start?

* More discussion in [Slack](https://citizennet.slack.com/archives/C3Q0ATZST/p1578087753001500).
* More information in [JIRA](https://citizennet.atlassian.net/browse/PS-3166).

## How should this be manually tested?

1. [x] Build the UI: `yarn run build-ui`.
1. [x] Look at the buttons in the browser: `#buttons`.
1. [x] The dark buttons should have white text.