### PR TITLE
Fix syntax to work on both 0.12.x and 0.13.x

### DIFF
--- a/src/Components/Tree/Component.purs
+++ b/src/Components/Tree/Component.purs
@@ -97,8 +97,7 @@ component =
     render { items, renderItem, checkable } =
       HH.div_ $ A.concat $ A.mapWithIndex (renderRow 0 [] []) items
       where
-        renderRow depth indexPath itemPath ix (Node { selected, expanded, children, value }) = do
-          let path = A.cons ix indexPath
+        renderRow depth indexPath itemPath ix (Node { selected, expanded, children, value }) =
           [ HH.div
             [ css $ "flex border-b py-2 pr-2 " <> ("pl-" <> (show (depth * 10))) ]
             [ renderCarat children expanded path
@@ -129,6 +128,8 @@ component =
               )
             ]
           )
+          where
+            path = A.cons ix indexPath
 
         renderCarat children expanded path =
           carat


### PR DESCRIPTION
## What does this pull request do?

The previous syntax only worked for 0.12.x. But since we use `purescript-ocelot` in both 0.12.x and 0.13.x downstream, we need to support syntax for both.

## Where should the reviewer start?

* More discussion on [Slack](https://citizennet.slack.com/archives/C3Q0ATZST/p1578419822023000). Decided not to make CI enforce this stuff.

## How should this be manually tested?

* Making `purescript-ocelot` work with 0.13.x is non-trivial (the dependencies are all messed up). I've checked it locally, but if you'd like I can add a patch with the things that need to change. Otherwise, trusting CI is probably fine 🤷‍♂.