### PR TITLE
Fix gh-pages index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   </head>
 
   <body>
-    <script src="dist/example.js"></script>
+    <script src="dist/index.js"></script>
   </body>
 
 </html>


### PR DESCRIPTION
## What does this pull request do?

As `kejace` reported in issue #140, our document page is down.

Looks like the actual issue is that `example.js` is no longer a build artifact in `dist/` folder so updating `index.html`on branch `gh-pages` should fix this (hopefully).