### PR TITLE
PS-3174: Bugfix: Time components not rendering values

### DIFF
--- a/src/Components/TimePicker/Component.purs
+++ b/src/Components/TimePicker/Component.purs
@@ -86,7 +86,7 @@ component =
     , render
     , eval
     , receiver: const Nothing
-    , initializer: Nothing
+    , initializer: Just (Synchronize unit)
     , finalizer: Nothing
     }
   where


### PR DESCRIPTION
## What does this pull request do?

There was a bug where the TimePicker (and by usage, DateTimePicker) wasn't rendering the initially provided value. We weren't setting it on the state upon initializing the component. That's fixed now.

## How should this be manually tested?

It depends on your environment.

If you're developing locally (I haven't tested this method):

* [x]  You should be able to run `yarn run build-all` then serve the `dist` folder to localhost
* [x]  Then navigate to `/#date-pickers` and verify in the UI.

If you're developing on EC2:

* [ ]  You should be able to deploy the UI Guide by following the instructions in `.k8s/README.md`
* [ ]  Then navigate to `/ocelot/#date-pickers` to verify the UI.

Before:
![Screen Shot 2020-01-06 at 8 02 11 PM](https://user-images.githubusercontent.com/709141/71867825-a1862a80-30c0-11ea-808c-490d4bbdd12b.png)

After:
![Screen Shot 2020-01-06 at 8 02 28 PM](https://user-images.githubusercontent.com/709141/71867831-a814a200-30c0-11ea-808f-d9c79b83f480.png)



