### PR TITLE
Bugfix: open selection panel when clicking on the selected or Change button

### DIFF
--- a/src/Components/Typeahead/Render.purs
+++ b/src/Components/Typeahead/Render.purs
@@ -51,13 +51,16 @@ renderSingle iprops renderItem renderContainer st =
             maybe (HH.text "")
             ( \selected -> HH.div
               [ HP.classes Input.mainLeftClasses ]
-              [ IC.selectionGroup renderItem []
+              [ IC.selectionGroup renderItem
+                [ HE.onClick $ Just <<< S.ToggleClick ]
                 [ HE.onClick $ const <<< Just <<< S.Action $ TA.Remove selected ]
                 selected
               ])
             st.selected
       , Input.borderRight
-        [ HP.classes $ linkClasses disabled ]
+        [ HP.classes $ linkClasses disabled
+        , HE.onClick $ Just <<< S.ToggleClick
+        ]
         [ HH.text "Change" ]
       ]
     , Input.inputGroup


### PR DESCRIPTION
## What does this pull request do?

This is the expected behavior in older versions (like v0.18) but lost after migrating to v5.

## How should this be manually tested?

- [x] `yarn build-ui`
- [x] open `dist/index.html#typeaheads`
- use the example at the bottom right of the first section (`Typeaheads - Single-Select`) where a user has been selected
  - [x] click on the selected user
    - the selection panel should show up
  - [x] click out of the component
    - the old selection should be kept
  - [x] click on the `Change` button
    - the selection panel should show up
  - [x] click out of the component
    - the old selection should be kept
