### PR TITLE
vjp/searchbar-alt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-ocelot",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "private": true,
   "scripts": {
     "build-all": "yarn run build-ui && yarn run build-css",
@@ -12,8 +12,6 @@
     "build-css": "cd css && yarn run build-all"
   },
   "devDependencies": {
-    "bower": "^1.8.8",
-    "pulp": "^13.0.0",
     "purescript": "^0.13.6",
     "spago": "^0.15.2"
   },

--- a/src/Components/SearchBar.purs
+++ b/src/Components/SearchBar.purs
@@ -106,9 +106,8 @@ handleAction = case _ of
     closeIfNullQuery query
 
   Clear ev -> do
-    st <- H.get
     H.liftEffect $ stopPropagation $ ME.toEvent ev
-    H.modify_ _ { query = "", open = st.keepOpen }
+    H.modify_ \st -> st { query = "", open = st.keepOpen }
     H.raise $ Searched ""
 
   Search str -> do
@@ -162,8 +161,7 @@ closeIfNullQuery :: forall m.
   String ->
   m Unit
 closeIfNullQuery q = do
-  st <- H.get
-  if null q then H.modify_ _ { open = st.keepOpen } else pure unit
+  if null q then H.modify_ \st -> st { open = st.keepOpen } else pure unit
 
 render :: forall m.
   MonadAff m =>


### PR DESCRIPTION
## What does this pull request do?
Creates an alternative searchbar component. The alternative lets the consumer choose if the searchbar should close when unfocused (the original behavior) or if it should always remain in an opened state.

I wrote it in a way that it wouldn't be a breaking change with downstream consumers. But it would also be easy to transition to the new one if we decided we want this to be the new default component for the searchbar.