### PR TITLE
AS-991 Show clear button when search bar is configured to keep open

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-ocelot",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "private": true,
   "scripts": {
     "build-all": "yarn run build-ui && yarn run build-css",

--- a/src/Components/SearchBar.purs
+++ b/src/Components/SearchBar.purs
@@ -5,6 +5,7 @@ import Prelude
 import Control.Monad.State (class MonadState)
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.String (null)
+import Data.String as Data.String
 import Data.Time.Duration (Milliseconds(..))
 import Effect.Aff (Fiber, delay, forkAff, killFiber)
 import Effect.Aff.AVar (AVar)
@@ -189,7 +190,7 @@ render st@{ query, open } =
     , HH.button
       [ HE.onClick $ Just <<< Clear
       , HP.type_ HP.ButtonButton
-      , HP.classes $ buttonClasses <> buttonCondClasses <> keepOpenClasses
+      , HP.classes $ buttonClasses <> buttonCondClasses <> hideClearClasses
       ]
       [ Icon.delete_ ]
     ]
@@ -247,8 +248,8 @@ render st@{ query, open } =
          [ "opacity-100", "visible" ]
          [ "opacity-0", "invisible" ]
 
-     keepOpenClasses = HH.ClassName <$>
-       if st.keepOpen then ["hidden"] else []
+     hideClearClasses = HH.ClassName <$>
+       if Data.String.null st.query then ["hidden"] else []
 
      ifOpen openClasses closedClasses =
        HH.ClassName <$> if open then openClasses else closedClasses

--- a/ui-guide/Components/TextFields.purs
+++ b/ui-guide/Components/TextFields.purs
@@ -422,12 +422,34 @@ cnDocumentationBlocks =
     , subheader: "A component for handling searching"
     }
     [ Backdrop.backdrop_
-      [ Backdrop.content_
-        [ HH.div
-          [ css "w-1/3 pb-6" ]
-          [ HH.slot _search unit SearchBar.component
-            { debounceTime: Just (Milliseconds 250.0) }
-            ( Just <<< HandleSearch )
+      [ content
+        [ Card.card
+          [ HP.class_ $ HH.ClassName "flex-1" ]
+          [ HH.h3
+            [ HP.classes Format.captionClasses ]
+            [ HH.text "Standard" ]
+          , HH.div
+            [ css "w-50" ]
+            [ HH.slot _search unit SearchBar.component
+              { debounceTime: Just (Milliseconds 250.0) }
+              ( Just <<< HandleSearch )
+            ]
+          ]
+        ]
+      , content
+        [ Card.card
+          [ HP.class_ $ HH.ClassName "flex-1" ]
+          [ HH.h3
+            [ HP.classes Format.captionClasses ]
+            [ HH.text "Keep Open" ]
+          , HH.div
+            [ css "w-50" ]
+            [ HH.slot _search unit SearchBar.component'
+              { debounceTime: Just (Milliseconds 250.0)
+              , keepOpen: true
+              }
+              ( Just <<< HandleSearch )
+            ]
           ]
         ]
       ]


### PR DESCRIPTION
## What does this pull request do?

When a search bar is configured to keep open, we still want to show the clear button unless the query string is empty.

## How should this be manually tested?

- [ ] `yarn build-ui`
- [ ] open `dist/index.html`, and go to Text Fields page (`#textfields`) > Search Bar section > Keep Open sub-section
- [ ] type something in the search field
  - you should see the clear (`x`) button
- [ ] click on the clear button
  - the query string should be cleared and the search bar should stay open