### PR TITLE
Raise SelectionChanged whenever Date/Time selection is updated

### DIFF
--- a/src/Components/DatePicker/Component.purs
+++ b/src/Components/DatePicker/Component.purs
@@ -234,6 +234,7 @@ setSelection selection = do
   st <- H.get
   let targetDate = maybe st.targetDate (\d -> (year d) /\ (month d)) selection
   H.modify_ _ { selection = selection, targetDate = targetDate }
+  H.raise $ SelectionChanged selection
   synchronize
 
 --------------------------

--- a/src/Components/TimePicker/Component.purs
+++ b/src/Components/TimePicker/Component.purs
@@ -338,4 +338,5 @@ synchronize = do
 setSelection :: forall m. Maybe Time -> CompositeComponentM m Unit
 setSelection selection = do
   H.modify_ _ { selection = selection }
+  H.raise $ SelectionChanged selection
   synchronize


### PR DESCRIPTION
## What does this pull request do?

Before, we only raise `SelectionChanged` when a date/time is selected through the calendar but not through text input which is inconsistent and makes text input less useful. Now we raise `SelectionChanged` whenever `selection` in the `State` is modified.

