### PR TITLE
Bump version to 0.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-ocelot",
-  "version": "0.18.3",
+  "version": "0.19.0",
   "private": true,
   "scripts": {
     "build-all": "yarn run build-ui && yarn run build-css",


### PR DESCRIPTION
Bumping the minor version so we can tag a release for the [Date component work](https://github.com/citizennet/purescript-ocelot/compare/v0.18.3...12766fe), which is breaking.