### PR TITLE
fix SWAPI urls in UIGuide

### DIFF
--- a/ui-guide/Utilities/Async.purs
+++ b/ui-guide/Utilities/Async.purs
@@ -45,14 +45,14 @@ type Err = String
 
 users :: Source User
 users = Source
-  { path: "https://swapi.co/api/people/?search="
+  { path: "https://swapi.dev/api/people/?search="
   , speed: Fast
   , decoder: decodeWith decodeUser
   }
 
 locations :: Source Location
 locations = Source
-  { path: "https://swapi.co/api/planets/?search="
+  { path: "https://swapi.dev/api/planets/?search="
   , speed: Fast
   , decoder: decodeWith decodeLocation
   }


### PR DESCRIPTION
## What does this pull request do?

The `#typeaheads` of `UIGuide` is broken ever since SWAPI changes its domain from `.co` to `.dev`.

## How should this be manually tested?

- [ ] `yarn build-ui`
- [ ] open `dist/index.html#typeaheads`
  - see if examples load up properly