### PR TITLE
FBCM-3571 Allow disabling Typeaheads dynamically

### DIFF
--- a/src/Components/Typeahead/Component.purs
+++ b/src/Components/Typeahead/Component.purs
@@ -21,7 +21,7 @@ import Effect.Aff.Class (class MonadAff)
 import Foreign.Object (Object)
 import Halogen.HTML as HH
 import Network.RemoteData (RemoteData(..))
-import Ocelot.Component.Typeahead.Render (defRenderContainer, renderMulti, renderSingle) as TA
+import Ocelot.Component.Typeahead.Render (defRenderContainer, isDisabled, renderMulti, renderSingle) as TA
 
 -- | Forgive the long name; it provides clarity into what exactly
 -- | this type represents and you don't ordinarily need to write
@@ -45,6 +45,7 @@ syncSingle { itemToObject, renderFuzzy } props =
   , itemToObject
   , debounceTime: Nothing
   , async: Nothing
+  , disabled: TA.isDisabled props
   , render: TA.renderSingle
       props
       (renderFuzzy <<< match false itemToObject "")
@@ -65,6 +66,7 @@ syncMulti { itemToObject, renderFuzzy } props =
   , itemToObject
   , debounceTime: Nothing
   , async: Nothing
+  , disabled: TA.isDisabled props
   , render: TA.renderMulti
       props
       (renderFuzzy <<< match false itemToObject "")
@@ -94,6 +96,7 @@ asyncSingle { async, itemToObject, renderFuzzy } props =
   , itemToObject
   , debounceTime: Just $ Milliseconds 300.0
   , async: Just async
+  , disabled: TA.isDisabled props
   , render: TA.renderSingle
       props
       (renderFuzzy <<< match false itemToObject "")
@@ -114,6 +117,7 @@ asyncMulti { async, itemToObject, renderFuzzy } props =
   , itemToObject
   , debounceTime: Just $ Milliseconds 300.0
   , async: Just async
+  , disabled: TA.isDisabled props
   , render: TA.renderMulti
       props
       (renderFuzzy <<< match false itemToObject "")

--- a/src/Components/Typeahead/Render.purs
+++ b/src/Components/Typeahead/Render.purs
@@ -80,7 +80,7 @@ renderSingle iprops renderItem renderContainer st =
 
   where
 
-  disabled = isDisabled iprops
+  disabled = st.disabled
   showSelected = isJust st.selected && st.visibility == S.Off
 
 
@@ -132,7 +132,7 @@ renderMulti iprops renderItem renderContainer st =
 
   where
 
-  disabled = isDisabled iprops
+  disabled = st.disabled
 
 
 ----------
@@ -245,7 +245,7 @@ inputProps disabled iprops = if disabled
   then iprops'
   else Setters.setInputProps iprops'
   where
-    iprops' = [ HP.autocomplete false, css "focus:next:text-blue-88" ] <&> iprops
+    iprops' = [ HP.disabled disabled, HP.autocomplete false, css "focus:next:text-blue-88" ] <&> iprops
 
 
 disabledClasses :: Array HH.ClassName

--- a/src/Interfaces/Typeahead/Interface.purs
+++ b/src/Interfaces/Typeahead/Interface.purs
@@ -118,6 +118,7 @@ typeaheadInputToSingleInput r =
   , itemToObject: \a -> Object.singleton r.key (unsafePartial (fromJust (Object.lookup r.key a)))
   , debounceTime: if r.debounceTime > 0 then Just (Milliseconds (toNumber r.debounceTime)) else Nothing
   , async: Nothing
+  , disabled: false
   , render: renderSingle
       [ HP.placeholder r.placeholder ]
       (renderFuzzy <<< match false identity "")
@@ -139,6 +140,7 @@ typeaheadInputToMultiInput r =
   , itemToObject: \a -> Object.singleton r.key (unsafePartial (fromJust (Object.lookup r.key a)))
   , debounceTime: if r.debounceTime > 0 then Just (Milliseconds (toNumber r.debounceTime)) else Nothing
   , async: Nothing
+  , disabled: false
   , render: renderMulti
       [ HP.placeholder r.placeholder ]
       (renderFuzzy <<< match false identity "")
@@ -160,6 +162,7 @@ dropdownInputToSingleInput r =
   , itemToObject: \a -> Object.singleton r.key (unsafePartial (fromJust (Object.lookup r.key a)))
   , debounceTime: Nothing
   , async: Nothing
+  , disabled: false
   , render
   }
   where
@@ -270,6 +273,7 @@ searchDropdownInputToHeaderSingleInput r =
   , itemToObject: \a -> Object.singleton r.key (unsafePartial (fromJust (Object.lookup r.key a)))
   , debounceTime: Nothing
   , async: Nothing
+  , disabled: false
   , render: renderHeaderSearchDropdown
       r.placeholder
       r.resetLabel
@@ -294,6 +298,7 @@ searchDropdownInputToToolbarSingleInput r =
   , itemToObject: \a -> Object.singleton r.key (unsafePartial (fromJust (Object.lookup r.key a)))
   , debounceTime: Nothing
   , async: Nothing
+  , disabled: false
   , render: renderToolbarSearchDropdown
       r.placeholder
       r.resetLabel

--- a/ui-guide/Components/Typeaheads.purs
+++ b/ui-guide/Components/Typeaheads.purs
@@ -555,6 +555,7 @@ cnDocumentationBlocks =
                 , debounceTime: Nothing
                 , async: Nothing
                 , itemToObject: Async.locationToObject
+                , disabled: false
                 , render: TARender.renderHeaderSearchDropdown
                   "All Locations"
                   "All Locations"
@@ -584,6 +585,7 @@ cnDocumentationBlocks =
               , debounceTime: Nothing
               , async: Nothing
               , itemToObject: Async.locationToObject
+              , disabled: false
               , render: TARender.renderToolbarSearchDropdown
                 "All Locations"
                 "All Locations"


### PR DESCRIPTION
## What does this pull request do?

Typeaheads were only allowing statically setting the `disabled` property. We need them to allow setting the property dynamically (when state changes). We added a query to allow setting that property.

## Where should the reviewer start?

* Paired with @davezuch.