### PR TITLE
Fix `.clearfix` class

### DIFF
--- a/css/src/index.css
+++ b/css/src/index.css
@@ -51,6 +51,12 @@ dt {
 
 .container { max-width: 1200px; }
 
+.clearfix::before,
+.clearfix::after {
+  content: "";
+  display: table;
+}
+
 .flex-2 { flex: 2 }
 .flex-3 { flex: 3 }
 


### PR DESCRIPTION
## What does this pull request do?

Seems Tailwind ships its own `.clearfix` class, but it doesn't work in all situations (it only includes a rule for `.clearfix::after`, but we need the same rule for `.clearfix::before` as well). We are using an older version of Tailwind, it's possible this issue is fixed in a more recent version, but it's a lot easier to fix the class ourselves than to upgrade a major version.

## How should this be manually tested?

Not really an easy way to test. 
