### PR TITLE
PS-3164: Disabled Dates

### DIFF
--- a/src/Components/DatePicker/Component.purs
+++ b/src/Components/DatePicker/Component.purs
@@ -35,11 +35,13 @@ type State =
   , selection :: Maybe Date
   , search :: String
   , calendarItems :: Array CalendarItem
+  , disabled :: Boolean
   }
 
 type Input =
   { targetDate :: Maybe (Tuple Year Month)
   , selection :: Maybe Date
+  , disabled :: Boolean
   }
 
 data Query a
@@ -111,13 +113,14 @@ component =
     }
   where
     initialState :: Input -> State
-    initialState { targetDate, selection } =
+    initialState { targetDate, selection, disabled } =
       let targetDate' = fromMaybe (Tuple (ODT.unsafeMkYear 2001) (ODT.unsafeMkMonth 1)) targetDate
         in
       { targetDate: targetDate'
       , selection
       , search: ""
       , calendarItems: generateCalendarRows selection (fst targetDate') (snd targetDate')
+      , disabled
       }
 
     eval
@@ -227,7 +230,9 @@ component =
 
     render :: State -> H.ParentHTML Query ChildQuery Unit m
     render st = HH.div_
-        [ HH.slot unit Select.component selectInput (HE.input HandleSelect) ]
+      if st.disabled
+        then [ Input.input [ HP.disabled true, HP.value st.search ] ]
+        else [ HH.slot unit Select.component selectInput (HE.input HandleSelect) ]
       where
         selectInput =
           { initialSearch: Nothing

--- a/src/Components/DateTimePicker/Component.purs
+++ b/src/Components/DateTimePicker/Component.purs
@@ -117,7 +117,9 @@ component =
         , HH.div
           [ css "flex-1" ]
           [ HH.slot' CP.cp2 unit TP.component
-            { selection: time }
+            { selection: time
+            , disabled
+            }
             (HE.input HandleTime)
           ]
         ]

--- a/src/Components/DateTimePicker/Component.purs
+++ b/src/Components/DateTimePicker/Component.purs
@@ -20,11 +20,13 @@ type State =
   { date :: Maybe Date
   , time :: Maybe Time
   , targetDate :: Maybe (Tuple Year Month)
+  , disabled :: Boolean
   }
 
 type Input =
   { selection :: Maybe DateTime
   , targetDate :: Maybe (Tuple Year Month)
+  , disabled :: Boolean
   }
 
 data Query a
@@ -58,10 +60,11 @@ component =
     }
   where
     initialState :: Input -> State
-    initialState { selection, targetDate } =
+    initialState { selection, targetDate, disabled } =
       { date: date <$> selection
       , time: time <$> selection
       , targetDate
+      , disabled
       }
 
     eval :: Query ~> H.ParentDSL State Query ChildQuery ChildSlot Message m
@@ -99,7 +102,7 @@ component =
 
 
     render :: State -> H.ParentHTML Query ChildQuery ChildSlot m
-    render { date, time, targetDate } =
+    render { date, time, targetDate, disabled } =
       HH.div
         [ css "flex" ]
         [ HH.div
@@ -107,6 +110,7 @@ component =
           [ HH.slot' CP.cp1 unit DP.component
             { targetDate
             , selection: date
+            , disabled
             }
             (HE.input HandleDate)
           ]

--- a/src/Components/TimePicker/Component.purs
+++ b/src/Components/TimePicker/Component.purs
@@ -26,10 +26,12 @@ type State =
   { selection :: Maybe Time
   , search :: String
   , timeUnits :: Array TimeUnit
+  , disabled :: Boolean
   }
 
 type Input =
   { selection :: Maybe Time
+  , disabled :: Boolean
   }
 
 data Query a
@@ -91,10 +93,11 @@ component =
     }
   where
     initialState :: Input -> State
-    initialState { selection } =
+    initialState { selection, disabled } =
       { selection
       , search: ""
       , timeUnits: generateTimes selection
+      , disabled
       }
 
     eval
@@ -170,7 +173,9 @@ component =
 
     render :: State -> H.ParentHTML Query ChildQuery Unit m
     render st = HH.div_
-        [ HH.slot unit Select.component selectInput (HE.input HandleSelect) ]
+      if st.disabled
+        then [ Input.input [ HP.disabled true, HP.value st.search ] ]
+        else [ HH.slot unit Select.component selectInput (HE.input HandleSelect) ]
       where
         selectInput =
           { initialSearch: Nothing

--- a/ui-guide/Components/DatePickers.purs
+++ b/ui-guide/Components/DatePickers.purs
@@ -240,6 +240,20 @@ cnDocumentationBlocks =
                 }
                 (const Nothing)
               ]
+            , Format.caption_ [ HH.text "Standard Disabled" ]
+            , FormField.field_
+              { label: HH.text "Start"
+              , helpText: [ HH.text "Choose a start date and time." ]
+              , error: []
+              , inputId: "start-disabled"
+              }
+              [ HH.slot' CP.cp3 2 DateTimePicker.component
+                { targetDate: Nothing
+                , selection: Nothing
+                , disabled: true
+                }
+                (const Nothing)
+              ]
             ]
           ]
         , content
