### PR TITLE
AS-1091 Add pager with new design

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-ocelot",
-  "version": "0.25.5",
+  "version": "0.25.6",
   "private": true,
   "scripts": {
     "build-all": "yarn run build-ui && yarn run build-css",

--- a/src/Blocks/Pager.purs
+++ b/src/Blocks/Pager.purs
@@ -2,18 +2,21 @@ module Ocelot.Block.Pager where
 
 import Prelude
 
-import Web.UIEvent.MouseEvent (MouseEvent)
+import DOM.HTML.Indexed (HTMLdiv)
 import Data.Array ((..))
 import Data.FoldableWithIndex (foldlWithIndex)
 import Data.Maybe (Maybe)
+import Foreign.Object as Foreign.Object
 import Halogen.HTML as HH
 import Halogen.HTML.Core (ClassName(..))
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
-
+import Ocelot.Block.Icon as Ocelot.Block.Icon
+import Ocelot.HTML.Properties as Ocelot.HTML.Properties
+import Web.UIEvent.MouseEvent (MouseEvent)
 
 -----
--- A block for handling paging in list components
+-- old CN pager (require citizennet.css)
 
 pager :: ∀ p i. Int -> Int -> (Int -> MouseEvent -> Maybe i) -> HH.HTML p i
 pager skip last query =
@@ -90,3 +93,96 @@ pager skip last query =
           [ HH.text "…"
           ]
         ]
+
+-----
+-- A block for handling paging in list components
+
+pagerNew ::
+  forall p i.
+  Int ->
+  Int ->
+  Array (HP.IProp HTMLdiv i) ->
+  (Int -> MouseEvent -> Maybe i) ->
+  HH.HTML p i
+pagerNew skip last iprops query = HH.div iprops (makePagingButtonsNew skip last query)
+
+makePagingButtonsNew ::
+  forall p i.
+  Int ->
+  Int ->
+  (Int -> MouseEvent -> Maybe i) ->
+  Array (HH.HTML p i)
+makePagingButtonsNew skip last query = foldlWithIndex makePagingButtons' [] makeList
+  where
+  makeList :: Array Int
+  makeList | last < 2 = []
+  makeList | last <= 6 = 1 .. last
+  makeList | skip < 5 = 1 .. 6 <> [last]
+  makeList | skip > (last - 4) = [1] <> (last - 5) .. last
+  makeList = [1] <> (skip - 2) .. (skip + 2) <> [last]
+
+  makePagingButtons' :: Int -> Array (HH.HTML p i) -> Int -> Array (HH.HTML p i)
+  makePagingButtons' 0 btns btn =
+    (if skip == 1 then [] else [backArrow]) <> [button btn]
+  makePagingButtons' 1 btns btn | btn /= 2 =
+    btns <> [ellipsis] <> [button btn]
+  makePagingButtons' idx btns btn | btn == last && last < 7 && skip /= last =
+    btns <> [button btn] <> [forwardArrow]
+  makePagingButtons' idx btns btn | btn == last && last < 7 =
+    btns <> [button btn]
+  makePagingButtons' idx btns btn | btn == last && skip < (last - 3) =
+    btns <> [ellipsis] <> [button btn] <> [forwardArrow]
+  makePagingButtons' idx btns btn | btn == last =
+    btns <> [button btn] <> (if skip == last then [] else [forwardArrow])
+  makePagingButtons' _ btns btn =
+    btns <> [button btn]
+
+  arrow :: Int -> HH.HTML p i -> HH.HTML p i
+  arrow skip' label =
+    HH.a
+    [ HE.onMouseDown $ query skip'
+    , Ocelot.HTML.Properties.css "mx-4"
+    , Ocelot.HTML.Properties.style <<< Foreign.Object.fromHomogeneous
+      $ { "line-height": "2.5rem"
+        }
+    ]
+    [ label ]
+
+  backArrow :: HH.HTML p i
+  backArrow = arrow (skip - 1) (Ocelot.Block.Icon.chevronLeft [ Ocelot.HTML.Properties.css "hover:text-grey"])
+
+  forwardArrow :: HH.HTML p i
+  forwardArrow = arrow (skip + 1) (Ocelot.Block.Icon.chevronRight [ Ocelot.HTML.Properties.css "hover:text-grey"])
+
+  button :: Int -> HH.HTML p i
+  button btn =
+    HH.a
+    (if btn == skip then disabled else active)
+    [ HH.span_
+      [ HH.text $ show btn ]
+    ]
+    where
+    disabled =
+      [ Ocelot.HTML.Properties.css "border border-black disabled inline-block text-center"
+      , Ocelot.HTML.Properties.style <<< Foreign.Object.fromHomogeneous
+        $ { "border-radius": "50%"
+          , "width": "2.5rem"
+          , "line-height": "2.5rem"
+          }
+      ]
+
+    active =
+      [ Ocelot.HTML.Properties.css "inline-block hover:bg-grey hover:text-white text-center"
+      , Ocelot.HTML.Properties.style <<< Foreign.Object.fromHomogeneous
+        $ { "border-radius": "50%"
+          , "width": "2.5rem"
+          , "line-height": "2.5rem"
+          }
+      , HE.onMouseDown $ query btn
+      ]
+
+  ellipsis :: HH.HTML p i
+  ellipsis =
+    HH.span
+    [ Ocelot.HTML.Properties.css "mx-2"]
+    [ HH.text "…" ]

--- a/ui-guide/Components/Table.purs
+++ b/ui-guide/Components/Table.purs
@@ -71,7 +71,7 @@ render { page } =
       [ HH.div_
         [ renderTable
         , Ocelot.Block.Pager.pagerNew page 100
-          [ css "flex justify-end mt-2"]
+          [ css "flex justify-end mt-6"]
           (\index event -> Just (Page index event))
         ]
       ]


### PR DESCRIPTION
## What does this pull request do?

Add a pager block with new design.

## How should this be manually tested?

- [x] `yarn build-ui`
- [x] go to `dist/index.html#tables`
  - you should see the pager at the bottom of the table
- [x] click on a page (number)
  - that page should be selected (the content of the table won't change)
- [x] click on left/right arrow
  - previous/next page should be selected

## Other Notes:

Looks like the old pager relies on `citizennet.css` for class names `cn-pagination` and `pagination` to style properly. Basically the following rules

```css
.cn-pagination {
 margin:20px auto;
 text-align:right;
 max-width:1220px
}
.cn-pagination .pagination {
 margin:0 0 0 20px;
 vertical-align:middle
}
.cn-pagination .pagination>li>a,
.cn-pagination .pagination>li>span {
 border-radius:2px;
 background:0 0;
 border:none
}
.cn-pagination .pagination>li>a {
 color:#3ba0cc
}
.cn-pagination .pagination>li>a:hover {
 color:#fff;
 background-color:#d4d4d4
}
.cn-pagination .pagination>li.active>a {
 color:#3f4041;
 background-color:#d4d4d4
}
```

Should we remove the old pager or add those rules to css in ocelot? If latter, how?