### PR TITLE
AS-1073 Bugfix: Toast is blocked by Modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-ocelot",
-  "version": "0.25.4",
+  "version": "0.25.5",
   "private": true,
   "scripts": {
     "build-all": "yarn run build-ui && yarn run build-css",

--- a/src/Blocks/Toast.purs
+++ b/src/Blocks/Toast.purs
@@ -31,6 +31,7 @@ toastContainerClasses = HH.ClassName <$>
   , "pin-l"
   , "pin-r"
   , "pin-b"
+  , "z-10"
   ]
 
 containerVisibleClasses :: Array HH.ClassName


### PR DESCRIPTION
## What does this pull request do?

When a Toast is raised with a Modal open, it's barely visible behind the dark background of Modal. We fix this issue by lifting Toast to the same `z-index` as Modal.

## How should this be manually tested?

- [ ] `yarn build-ui`
- [ ] go to `dist/index.html#modals`
- [ ] click on `Open Modal` and then `Submit`
  - you should see an error toast which is not blocked by the dark background