### PR TITLE
Trigger Date/Time search on blur

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-ocelot",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "private": true,
   "scripts": {
     "build-all": "yarn run build-ui && yarn run build-css",

--- a/src/Components/DatePicker/Component.purs
+++ b/src/Components/DatePicker/Component.purs
@@ -68,6 +68,7 @@ data Action
 data EmbeddedAction
   = Initialize
   | Key KeyboardEvent
+  | OnBlur
   | ToggleMonth Direction
   | ToggleYear  Direction
 
@@ -276,6 +277,9 @@ embeddedHandleAction = case _ of
         H.modify_ _ { visibility = S.Off }
       otherwise -> pure unit
 
+  OnBlur -> do
+    handleSearch
+
   ToggleYear dir -> do
     st <- H.get
     let y = fst st.targetDate
@@ -360,7 +364,8 @@ renderSearch :: forall m. String -> CompositeComponentHTML m
 renderSearch search =
   Input.input
   $ SS.setInputProps
-    [ HE.onKeyDown $ Just <<< S.Action <<< Key
+    [ HE.onBlur \_ -> Just (S.Action OnBlur)
+    , HE.onKeyDown $ Just <<< S.Action <<< Key
     , HP.value search
     ]
 

--- a/src/Components/DatePicker/Component.purs
+++ b/src/Components/DatePicker/Component.purs
@@ -270,16 +270,7 @@ embeddedHandleAction = case _ of
     case KE.code ev of
       "Enter" -> do
         preventIt
-        search <- H.gets _.search
-        today <- H.liftEffect nowDate
-        _ <- case search of
-          "" -> setSelection Nothing
-          _  -> case Utils.guessDate today (Utils.MaxYears 5) search of
-            Nothing -> pure unit
-            Just d  -> do
-              setSelection (Just d)
-        H.modify_ _ { visibility = S.Off }
-        H.raise $ Searched search
+        handleSearch
       "Escape" -> do
         preventIt
         H.modify_ _ { visibility = S.Off }
@@ -294,6 +285,19 @@ embeddedHandleAction = case _ of
             Prev -> ODT.prevYear (canonicalDate y m bottom)
     H.modify_ _ { targetDate = Tuple (year newDate) (month newDate) }
     synchronize
+
+handleSearch :: forall m. MonadAff m => CompositeComponentM m Unit
+handleSearch = do
+  search <- H.gets _.search
+  today <- H.liftEffect nowDate
+  _ <- case search of
+    "" -> setSelection Nothing
+    _  -> case Utils.guessDate today (Utils.MaxYears 5) search of
+      Nothing -> pure unit
+      Just d  -> do
+        setSelection (Just d)
+  H.modify_ _ { visibility = S.Off }
+  H.raise $ Searched search
 
 -------------------------
 -- Embedded > handleQuery

--- a/src/Components/TimePicker/Component.purs
+++ b/src/Components/TimePicker/Component.purs
@@ -53,6 +53,7 @@ data Action
 data EmbeddedAction
   = Initialize
   | Key KeyboardEvent
+  | OnBlur
 
 data Query a
   = GetSelection (Time -> a)
@@ -178,6 +179,9 @@ embeddedHandleAction = case _ of
         H.modify_ _ { visibility = S.Off }
       otherwise -> pure unit
 
+  OnBlur -> do
+    handleSearch
+
 handleSearch :: forall m. MonadAff m => CompositeComponentM m Unit
 handleSearch = do
   search <- H.gets _.search
@@ -238,7 +242,8 @@ renderSearch :: forall m. String -> CompositeComponentHTML m
 renderSearch search =
   Input.input
     ( Setters.setInputProps
-      [ HE.onKeyDown $ Just <<< S.Action <<< Key
+      [ HE.onBlur \_ -> Just (S.Action OnBlur)
+      , HE.onKeyDown $ Just <<< S.Action <<< Key
       , HP.value search
       ]
     )

--- a/src/Components/TimePicker/Component.purs
+++ b/src/Components/TimePicker/Component.purs
@@ -52,7 +52,6 @@ data Action
 
 data EmbeddedAction
   = Initialize
-  | Search String
   | Key KeyboardEvent
 
 data Query a
@@ -167,28 +166,29 @@ embeddedHandleAction = case _ of
   Initialize -> do
     synchronize
 
-  Search text -> do
-    case text of
-      "" -> setSelection Nothing
-      _  -> case Utils.guessTime text of
-        Nothing -> pure unit
-        Just t  -> do
-          setSelection (Just t)
-          H.modify_ _ { visibility = S.Off }
-    H.raise $ Searched text
-
   Key ev -> do
     H.modify_ _ { visibility = S.Off }
     let preventIt = H.liftEffect $ preventDefault $ KE.toEvent ev
     case KE.code ev of
       "Enter"   -> do
         preventIt
-        { search } <- H.get
-        embeddedHandleAction $ Search search
+        handleSearch
       "Escape" -> do
         preventIt
         H.modify_ _ { visibility = S.Off }
       otherwise -> pure unit
+
+handleSearch :: forall m. MonadAff m => CompositeComponentM m Unit
+handleSearch = do
+  search <- H.gets _.search
+  case search of
+    "" -> setSelection Nothing
+    _  -> case Utils.guessTime search of
+      Nothing -> pure unit
+      Just t  -> do
+        setSelection (Just t)
+        H.modify_ _ { visibility = S.Off }
+  H.raise $ Searched search
 
 embeddedHandleMessage
   :: forall m


### PR DESCRIPTION
## What does this pull request do?

We postpone parsing and selecting date/time through text input until user presses Enter for confirmation which is reasonable. But this might lead to inconsistent presentation of state between the input field and the calendar.
For example, when user clears the input field and unfocuses it, the selection is expected to be cleared as well, but given current implementation the previous selection persists.

To fix this issue, we force a search when the input field is unfocused just like pressing Enter.

## How should this be manually tested?

- [ ] `yarn build-ui`
- [ ] open `dist/index.html`, and go to Date Pickers page (`#date-pickers`) > DateTime Pickers section
- [ ] click on the input field of a Date Picker, type in `2021,1,31` and then click outside
  - the selection should be `Sun, Jan 31 2021`
- [ ] click on the input field of a Time Picker, type in `13`, and then click outside
  - the selection should be `1:00 PM`