### PR TITLE
Fix bundling

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -7,7 +7,7 @@
   </head>
 
   <body>
-    <script src="example.js"></script>
+    <script src="index.js"></script>
   </body>
 
 </html>

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,0 +1,1 @@
+require("../output/Main/index.js").main();

--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
     "build-all": "yarn run build-ui && yarn run build-css",
     "postinstall": "cd css && npm i",
     "clean": "rm -rf output .spago node_modules && cd css && rm -rf node_modules",
-    "build-ui": "yarn run spago build -p \"ui-guide/**/*.purs\" -u \"$RTS_ARGS\" && purs bundle output/*/*.js -o dist/example.js $RTS_ARGS",
-    "watch-ui": "yarn run spago bundle-app -w -u \"$RTS_ARGS\" --then 'yarn run build-css' -p \"ui-guide/**/*.purs\" --to dist/example.js",
+    "build-ui": "yarn run build-ui-build && yarn run build-ui-bundle && yarn run build-ui-browserify",
+    "build-ui-build": "yarn run spago build -p \"ui-guide/**/*.purs\" -u \"$RTS_ARGS\"",
+    "build-ui-bundle": "purs bundle output/*/*.js --main Main --module Main -o dist/bundled.js $RTS_ARGS",
+    "build-ui-browserify": "yarn run browserify dist/main.js --outfile dist/index.js",
     "install-css": "cd css && yarn install",
     "build-css": "cd css && yarn run build-all"
   },
   "devDependencies": {
+    "browserify": "^16.5.1",
     "purescript": "^0.13.6",
     "spago": "^0.15.2"
   },


### PR DESCRIPTION
## What does this pull request do?

When we moved to Spago, we had to update the way we were building and bundling our UI Guide application, because the tools we were using were no longer available. In the process we didn't realize that our tooling no longer bundled for the browser automatically. We install `browserify` to fill that gap, and add the extra step to our build. Since our build has now grown to several steps, we break each out to their own command to make things easier to read, and so we can run each individually, if desired.

## How should this be manually tested?

If you wish to test this in a local minikube cluster, make sure to follow the directions here: https://github.com/citizennet/purescript-ocelot/tree/master/.k8s/README.md

- [x] Install latest dependencies: `yarn install`
- [x] Run updated build: `yarn run build-all`
- [x] Load up the UI Guide in your browser (if you followed the `.k8s` guide, it should be viewable at `https://$hostname/ocelot/`)
- [x] Verify it loads without error
