### PR TITLE
Add support for deploying to k8s cluster

### DIFF
--- a/.k8s/.helmignore
+++ b/.k8s/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/.k8s/Chart.yaml
+++ b/.k8s/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: Standard web application chart for kubernetes
+name: ocelot
+version: 0.1.0

--- a/.k8s/README.md
+++ b/.k8s/README.md
@@ -1,0 +1,35 @@
+# Deploying into local Kubernetes cluster
+
+If you've got a local Kubernetes cluster that you'd like to deploy Ocelot to, the files here should make that easy to do via `helm`.
+
+First, if you haven't created a Docker build, run the following from the project root:
+
+```bash
+docker build -t ocelot-local .
+```
+
+With that out of the way, run the following to kick off a local deployment:
+
+```bash
+helm install --name ocelot .k8s/ --set ingress.host=$(hostname),persistence.path=/home/$USER/src/purescript-ocelot
+```
+
+If you don't have `hostname` configured or your project repo is not set up in `~/src`, then you'll have to manually substitute the value for `ingress.host` with your hostname, and the value for `persistence.path` with your actual project location.
+
+Configuring your `hostname` is as simple as:
+
+```bash
+hostname dude.dev.citizennet.com
+hostname > /etc/hostname
+```
+
+If you don't want to mess with your system's `hostname` settings, just hardcode that part in the `helm install` command.
+
+And that's it! You can verify your deployment by running `kubectl get pods` and looking for `ocelot-...`. To view the logs for either, run `kubectl logs <pod name> <container name>` where `<container name>` is either `ocelot` for the http server logs.
+
+## Helm config options
+
+There are a few options you can pass to `helm` via the `--set` flag when deploying:
+
+- `ingress.host` **required**: the hostname for your local deployment, e.g. `dude.dev.citizennet.com`
+- `persistence.path` **required**: the local path to your Ocelot repository, e.g. `/home/dude/src/purescript-ocelot`

--- a/.k8s/templates/_helpers.tpl
+++ b/.k8s/templates/_helpers.tpl
@@ -1,0 +1,8 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/.k8s/templates/deployment.yaml
+++ b/.k8s/templates/deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+        release: {{ .Release.Name }}
+        repository: {{ .Release.Name }}-local
+        imageTag: latest
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "ocelot-local:latest"
+          command: ["http-server", "./dist", "-p", "80"]
+          volumeMounts:
+            - name: src
+              mountPath: /usr/src/app
+          imagePullPolicy: IfNotPresent
+          env: []
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: althttp
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /index.html
+              port: http
+            initialDelaySeconds: 10
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: http
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+          resources: {}
+        {{- if .Values.watch }}
+        - name: {{ .Chart.Name }}-watch
+          image: "ocelot-local:latest"
+          command: ["make", "watch", "BOWER_ARGS=--allow-root"]
+          volumeMounts:
+            - name: src
+              mountPath: /usr/src/app
+          imagePullPolicy: IfNotPresent
+          env: []
+        {{- end }}
+      volumes:
+        - name: src
+          hostPath:
+            type: Directory
+            path: {{ .Values.persistence.path }}
+      nodeSelector: {}
+      affinity: {}
+      tolerations: []

--- a/.k8s/templates/ingress.yaml
+++ b/.k8s/templates/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    # adds 301 redirect with trailing slash
+    nginx.ingress.kubernetes.io/configuration-snippet: rewrite ^(/ocelot)$ $1/ permanent;
+spec:
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /ocelot(/|$)(.*)
+            backend:
+              serviceName: {{ .Release.Name }}
+              servicePort: http

--- a/.k8s/templates/service.yaml
+++ b/.k8s/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+    chart: {{ template "chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: 8080
+      targetPort: althttp
+      protocol: TCP
+      name: althttp
+  selector:
+    app: {{ .Chart.Name }}
+    release: {{ .Release.Name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:stretch
+
+# Global install yarn package manager
+# Global install purescript, pulp, and bower
+RUN apt-get update && apt-get install -y curl apt-transport-https && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && apt-get install -y yarn && \
+    yarn global add webpack-cli purescript pulp bower http-server
+
+RUN mkdir -p /usr/src/app
+
+COPY . /usr/src/app
+
+WORKDIR /usr/src/app
+
+RUN yarn run build-all
+
+ENTRYPOINT http-server ./dist -p 80


### PR DESCRIPTION
## What does this pull request do?

This is more or less copy-pasted from the Lynx repository. A common workflow for some of us it to work on a remote server, where the best way to get browser feedback is to deploy to a k8s cluster managed by helm. Notably we don't really on outside configuration files like in our private repos, since this is a public repo, it should be able to be deployed independently (assuming a compatible deployment environment).

## How should this be manually tested?

Follow the directions in `.k8s/README.md` from an environment running k8s and helm:

```bash
docker build -t ocelot-local .
helm install --name ocelot .k8s/ --set ingress.host=$(hostname),persistence.path=/home/$USER/src/purescript-ocelot
```

## Other Notes:

These configs could probably be cleaned up plenty, but wanted to just get this working and move on to the actual task to be worked on.