### PR TITLE
AS-1091 Minor style tweaks to the new pager

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-ocelot",
-  "version": "0.25.6",
+  "version": "0.25.7",
   "private": true,
   "scripts": {
     "build-all": "yarn run build-ui && yarn run build-css",

--- a/src/Blocks/Pager.purs
+++ b/src/Blocks/Pager.purs
@@ -139,7 +139,7 @@ makePagingButtonsNew skip last query = foldlWithIndex makePagingButtons' [] make
 
   arrow :: Int -> HH.HTML p i -> HH.HTML p i
   arrow skip' label =
-    HH.a
+    HH.button
     [ HE.onMouseDown $ query skip'
     , Ocelot.HTML.Properties.css "mx-4"
     , Ocelot.HTML.Properties.style <<< Foreign.Object.fromHomogeneous
@@ -156,7 +156,7 @@ makePagingButtonsNew skip last query = foldlWithIndex makePagingButtons' [] make
 
   button :: Int -> HH.HTML p i
   button btn =
-    HH.a
+    HH.button
     (if btn == skip then disabled else active)
     [ HH.span_
       [ HH.text $ show btn ]

--- a/src/Blocks/Pager.purs
+++ b/src/Blocks/Pager.purs
@@ -163,7 +163,7 @@ makePagingButtonsNew skip last query = foldlWithIndex makePagingButtons' [] make
     ]
     where
     disabled =
-      [ Ocelot.HTML.Properties.css "border border-black disabled inline-block text-center"
+      [ Ocelot.HTML.Properties.css "border border-black disabled focus:outline-none inline-block text-center"
       , Ocelot.HTML.Properties.style <<< Foreign.Object.fromHomogeneous
         $ { "border-radius": "50%"
           , "width": "2.5rem"


### PR DESCRIPTION
## What does this pull request do?

Should've tested this with `citizennet.css` before merging #149  but there's two minor changes we need to make to the new pager
- use `button` instead of `a` to avoid global style rules on `a`
- remove outline of `button` in `focus` state
