### PR TITLE
Fix Header CSS

### DIFF
--- a/src/Blocks/Header.purs
+++ b/src/Blocks/Header.purs
@@ -68,7 +68,7 @@ stickyFormHeader hConfig tConfig =
 stickyHeader_ :: ∀ p i. FormHeaderProps p i -> HH.HTML p i
 stickyHeader_ config =
   HH.div
-    [ HP.class_ $ HH.ClassName "h-20" ]
+    [ HP.class_ $ HH.ClassName "h-24" ]
     [ HH.div
       [ HP.classes Layout.stickyClasses ]
       [ formHeader config ]


### PR DESCRIPTION
## What does this pull request do?

There was a small layout bug where we were giving the `Ocelot.Block.Header.stickyHeader` block a height of `h-20`, but in usage, we throw `Ocelot.Block.Header.header` inside, which has a height of `h-24`. This caused a discrepancy between the visual height of the header, and the height it took up in the layout (`stickyHeader` gets fixed positioning, so the inner and outer height have to match up so that content doesn't show up underneath the block).

## How should this be manually tested?

Easiest way to verify is to:
- [x] Load up [`/manager/#/groups/twitter/new/details`](https://staging.citizennet.com/manager/#/groups/twitter/new/details)
- [x] Right-click on the form header and "Inspect", then look for the div with the class `h-20`
  ![Screen Shot 2020-01-23 at 3 19 21 PM](https://user-images.githubusercontent.com/709141/73032486-1319e480-3df4-11ea-86c5-ef4ec68e2f7c.png)
- [x] Change the `h-20` to `h-24` and verify that the spacing below matches the gutter spacing between the columns better
