### PR TITLE
AS-1029 Add Percentage Bar Graph block

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-ocelot",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "private": true,
   "scripts": {
     "build-all": "yarn run build-ui && yarn run build-css",

--- a/src/Blocks/Diagram.purs
+++ b/src/Blocks/Diagram.purs
@@ -1,0 +1,61 @@
+module Ocelot.Block.Diagram where
+
+import Prelude
+import DOM.HTML.Indexed (HTMLdiv, HTMLspan)
+import Halogen.HTML as Halogen.HTML
+import Halogen.HTML.Properties as Halogen.HTML.Properties
+import Ocelot.HTML.Properties ((<&>))
+
+percentBarContainerClasses :: Array Halogen.HTML.ClassName
+percentBarContainerClasses =
+  [ "inline-block"
+  , "relative"
+  ]
+    <#> Halogen.HTML.ClassName
+
+percentBarBackClasses :: Array Halogen.HTML.ClassName
+percentBarBackClasses =
+  [ "absolute"
+  , "bg-grey-80"
+  , "h-full"
+  , "w-full"
+  , "z-10"
+  ]
+    <#> Halogen.HTML.ClassName
+
+percentBarFrontClasses :: Array Halogen.HTML.ClassName
+percentBarFrontClasses =
+  [ "absolute"
+  , "h-full"
+  , "z-20"
+  ]
+    <#> Halogen.HTML.ClassName
+
+percentBar ::
+  forall p i.
+  Number ->
+  Array (Halogen.HTML.IProp HTMLdiv i) ->
+  Array (Halogen.HTML.IProp HTMLspan i) ->
+  Halogen.HTML.HTML p i
+percentBar percent containerProps frontProps =
+  Halogen.HTML.div
+    ( [ Halogen.HTML.Properties.classes percentBarContainerClasses ]
+        <&> containerProps
+    )
+    [ Halogen.HTML.span
+        [ Halogen.HTML.Properties.classes percentBarBackClasses ]
+        []
+    , Halogen.HTML.span
+        ( [ Halogen.HTML.Properties.attr (Halogen.HTML.AttrName "style") css
+          , Halogen.HTML.Properties.classes percentBarFrontClasses
+          ]
+            <&> frontProps
+        )
+        []
+    ]
+  where
+  css :: String
+  css = "width: " <> show width <> "%"
+
+  width :: Number
+  width = clamp 0.0 100.0 percent

--- a/ui-guide/App/Routes.purs
+++ b/ui-guide/App/Routes.purs
@@ -3,17 +3,18 @@ module UIGuide.App.Routes
 where
 
 import Prelude
-
-import Effect.Aff (Aff)
 import Data.Const (Const)
 import Data.Map (Map, fromFoldable)
 import Data.Tuple (Tuple(..))
+import Effect.Aff (Aff)
 import Halogen as H
 import Halogen.HTML as HH
 import UIGuide.App (Group(..), proxy)
 import UIGuide.Component.Badge as Badge
 import UIGuide.Component.Button as Button
 import UIGuide.Component.DatePickers as DatePickers
+import UIGuide.Component.Diagram as Diagram
+import UIGuide.Component.Dialogs as Dialogs
 import UIGuide.Component.Dropdown as Dropdown
 import UIGuide.Component.ExpansionCards as ExpansionCards
 import UIGuide.Component.FormControl as FormControl
@@ -23,7 +24,6 @@ import UIGuide.Component.MultiInput as MultiInput
 import UIGuide.Component.Table as Table
 import UIGuide.Component.TextFields as TextFields
 import UIGuide.Component.Tray as Tray
-import UIGuide.Component.Dialogs as Dialogs
 import UIGuide.Component.Type as Type
 import UIGuide.Component.Typeaheads as Typeaheads
 
@@ -123,5 +123,10 @@ routes = fromFoldable
     { anchor: "Multi Input"
     , component: proxy MultiInput.component
     , group: Components
+    }
+  , Tuple "diagram"
+    { anchor: "Diagram"
+    , component: proxy Diagram.component
+    , group: Basics
     }
   ]

--- a/ui-guide/Components/Diagram.purs
+++ b/ui-guide/Components/Diagram.purs
@@ -1,0 +1,87 @@
+module UIGuide.Component.Diagram where
+
+import Prelude
+
+import Halogen as Halogen
+import Halogen.HTML as Halogen.HTML
+import Ocelot.Block.Card as Card
+import Ocelot.Block.Diagram as Ocelot.Block.Diagram
+import Ocelot.HTML.Properties as Ocelot.HTML.Properties
+import UIGuide.Block.Backdrop as Backdrop
+import UIGuide.Block.Documentation as Documentation
+
+type Component m = Halogen.Component Halogen.HTML.HTML Query Input Output m
+
+type ComponentHTML m = Halogen.ComponentHTML Action ChildSlots m
+
+type ComponentM m a = Halogen.HalogenM State Action ChildSlots Output m a
+
+type State = Unit
+
+data Query a
+
+type Action = Unit
+
+type Input = Unit
+
+type Output = Void
+
+type ChildSlots =
+  ()
+
+----------
+-- HTML
+
+component :: forall m. Component m
+component =
+  Halogen.mkComponent
+    { initialState: const unit
+    , render
+    , eval: Halogen.mkEval Halogen.defaultEval
+    }
+
+render :: forall m. State -> ComponentHTML m
+render _ =
+  Halogen.HTML.div_
+  [ Documentation.block_
+    { header: "Percentage Bar Graph"
+    , subheader: "Visualize a number in percentage"
+    }
+    [ Backdrop.backdrop_
+      [ Backdrop.content_
+        [ Card.card_
+          [ Halogen.HTML.p
+            [ Ocelot.HTML.Properties.css "flex items-center" ]
+            [ Halogen.HTML.span
+              [ Ocelot.HTML.Properties.css "min-w-5"]
+              [ Halogen.HTML.text "A:" ]
+            , Ocelot.Block.Diagram.percentBar percentA
+              [ Ocelot.HTML.Properties.css "h-4 pl-2 w-1/3" ]
+              [ Ocelot.HTML.Properties.css "bg-red"]
+            , Halogen.HTML.span
+              [ Ocelot.HTML.Properties.css "ml-4 text-red" ]
+              [ Halogen.HTML.text (show percentA <> "%")]
+            ]
+          , Halogen.HTML.p
+            [ Ocelot.HTML.Properties.css "flex items-center" ]
+            [ Halogen.HTML.span
+              [ Ocelot.HTML.Properties.css "min-w-5"]
+              [ Halogen.HTML.text "B:" ]
+            , Ocelot.Block.Diagram.percentBar percentB
+              [ Ocelot.HTML.Properties.css "h-4 pl-2 w-1/3" ]
+              [ Ocelot.HTML.Properties.css "bg-blue-82"]
+            , Halogen.HTML.span
+              [ Ocelot.HTML.Properties.css "ml-4 text-blue-82" ]
+              [ Halogen.HTML.text (show percentB <> "%")]
+            ]
+          ]
+        ]
+      ]
+    ]
+  ]
+  where
+  percentA :: Number
+  percentA = 30.0
+
+  percentB :: Number
+  percentB = 100.0


### PR DESCRIPTION
## What does this pull request do?

Add `Ocelot.Block.Diagram.percentBar` for visualizing number in percentage.

## How should this be manually tested?

- [x] `yarn build-ui`
- [x] go to `dist/index.html#diagram` and see if the percentage bar graphs display correctly

<img src="https://user-images.githubusercontent.com/18127498/106683887-5b391e80-6593-11eb-893c-4cb1f8e2d13f.png" width=300px />