@@ -256,6 +270,20 @@ cnDocumentationBlocks =
                 { targetDate: Nothing
                 , selection: Just $ DateTime (unsafeMkDate 2019 1 1) (unsafeMkTime 0 0 0 0)
                 , disabled: false
+                }
+                (const Nothing)
+              ]
+            , Format.caption_ [ HH.text "Hydrated Disabled" ]
+            , FormField.field_
+              { label: HH.text "End"
+              , helpText: [ HH.text "Choose an end date and time." ]
+              , error: []
+              , inputId: "end-disabled"
+              }
+              [ HH.slot' CP.cp3 3 DateTimePicker.component
+                { targetDate: Nothing
+                , selection: Just $ DateTime (unsafeMkDate 2019 1 1) (unsafeMkTime 0 0 0 0)
+                , disabled: true
                 }
                 (const Nothing)
               ]

--- a/ui-guide/Components/DatePickers.purs
+++ b/ui-guide/Components/DatePickers.purs
@@ -94,6 +94,21 @@ cnDocumentationBlocks =
               [ HH.slot' CP.cp1 0 DatePicker.component
                 { targetDate: Nothing
                 , selection: Nothing
+                , disabled: false
+                }
+                (const Nothing)
+              ]
+            , Format.caption_ [ HH.text "Disabled" ]
+            , FormField.fieldMid_
+              { label: HH.text "Start"
+              , helpText: [ HH.text "Choose a start date." ]
+              , error: []
+              , inputId: "start-date-disabled"
+              }
+              [ HH.slot' CP.cp1 2 DatePicker.component
+                { targetDate: Nothing
+                , selection: Nothing
+                , disabled: true
                 }
                 (const Nothing)
               ]
@@ -112,6 +127,21 @@ cnDocumentationBlocks =
               [ HH.slot' CP.cp1 1 DatePicker.component
                 { targetDate: Nothing
                 , selection: Just $ unsafeMkDate 2019 1 1
+                , disabled: false
+                }
+                (const Nothing)
+              ]
+            , Format.caption_ [ HH.text "Hydrated Disabled" ]
+            , FormField.fieldMid_
+              { label: HH.text "End"
+              , helpText: [ HH.text "Choose an end date." ]
+              , error: []
+              , inputId: "end-date-disabled"
+              }
+              [ HH.slot' CP.cp1 3 DatePicker.component
+                { targetDate: Nothing
+                , selection: Just $ unsafeMkDate 2019 1 1
+                , disabled: true
                 }
                 (const Nothing)
               ]
@@ -178,6 +208,7 @@ cnDocumentationBlocks =
               [ HH.slot' CP.cp3 0 DateTimePicker.component
                 { targetDate: Nothing
                 , selection: Nothing
+                , disabled: false
                 }
                 (const Nothing)
               ]
@@ -196,6 +227,7 @@ cnDocumentationBlocks =
               [ HH.slot' CP.cp3 1 DateTimePicker.component
                 { targetDate: Nothing
                 , selection: Just $ DateTime (unsafeMkDate 2019 1 1) (unsafeMkTime 0 0 0 0)
+                , disabled: false
                 }
                 (const Nothing)
               ]

--- a/ui-guide/Components/DatePickers.purs
+++ b/ui-guide/Components/DatePickers.purs
@@ -98,7 +98,7 @@ cnDocumentationBlocks =
                 }
                 (const Nothing)
               ]
-            , Format.caption_ [ HH.text "Disabled" ]
+            , Format.caption_ [ HH.text "Standard Disabled" ]
             , FormField.fieldMid_
               { label: HH.text "Start"
               , helpText: [ HH.text "Choose a start date." ]
@@ -166,6 +166,20 @@ cnDocumentationBlocks =
               }
               [ HH.slot' CP.cp2 0 TimePicker.component
                 { selection: Nothing
+                , disabled: false
+                }
+                (const Nothing)
+              ]
+            , Format.caption_ [ HH.text "Standard Disabled" ]
+            , FormField.fieldMid_
+              { label: HH.text "Start"
+              , helpText: [ HH.text "Choose a start time." ]
+              , error: []
+              , inputId: "start-time-disabled"
+              }
+              [ HH.slot' CP.cp2 2 TimePicker.component
+                { selection: Nothing
+                , disabled: true
                 }
                 (const Nothing)
               ]
@@ -183,6 +197,20 @@ cnDocumentationBlocks =
               }
               [ HH.slot' CP.cp2 1 TimePicker.component
                 { selection: Just $ unsafeMkTime 12 0 0 0
+                , disabled: false
+                }
+                (const Nothing)
+              ]
+            , Format.caption_ [ HH.text "Hydrated Disabled" ]
+            , FormField.fieldMid_
+              { label: HH.text "End"
+              , helpText: [ HH.text "Choose an end time." ]
+              , error: []
+              , inputId: "end-time-disabled"
+              }
+              [ HH.slot' CP.cp2 1 TimePicker.component
+                { selection: Just $ unsafeMkTime 12 0 0 0
+                , disabled: true
                 }
                 (const Nothing)
               ]


### PR DESCRIPTION
## What does this pull request do?

We need the ability to set date components to disabled/read-only. That's exactly what this PR lets us do.

## How should this be manually tested?

It depends on your environment. 

If you're developing locally (I haven't tested this method): 
- [x] You should be able to run `yarn run build-all` then serve the `dist` folder to localhost
- [x] Then navigate to `/#date-pickers` and verify in the UI. 

If you're developing on EC2:
- [ ] You should be able to deploy the UI Guide by following the instructions in `.k8s/README.md`
- [ ] Then navigate to `/ocelot/#date-pickers` to verify the UI.

![Screen Shot 2020-01-06 at 7 49 26 PM](https://user-images.githubusercontent.com/709141/71867162-d6dd4900-30bd-11ea-9a68-0aca1d8efcf6.png)

## Other Notes:

There is an issue with the hydrated TimePicker not rendering its value, that will be addressed in a separate PR.