### PR TITLE
FBCM-4107 Configurable filtering for Typeahead search results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,10 @@ jobs:
             - v1-spago-cache
 
       - run:
+          name: Verify the tests pass
+          command: make test
+
+      - run:
           name: Verify the project and all components build successfully
           command: make build
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ OUTPUT_DIR ?= $(ROOT_DIR)/output
 PARCEL_DIR ?= $(BUILD_DIR)/parcel
 RTS_ARGS ?=
 SRC_DIR ?= $(ROOT_DIR)/src
+TEST_DIR ?= $(ROOT_DIR)/test
 UI_GUIDE_DIR ?= $(ROOT_DIR)/ui-guide
 
 # Variables that we control
@@ -16,6 +17,7 @@ FIND_SRC_FILES_ARGS := \( -name '*.purs' -o -name '*.js' \) -type f
 NODE_MODULES := $(ROOT_DIR)/node_modules/.stamp
 PACKAGE_JSON := $(ROOT_DIR)/package.json
 SRC_FILES := $(shell find $(SRC_DIR) $(FIND_SRC_FILES_ARGS))
+TEST_FILES := $(shell find $(TEST_DIR) $(FIND_SRC_FILES_ARGS))
 UI_GUIDE_FILES := $(shell find $(UI_GUIDE_DIR) $(FIND_SRC_FILES_ARGS))
 YARN_LOCK := $(ROOT_DIR)/yarn.lock
 
@@ -28,16 +30,29 @@ YARN := cd $(ROOT_DIR) && yarn
 $(BUILD_DIR) $(DIST_DIR) $(PARCEL_DIR):
 	mkdir -p $@
 
+$(BUILD_DIR)/test.js: $(OUTPUT_DIR)/Test.Main/index.js | $(BUILD_DIR)
+	$(YARN) run purs bundle \
+		$(RTS_ARGS) \
+		$(OUTPUT_DIR)/*/*.js \
+		--main Test.Main \
+		--module Test.Main \
+		--output $@
+
+$(BUILD_DIR)/test.out: $(BUILD_DIR)/test.js
+	node $< | tee $@.tmp # Store output in a temp file in case of a failure.
+	mv $@.tmp $@ # Move the output where it belongs.
+
 $(DEPS): packages.dhall spago.dhall $(NODE_MODULES) | $(BUILD_DIR)
 	$(YARN) run spago install $(RTS_ARGS)
 	touch $@
 
 $(DIST_DIR)/bundled.js: $(OUTPUT_DIR)/Main/index.js
-	$(YARN) run purs bundle $(OUTPUT_DIR)/*/*.js \
+	$(YARN) run purs bundle \
+		$(RTS_ARGS) \
+		$(OUTPUT_DIR)/*/*.js \
 		--main Main \
 		--module Main \
-		--output $@ \
-		$(RTS_ARGS)
+		--output $@
 
 $(DIST_DIR)/index.js: $(OUTPUT_DIR)/Main/index.js
 	$(YARN) run browserify dist/main.js --outfile $@
@@ -48,6 +63,9 @@ $(NODE_MODULES): $(PACKAGE_JSON) $(YARN_LOCK)
 
 $(OUTPUT_DIR)/Main/index.js: $(SRC_FILES) $(UI_GUIDE_FILES) $(DEPS)
 	$(YARN) run spago build -p "$(UI_GUIDE_DIR)/**/*.purs" -u "$(RTS_ARGS)"
+
+$(OUTPUT_DIR)/Test.Main/index.js: $(SRC_FILES) $(TEST_FILES) $(DEPS)
+	$(YARN) run spago build -p "$(TEST_DIR)/Main.purs $(TEST_DIR)/Test/**/*.purs" -u "$(RTS_ARGS)"
 
 .PHONY: build
 build: $(BUILD_DEPS)
@@ -64,6 +82,9 @@ clean: $(CLEAN_DEPS)
 		$(OUTPUT_DIR) \
 		$(ROOT_DIR)/.spago \
 		$(ROOT_DIR)/node_modules
+
+.PHONY: test
+test: $(BUILD_DIR)/test.out
 
 .PHONY: ui-guide
 ui-guide: build-css $(OUTPUT_DIR)/Main/index.js $(NODE_MODULES) | $(PARCEL_DIR)

--- a/src/Interfaces/Typeahead/Interface.purs
+++ b/src/Interfaces/Typeahead/Interface.purs
@@ -247,7 +247,7 @@ single' :: ∀ action item. Eq item => Component action Maybe item Aff
 single' = component
   { runSelect: const <<< Just
   , runRemove: const (const Nothing)
-  , runFilter: const
+  , runFilterItems: const
   }
 
 -- DEPRECATED

--- a/src/Interfaces/Typeahead/Interface.purs
+++ b/src/Interfaces/Typeahead/Interface.purs
@@ -27,7 +27,7 @@ import Halogen.VDom.Driver (runUI)
 import Html.Renderer.Halogen as Parser
 import Network.RemoteData (RemoteData(..))
 import Ocelot.Block.ItemContainer (boldMatches)
-import Ocelot.Typeahead (Component, Input, Insertable(..), Output(..), Query(..), defRenderContainer, multi, renderMulti, renderSingle, single, component, renderHeaderSearchDropdown, renderSearchDropdown, renderToolbarSearchDropdown)
+import Ocelot.Typeahead (Component, Input, Insertable(..), Output(..), Query(..), defFilterFuzzy, defRenderContainer, multi, renderMulti, renderSingle, single, component, renderHeaderSearchDropdown, renderSearchDropdown, renderToolbarSearchDropdown)
 import Ocelot.HTML.Properties (css)
 import Ocelot.Interface.Utilities (Interface, mkSubscription)
 import Partial.Unsafe (unsafePartial)
@@ -247,6 +247,7 @@ single' :: ∀ action item. Eq item => Component action Maybe item Aff
 single' = component
   { runSelect: const <<< Just
   , runRemove: const (const Nothing)
+  , runFilterFuzzy: defFilterFuzzy
   , runFilterItems: const
   }
 

--- a/src/Typeahead.purs
+++ b/src/Typeahead.purs
@@ -257,6 +257,9 @@ single = component
   , runFilterItems: \items -> Data.Maybe.maybe items (\i -> Data.Array.filter (_ /= i) items)
   }
 
+-- | Typeahead that doesn't filter or search results, only highlights matches.
+-- |
+-- | This is useful when using an endpoint that already filters and sorts the results.
 singleHighlightOnly ::
   forall action item m.
   Eq item =>
@@ -282,6 +285,9 @@ multi = component
   , runFilterItems: Data.Array.difference
   }
 
+-- | Typeahead that doesn't filter or search results, only highlights matches.
+-- |
+-- | This is useful when using an endpoint that already filters and sorts the results.
 multiHighlightOnly ::
   forall action item m.
   Eq item =>

--- a/src/Typeahead.purs
+++ b/src/Typeahead.purs
@@ -40,6 +40,7 @@ module Ocelot.Typeahead
   , isDisabled
   , linkClasses
   , multi
+  , multiHighlightOnly
   , renderError
   , renderHeaderSearchDropdown
   , renderMulti
@@ -47,6 +48,7 @@ module Ocelot.Typeahead
   , renderSingle
   , renderToolbarSearchDropdown
   , single
+  , singleHighlightOnly
   , spinner
   , syncMulti
   , syncSingle
@@ -255,6 +257,19 @@ single = component
   , runFilterItems: \items -> Data.Maybe.maybe items (\i -> Data.Array.filter (_ /= i) items)
   }
 
+singleHighlightOnly ::
+  forall action item m.
+  Eq item =>
+  Effect.Aff.Class.MonadAff m =>
+  Component action Maybe item m 
+singleHighlightOnly = component
+  { runSelect: const <<< Just 
+  , runRemove: const (const Nothing)
+  , runFilterFuzzy: identity
+  , runFilterItems: \items -> Data.Maybe.maybe items (\item -> Data.Array.filter (_ /= item) items)
+  }
+
+
 multi
   :: forall action item m
   . Eq item
@@ -264,6 +279,18 @@ multi = component
   { runSelect: (:)
   , runRemove: Data.Array.filter <<< (/=)
   , runFilterFuzzy: defFilterFuzzy
+  , runFilterItems: Data.Array.difference
+  }
+
+multiHighlightOnly ::
+  forall action item m.
+  Eq item =>
+  Effect.Aff.Class.MonadAff m =>
+  Component action Array item m
+multiHighlightOnly = component 
+  { runSelect: (:)
+  , runRemove: Data.Array.filter <<< (/=)
+  , runFilterFuzzy: identity
   , runFilterItems: Data.Array.difference
   }
 

--- a/src/Typeahead.purs
+++ b/src/Typeahead.purs
@@ -373,10 +373,12 @@ applyInsertable match insertable text items = case insertable of
 
 defFilterFuzzy ::
   forall item.
+  Eq item =>
   Array (Data.Fuzzy.Fuzzy item) ->
   Array (Data.Fuzzy.Fuzzy item)
-defFilterFuzzy = Data.Array.filter do
-  \(Data.Fuzzy.Fuzzy { ratio }) -> ratio > (2 % 3)
+defFilterFuzzy = 
+  Data.Array.sort 
+    <<< Data.Array.filter (\(Data.Fuzzy.Fuzzy { ratio }) -> ratio > (2 % 3))
 
 defRenderContainer
   :: ∀ action f item m
@@ -532,7 +534,6 @@ getNewItems st = st.items <#> \items ->
 
 getNewItems' ::
   forall f item state.
-  Eq item =>
   { insertable :: Insertable item
   , itemToObject :: item -> Foreign.Object.Object String 
   , runFilterFuzzy :: Array (Data.Fuzzy.Fuzzy item) -> Array (Data.Fuzzy.Fuzzy item)
@@ -544,8 +545,7 @@ getNewItems' ::
   Array item ->
   Array (Data.Fuzzy.Fuzzy item)
 getNewItems' st =
-  Data.Array.sort 
-    <<< st.runFilterFuzzy
+  st.runFilterFuzzy
     <<< applyInsert
     <<< fuzzyItems
     <<< flip st.runFilterItems st.selected

--- a/src/Typeahead.purs
+++ b/src/Typeahead.purs
@@ -51,39 +51,40 @@ module Ocelot.Typeahead
   ) where
 
 import Prelude
-import Control.Alternative (class Plus, empty)
-import Control.Comonad (extract)
-import Control.Comonad.Store (Store, store)
-import DOM.HTML.Indexed (HTMLinput)
-import Data.Array ((!!), (:), foldr)
-import Data.Array as Array
-import Data.Fuzzy (Fuzzy(..), match)
-import Data.Fuzzy as Fuzzy
-import Data.Maybe (Maybe(..), isJust, isNothing, maybe)
-import Data.Newtype (unwrap)
+import Control.Alternative as Control.Alternate
+import Control.Comonad as Control.Comonad
+import Control.Comonad.Store as Control.Comonad.Store
+import DOM.HTML.Indexed as DOM.HTML.Indexed
+import Data.Array ((!!), (:))
+import Data.Array as Data.Array
+import Data.Fuzzy as Data.Fuzzy
+import Data.Maybe (Maybe(..))
+import Data.Maybe as Data.Maybe
+import Data.Newtype as Data.Newtype
 import Data.Rational ((%))
-import Data.Time.Duration (Milliseconds(..))
-import Effect.Aff.Class (class MonadAff)
-import Foreign.Object (Object)
-import Halogen as H
-import Halogen.HTML as HH
-import Halogen.HTML.Core (Prop(..), PropValue)
-import Halogen.HTML.Events as HE
-import Halogen.HTML.Properties as HP
-import Network.RemoteData (RemoteData(..), isFailure, isLoading)
-import Ocelot.Block.Button as Button
-import Ocelot.Block.Conditional (conditional)
-import Ocelot.Block.Format as Format
-import Ocelot.Block.Icon as Icon
-import Ocelot.Block.Input as Input
-import Ocelot.Block.ItemContainer as IC
-import Ocelot.Block.Loading as Loading
-import Ocelot.HTML.Properties (css, (<&>))
-import Renderless.State(modifyStore_)
-import Select as S
-import Select.Setters as Setters
+import Data.Time.Duration as Data.Time.Duration
+import Effect.Aff.Class as Effect.Aff.Class
+import Foreign.Object as Foreign.Object
+import Halogen as Halogen
+import Halogen.HTML as Halogen.HTML
+import Halogen.HTML.Core as Halogen.HTML.Core
+import Halogen.HTML.Events as Halogen.HTML.Events
+import Halogen.HTML.Properties as Halogen.HTML.Properties
+import Network.RemoteData as Network.RemoteData
+import Ocelot.Block.Button as Ocelot.Block.Button
+import Ocelot.Block.Conditional as Ocelot.Block.Conditional
+import Ocelot.Block.Format as Ocelot.Block.Format
+import Ocelot.Block.Icon as Ocelot.Block.Icon
+import Ocelot.Block.Input as Ocelot.Block.Input
+import Ocelot.Block.ItemContainer as Ocelot.Block.ItemContainer
+import Ocelot.Block.Loading as Ocelot.Block.Loading
+import Ocelot.HTML.Properties ((<&>))
+import Ocelot.HTML.Properties as Ocelot.HTML.Properties
+import Renderless.State as Renderless.State
+import Select as Select
+import Select.Setters as Select.Setters
 import Type.Data.Symbol (SProxy(..))
-import Unsafe.Coerce (unsafeCoerce)
+import Unsafe.Coerce as Unsafe.Coerce
 
 --------
 -- Types
@@ -93,47 +94,55 @@ data Action action (f :: Type -> Type) item (m :: Type -> Type)
   | ReceiveRender (Input action f item m)
 
 type ChildSlots action f item =
-  ( select :: S.Slot (Query f item) EmbeddedChildSlots (Output action f item) Unit
+  ( select :: Select.Slot (Query f item) EmbeddedChildSlots (Output action f item) Unit
   )
 
 type Component action f item m 
-  = H.Component HH.HTML (Query f item) (Input action f item m) (Output action f item) m
+  = Halogen.Component Halogen.HTML.HTML (Query f item) (Input action f item m) (Output action f item) m
 
 type ComponentHTML action f item m 
-  = H.ComponentHTML (Action action f item m) (ChildSlots action f item) m
+  = Halogen.ComponentHTML (Action action f item m) (ChildSlots action f item) m
 
 type ComponentRender action f item m 
   = State f item m -> ComponentHTML action f item m
 
 type ComponentM action f item m a 
-  = H.HalogenM (StateStore action f item m) (Action action f item m) (ChildSlots action f item) (Output action f item) m a
+  = Halogen.HalogenM (StateStore action f item m) (Action action f item m) (ChildSlots action f item) (Output action f item) m a
 
-type CompositeAction action f item m = S.Action (EmbeddedAction action f item m)
+type CompositeAction action f item m 
+  = Select.Action (EmbeddedAction action f item m)
 
-type CompositeComponent action f item m = H.Component HH.HTML (CompositeQuery f item) (CompositeInput f item m) (Output action f item) m
+type CompositeComponent action f item m 
+  = Halogen.Component Halogen.HTML.HTML (CompositeQuery f item) (CompositeInput f item m) (Output action f item) m
 
-type CompositeComponentHTML action f item m = H.ComponentHTML (CompositeAction action f item m) EmbeddedChildSlots m
+type CompositeComponentHTML action f item m 
+  = Halogen.ComponentHTML (CompositeAction action f item m) EmbeddedChildSlots m
 
-type CompositeComponentM action f item m a = H.HalogenM (CompositeState f item m) (CompositeAction action f item m) EmbeddedChildSlots (Output action f item) m a
+type CompositeComponentM action f item m a 
+  = Halogen.HalogenM (CompositeState f item m) (CompositeAction action f item m) EmbeddedChildSlots (Output action f item) m a
 
-type CompositeComponentRender action f item m = (CompositeState f item m) -> CompositeComponentHTML action f item m
+type CompositeComponentRender action f item m 
+  = (CompositeState f item m) -> CompositeComponentHTML action f item m
 
-type CompositeInput f item m = S.Input (StateRow f item m)
+type CompositeInput f item m 
+  = Select.Input (StateRow f item m)
 
-type CompositeQuery f item = S.Query (Query f item) EmbeddedChildSlots
+type CompositeQuery f item 
+  = Select.Query (Query f item) EmbeddedChildSlots
 
-type CompositeState f item m = S.State (StateRow f item m)
+type CompositeState f item m 
+  = Select.State (StateRow f item m)
 
-type DefaultAsyncTypeaheadInput item m =
-  { itemToObject :: item -> Object String
-  , renderFuzzy :: Fuzzy item -> HH.PlainHTML
-  , async :: String -> m (RemoteData String (Array item))
-  }
+type DefaultAsyncTypeaheadInput item m 
+  = { itemToObject :: item -> Foreign.Object.Object String
+    , renderFuzzy :: Data.Fuzzy.Fuzzy item -> Halogen.HTML.PlainHTML
+    , async :: String -> m (Network.RemoteData.RemoteData String (Array item))
+    }
 
-type DefaultSyncTypeaheadInput item =
-  { itemToObject :: item -> Object String
-  , renderFuzzy :: Fuzzy item -> HH.PlainHTML
-  }
+type DefaultSyncTypeaheadInput item 
+  = { itemToObject :: item -> Foreign.Object.Object String
+    , renderFuzzy :: Data.Fuzzy.Fuzzy item -> Halogen.HTML.PlainHTML
+    }
 
 data EmbeddedAction action (f :: Type -> Type) item (m :: Type -> Type)
   = Initialize
@@ -141,28 +150,29 @@ data EmbeddedAction action (f :: Type -> Type) item (m :: Type -> Type)
   | RemoveAll
   | Raise action
 
-type EmbeddedChildSlots = () -- NOTE no extension
+type EmbeddedChildSlots 
+  = () -- NOTE no extension
 
-type Input action f item m =
-  { items :: RemoteData String (Array item)
-  , insertable :: Insertable item
-  , keepOpen :: Boolean
-  , itemToObject :: item -> Object String
-  , async :: Maybe (String -> m (RemoteData String (Array item)))
-  , disabled :: Boolean
-  , debounceTime :: Maybe Milliseconds
-  , render :: CompositeComponentRender action f item m
-  }
+type Input action f item m 
+  = { items :: Network.RemoteData.RemoteData String (Array item)
+    , insertable :: Insertable item
+    , keepOpen :: Boolean
+    , itemToObject :: item -> Foreign.Object.Object String
+    , async :: Maybe (String -> m (Network.RemoteData.RemoteData String (Array item)))
+    , disabled :: Boolean
+    , debounceTime :: Maybe Data.Time.Duration.Milliseconds
+    , render :: CompositeComponentRender action f item m
+    }
 
 data Insertable item
   = NotInsertable
   | Insertable (String -> item)
 
-type Operations f item =
-  { runSelect  :: item -> f item -> f item
-  , runRemove  :: item -> f item -> f item
-  , runFilter  :: Array item -> f item -> Array item
-  }
+type Operations f item 
+  = { runSelect  :: item -> f item -> f item
+    , runRemove  :: item -> f item -> f item
+    , runFilter  :: Array item -> f item -> Array item
+    }
 
 data Output action (f :: Type -> Type) item
   = Searched String
@@ -174,7 +184,7 @@ data Query f item a
   = GetSelected (f item -> a)
   | ReplaceSelected (f item) a
   | ReplaceSelectedBy (Array item -> f item) a
-  | ReplaceItems (RemoteData String (Array item)) a
+  | ReplaceItems (Network.RemoteData.RemoteData String (Array item)) a
   | Reset a
   | SetDisabled Boolean a
 
@@ -186,41 +196,45 @@ data SelectionCause
 
 derive instance eqSelectionCause :: Eq SelectionCause
 
-type Slot action f item id = H.Slot (Query f item) (Output action f item) id
+type Slot action f item id 
+  = Halogen.Slot (Query f item) (Output action f item) id
 
-type Spec action f item m = S.Spec (StateRow f item m) (Query f item) (EmbeddedAction action f item m) EmbeddedChildSlots (CompositeInput f item m) (Output action f item) m
+type Spec action f item m 
+  = Select.Spec (StateRow f item m) (Query f item) (EmbeddedAction action f item m) EmbeddedChildSlots (CompositeInput f item m) (Output action f item) m
 
-type State f item m = Record (StateRow f item m)
+type State f item m 
+  = Record (StateRow f item m)
 
-type StateRow f item m =
-  ( items :: RemoteData String (Array item) -- NOTE pst.items, Parent(Typeahead)
-  , insertable :: Insertable item
-  , keepOpen :: Boolean
-  , itemToObject :: item -> Object String
-  , async :: Maybe (String -> m (RemoteData String (Array item)))
-  , disabled :: Boolean
-  , ops :: Operations f item
-  , config :: { debounceTime :: Maybe Milliseconds }
-  , selected :: f item
-  , fuzzyItems :: Array (Fuzzy item) -- NOTE cst.items, Child(Select)
-  )
+type StateRow f item m 
+  = ( items :: Network.RemoteData.RemoteData String (Array item) -- NOTE pst.items, Parent(Typeahead)
+    , insertable :: Insertable item
+    , keepOpen :: Boolean
+    , itemToObject :: item -> Foreign.Object.Object String
+    , async :: Maybe (String -> m (Network.RemoteData.RemoteData String (Array item)))
+    , disabled :: Boolean
+    , ops :: Operations f item
+    , config :: { debounceTime :: Maybe Data.Time.Duration.Milliseconds }
+    , selected :: f item
+    , fuzzyItems :: Array (Data.Fuzzy.Fuzzy item) -- NOTE cst.items, Child(Select)
+    )
 
-type StateStore action f item m = Store (State f item m) (ComponentHTML action f item m)
+type StateStore action f item m 
+  = Control.Comonad.Store.Store (State f item m) (ComponentHTML action f item m)
 
 -------------
 -- Components
 
 component
   :: forall action f item m
-  . Plus f
+  . Control.Alternate.Plus f
   => Eq item
-  => MonadAff m
+  => Effect.Aff.Class.MonadAff m
   => Operations f item
   -> Component action f item m
-component ops = H.mkComponent
+component ops = Halogen.mkComponent
   { initialState: initialState ops
-  , render: extract
-  , eval: H.mkEval H.defaultEval
+  , render: Control.Comonad.extract
+  , eval: Halogen.mkEval Halogen.defaultEval
       { handleAction = handleAction
       , handleQuery = handleQuery
       }
@@ -229,76 +243,76 @@ component ops = H.mkComponent
 single
   :: forall action item m
   . Eq item
-  => MonadAff m
+  => Effect.Aff.Class.MonadAff m
   => Component action Maybe item m
 single = component
   { runSelect: const <<< Just
   , runRemove: const (const Nothing)
-  , runFilter: \items -> maybe items (\i -> Array.filter (_ /= i) items)
+  , runFilter: \items -> Data.Maybe.maybe items (\i -> Data.Array.filter (_ /= i) items)
   }
 
 multi
   :: forall action item m
   . Eq item
-  => MonadAff m
+  => Effect.Aff.Class.MonadAff m
   => Component action Array item m
 multi = component
   { runSelect: (:)
-  , runRemove: Array.filter <<< (/=)
-  , runFilter: Array.difference
+  , runRemove: Data.Array.filter <<< (/=)
+  , runFilter: Data.Array.difference
   }
 
 asyncSingle
   :: ∀ action item m
    . Eq item
-  => MonadAff m
+  => Effect.Aff.Class.MonadAff m
   => DefaultAsyncTypeaheadInput item m
-  -> Array (HH.IProp HTMLinput (CompositeAction action Maybe item m))
+  -> Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action Maybe item m))
   -> Input action Maybe item m
 asyncSingle { async, itemToObject, renderFuzzy } props =
-  { items: NotAsked
+  { items: Network.RemoteData.NotAsked
   , insertable: NotInsertable
   , keepOpen: false
   , itemToObject
-  , debounceTime: Just $ Milliseconds 300.0
+  , debounceTime: Just $ Data.Time.Duration.Milliseconds 300.0
   , async: Just async
   , disabled: isDisabled props
   , render: renderSingle
       props
-      (renderFuzzy <<< match false itemToObject "")
+      (renderFuzzy <<< Data.Fuzzy.match false itemToObject "")
       (defRenderContainer renderFuzzy)
   }
 
 asyncMulti
   :: ∀ action item m
    . Eq item
-  => MonadAff m
+  => Effect.Aff.Class.MonadAff m
   => DefaultAsyncTypeaheadInput item m
-  -> Array (HH.IProp HTMLinput (CompositeAction action Array item m))
+  -> Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action Array item m))
   -> Input action Array item m
 asyncMulti { async, itemToObject, renderFuzzy } props =
-  { items: NotAsked
+  { items: Network.RemoteData.NotAsked
   , insertable: NotInsertable
   , keepOpen: true
   , itemToObject
-  , debounceTime: Just $ Milliseconds 300.0
+  , debounceTime: Just $ Data.Time.Duration.Milliseconds 300.0
   , async: Just async
   , disabled: isDisabled props
   , render: renderMulti
       props
-      (renderFuzzy <<< match false itemToObject "")
+      (renderFuzzy <<< Data.Fuzzy.match false itemToObject "")
       (defRenderContainer renderFuzzy)
   }
 
 syncSingle
   :: ∀ action item m
    . Eq item
-  => MonadAff m
+  => Effect.Aff.Class.MonadAff m
   => DefaultSyncTypeaheadInput item
-  -> Array (HH.IProp HTMLinput (CompositeAction action Maybe item m))
+  -> Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action Maybe item m))
   -> Input action Maybe item m
 syncSingle { itemToObject, renderFuzzy } props =
-  { items: NotAsked
+  { items: Network.RemoteData.NotAsked
   , insertable: NotInsertable
   , keepOpen: false
   , itemToObject
@@ -307,19 +321,19 @@ syncSingle { itemToObject, renderFuzzy } props =
   , disabled: isDisabled props
   , render: renderSingle
       props
-      (renderFuzzy <<< match false itemToObject "")
+      (renderFuzzy <<< Data.Fuzzy.match false itemToObject "")
       (defRenderContainer renderFuzzy)
   }
 
 syncMulti
   :: ∀ action item m
    . Eq item
-  => MonadAff m
+  => Effect.Aff.Class.MonadAff m
   => DefaultSyncTypeaheadInput item
-  -> Array (HH.IProp HTMLinput (CompositeAction action Array item m))
+  -> Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action Array item m))
   -> Input action Array item m
 syncMulti { itemToObject, renderFuzzy } props =
-  { items: NotAsked
+  { items: Network.RemoteData.NotAsked
   , insertable: NotInsertable
   , keepOpen: true
   , itemToObject
@@ -328,7 +342,7 @@ syncMulti { itemToObject, renderFuzzy } props =
   , disabled: isDisabled props
   , render: renderMulti
       props
-      (renderFuzzy <<< match false itemToObject "")
+      (renderFuzzy <<< Data.Fuzzy.match false itemToObject "")
       (defRenderContainer renderFuzzy)
   }
 
@@ -339,28 +353,28 @@ _select = SProxy :: SProxy "select"
 
 applyInsertable
   :: forall item
-  . (item -> Fuzzy item)
+  . (item -> Data.Fuzzy.Fuzzy item)
   -> Insertable item
   -> String
-  -> Array (Fuzzy item)
-  -> Array (Fuzzy item)
+  -> Array (Data.Fuzzy.Fuzzy item)
+  -> Array (Data.Fuzzy.Fuzzy item)
 applyInsertable _ _ "" items = items
 applyInsertable match insertable text items = case insertable of
   NotInsertable -> items
-  Insertable mkItem | Array.length (Array.filter isExactMatch items) > 0 -> items
+  Insertable mkItem | Data.Array.length (Data.Array.filter isExactMatch items) > 0 -> items
                     | otherwise -> (match $ mkItem text) : items
   where
-    isExactMatch (Fuzzy { distance }) = distance == Fuzzy.Distance 0 0 0 0 0 0
+    isExactMatch (Data.Fuzzy.Fuzzy { distance }) = distance == Data.Fuzzy.Distance 0 0 0 0 0 0
 
 defRenderContainer
   :: ∀ action f item m
-   . (Fuzzy item -> HH.PlainHTML)
+   . (Data.Fuzzy.Fuzzy item -> Halogen.HTML.PlainHTML)
   -> CompositeComponentRender action f item m
 defRenderContainer renderFuzzy st =
-  IC.itemContainer st.highlightedIndex (renderFuzzy <$> st.fuzzyItems) []
+  Ocelot.Block.ItemContainer.itemContainer st.highlightedIndex (renderFuzzy <$> st.fuzzyItems) []
 
-disabledClasses :: Array HH.ClassName
-disabledClasses = HH.ClassName <$>
+disabledClasses :: Array Halogen.HTML.ClassName
+disabledClasses = Halogen.HTML.ClassName <$>
   [ "bg-grey-95"
   , "text-grey-70"
   , "sibling:bg-grey-95"
@@ -378,87 +392,92 @@ disabledClasses = HH.ClassName <$>
 embeddedHandleAction
   :: forall action f item m
   . Eq item
-  => Plus f
-  => MonadAff m
+  => Control.Alternate.Plus f
+  => Effect.Aff.Class.MonadAff m
   => EmbeddedAction action f item m
   -> CompositeComponentM action f item m Unit
 embeddedHandleAction = case _ of
   Initialize -> do
     synchronize
   Remove item -> do
-    st <- H.modify \st -> st { selected = st.ops.runRemove item st.selected }
-    H.raise $ SelectionChanged RemovalQuery st.selected
+    st <- Halogen.modify \st -> st { selected = st.ops.runRemove item st.selected }
+    Halogen.raise $ SelectionChanged RemovalQuery st.selected
     synchronize
   RemoveAll -> do
-    st <- H.modify \st ->
-      st { selected = empty :: f item
-         , visibility = S.Off
+    st <- Halogen.modify \st ->
+      st { selected = Control.Alternate.empty :: f item
+         , visibility = Select.Off
          }
-    H.raise $ SelectionChanged RemovalQuery st.selected
+    Halogen.raise $ SelectionChanged RemovalQuery st.selected
     synchronize
   Raise action -> do
-    H.raise $ Emit action
+    Halogen.raise $ Emit action
 
 embeddedHandleMessage
   :: forall action f item m
    . Eq item
-  => MonadAff m
-  => S.Event
+  => Effect.Aff.Class.MonadAff m
+  => Select.Event
   -> CompositeComponentM action f item m Unit
 embeddedHandleMessage = case _ of
-  S.Selected idx -> do
-    { fuzzyItems } <- H.get
+  Select.Selected idx -> do
+    { fuzzyItems } <- Halogen.get
     case fuzzyItems !! idx of
       Nothing -> pure unit
-      Just (Fuzzy { original: item }) -> do
-        st <- H.modify \st -> st { selected = st.ops.runSelect item st.selected }
+      Just (Data.Fuzzy.Fuzzy { original: item }) -> do
+        st <- Halogen.modify \st -> st { selected = st.ops.runSelect item st.selected }
         when (not st.keepOpen) do
-          H.modify_ _ { visibility = S.Off }
-        H.raise $ SelectionChanged SelectionMessage st.selected
-        H.raise $ Selected item
+          Halogen.modify_ _ { visibility = Select.Off }
+        Halogen.raise $ SelectionChanged SelectionMessage st.selected
+        Halogen.raise $ Selected item
         synchronize
   -- Perform a new search, fetching data if Async.
-  S.Searched text -> do
-    H.modify_ _ { search = text }
-    async <- H.gets _.async
+  Select.Searched text -> do
+    Halogen.modify_ _ { search = text }
+    async <- Halogen.gets _.async
     case async of
       Nothing -> pure unit
       Just fetchItems -> do
-        H.modify_ _ { items = Loading }
+        Halogen.modify_ _ { items = Network.RemoteData.Loading }
         synchronize
-        newItems <- H.lift $ fetchItems text
-        H.modify_ _ { items = newItems }
-    H.raise $ Searched text
+        newItems <- Halogen.lift $ fetchItems text
+        Halogen.modify_ _ { items = newItems }
+    Halogen.raise $ Searched text
     synchronize
   _ -> pure unit
 
 embeddedHandleQuery
   :: forall action f item m a
-  . Plus f
+  . Control.Alternate.Plus f
   => Eq item
-  => MonadAff m
+  => Effect.Aff.Class.MonadAff m
   => Query f item a
   -> CompositeComponentM action f item m (Maybe a)
 embeddedHandleQuery = case _ of
   GetSelected reply -> do
-    { selected } <- H.get
+    { selected } <- Halogen.get
     pure $ Just $ reply selected
   ReplaceSelected selected a -> Just a <$ do
     replaceSelected selected
   ReplaceSelectedBy f a -> Just a <$ do
-    { items } <- H.get
+    { items } <- Halogen.get
     case items of
-      Success items' -> replaceSelected (f items')
+      Network.RemoteData.Success items' -> replaceSelected (f items')
       _ -> pure unit
   ReplaceItems items a -> Just a <$ do
-    H.modify_ _ { items = items }
+    Halogen.modify_ _ { items = items }
     synchronize
   Reset a -> Just a <$ do
-    st <- H.modify _ { selected = empty :: f item, items = NotAsked }
-    H.raise $ SelectionChanged ResetQuery st.selected
+    st <- 
+      Halogen.modify 
+        _ 
+          { selected = Control.Alternate.empty :: f item
+          , items = Network.RemoteData.NotAsked 
+          }
+    Halogen.raise $ SelectionChanged ResetQuery st.selected
     synchronize
   SetDisabled disabled a -> Just a <$ do
-    H.modify_ _ { disabled = disabled }
+    Halogen.modify_ _ { disabled = disabled }
 
 embeddedInitialize :: forall action f item m. Maybe (EmbeddedAction action f item m)
 embeddedInitialize = Just Initialize
@@ -466,10 +485,10 @@ embeddedInitialize = Just Initialize
 -- NOTE configure Select
 embeddedInput :: forall f item m. State f item m -> CompositeInput f item m
 embeddedInput { items, selected, insertable, keepOpen, itemToObject, ops, async, fuzzyItems, config: { debounceTime }, disabled } =
-  { inputType: S.Text
+  { inputType: Select.Text
   , search: Nothing
   , debounceTime
-  , getItemCount: Array.length <<< _.fuzzyItems
+  , getItemCount: Data.Array.length <<< _.fuzzyItems
   , items
   , selected
   , insertable
@@ -484,72 +503,72 @@ embeddedInput { items, selected, insertable, keepOpen, itemToObject, ops, async,
 
 getNewItems
   :: forall f item m
-  . MonadAff m
+  . Effect.Aff.Class.MonadAff m
   => Eq item
   => CompositeState f item m
-  -> RemoteData String (Array (Fuzzy item))
+  -> Network.RemoteData.RemoteData String (Array (Data.Fuzzy.Fuzzy item))
 getNewItems st =
-  Array.sort
+  Data.Array.sort
   <<< applyF
   <<< applyI
   <<< fuzzyItems
   <$> (map (flip st.ops.runFilter st.selected) st.items)
   where
-    matcher :: item -> Fuzzy item
-    matcher = Fuzzy.match true st.itemToObject st.search
+    matcher :: item -> Data.Fuzzy.Fuzzy item
+    matcher = Data.Fuzzy.match true st.itemToObject st.search
 
-    fuzzyItems :: Array item -> Array (Fuzzy item)
+    fuzzyItems :: Array item -> Array (Data.Fuzzy.Fuzzy item)
     fuzzyItems = map matcher
 
-    applyI :: Array (Fuzzy item) -> Array (Fuzzy item)
+    applyI :: Array (Data.Fuzzy.Fuzzy item) -> Array (Data.Fuzzy.Fuzzy item)
     applyI = applyInsertable matcher st.insertable st.search
 
-    applyF :: Array (Fuzzy item) -> Array (Fuzzy item)
-    applyF = Array.filter (\(Fuzzy { ratio }) -> ratio > (2 % 3))
+    applyF :: Array (Data.Fuzzy.Fuzzy item) -> Array (Data.Fuzzy.Fuzzy item)
+    applyF = Data.Array.filter (\(Data.Fuzzy.Fuzzy { ratio }) -> ratio > (2 % 3))
 
 -- NOTE re-raise output messages from the embedded component
 -- NOTE update Dropdown render function if it relies on external state
 handleAction
   :: forall action f item m
-  . Plus f
+  . Control.Alternate.Plus f
   => Eq item
-  => MonadAff m
+  => Effect.Aff.Class.MonadAff m
   => Action action f item m
   -> ComponentM action f item m Unit
 handleAction = case _ of
   PassingOutput output ->
-    H.raise output
+    Halogen.raise output
   ReceiveRender { render } -> do
-    modifyStore_ (renderAdapter render) identity
+    Renderless.State.modifyStore_ (renderAdapter render) identity
 
 -- NOTE passing query to the embedded component
 handleQuery :: forall action f item m a. Query f item a -> ComponentM action f item m (Maybe a)
 handleQuery = case _ of
   GetSelected reply -> do
-    response <- H.query _select unit (S.Query $ H.request GetSelected)
+    response <- Halogen.query _select unit (Select.Query $ Halogen.request GetSelected)
     pure $ reply <$> response
   ReplaceSelected selected a -> Just a <$ do
-    H.query _select unit (S.Query $ H.tell $ ReplaceSelected selected)
+    Halogen.query _select unit (Select.Query $ Halogen.tell $ ReplaceSelected selected)
   ReplaceSelectedBy f a -> Just a <$ do
-    H.query _select unit (S.Query $ H.tell $ ReplaceSelectedBy f)
+    Halogen.query _select unit (Select.Query $ Halogen.tell $ ReplaceSelectedBy f)
   ReplaceItems items a -> Just a <$ do
-    H.query _select unit (S.Query $ H.tell $ ReplaceItems items)
+    Halogen.query _select unit (Select.Query $ Halogen.tell $ ReplaceItems items)
   Reset a -> Just a <$ do
-    H.query _select unit (S.Query $ H.tell $ Reset)
+    Halogen.query _select unit (Select.Query $ Halogen.tell $ Reset)
   SetDisabled disabled a -> Just a <$ do
-    H.query _select unit (S.Query $ H.tell $ SetDisabled disabled)
+    Halogen.query _select unit (Select.Query $ Halogen.tell $ SetDisabled disabled)
 
 initialState
   :: forall action f item m
-  . Plus f
+  . Control.Alternate.Plus f
   => Eq item
-  => MonadAff m
+  => Effect.Aff.Class.MonadAff m
   => Operations f item
   -> Input action f item m
   -> StateStore action f item m
 initialState ops
   { items, insertable, keepOpen, itemToObject, async, debounceTime, render, disabled }
-  = store (renderAdapter render)
+  = Control.Comonad.Store.store (renderAdapter render)
       { items
       , insertable
       , keepOpen
@@ -558,56 +577,62 @@ initialState ops
       , disabled
       , ops
       , config: {debounceTime}
-      , selected: empty :: f item
+      , selected: Control.Alternate.empty :: f item
       , fuzzyItems: []
       }
 
 inputProps
   :: ∀ action f item m
    . Boolean
-  -> Array (HP.IProp HTMLinput (CompositeAction action f item m))
-  -> Array (HP.IProp HTMLinput (CompositeAction action f item m))
+  -> Array (Halogen.HTML.Properties.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action f item m))
+  -> Array (Halogen.HTML.Properties.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action f item m))
 inputProps disabled iprops = if disabled
   then iprops'
-  else Setters.setInputProps iprops'
+  else Select.Setters.setInputProps iprops'
   where
-    iprops' = [ HP.disabled disabled, HP.autocomplete false, css "focus:next:text-blue-88" ] <&> iprops
+    iprops' = 
+      [ Halogen.HTML.Properties.disabled disabled
+      , Halogen.HTML.Properties.autocomplete false
+      , Ocelot.HTML.Properties.css "focus:next:text-blue-88" 
+      ] 
+      <&> iprops
 
-isDisabled :: ∀ i. Array (HH.IProp HTMLinput i) -> Boolean
-isDisabled = foldr f false
+isDisabled :: ∀ i. Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLinput i) -> Boolean
+isDisabled = Data.Array.foldr f false
   where
-    f (HP.IProp (Property "disabled" disabled)) | coercePropValue disabled == true = (||) true
+    f (Halogen.HTML.Properties.IProp (Halogen.HTML.Core.Property "disabled" disabled)) 
+      | coercePropValue disabled == true = (||) true
     f _ = (||) false
 
-    coercePropValue :: PropValue -> Boolean
-    coercePropValue = unsafeCoerce
+    coercePropValue :: Halogen.HTML.Core.PropValue -> Boolean
+    coercePropValue = Unsafe.Coerce.unsafeCoerce
 
-linkClasses :: Boolean -> Array HH.ClassName
+linkClasses :: Boolean -> Array Halogen.HTML.ClassName
 linkClasses = if _
-  then HH.ClassName <$> [ "text-grey-70", "no-underline", "font-medium" ]
-  else Format.linkClasses
+  then Halogen.HTML.ClassName <$> [ "text-grey-70", "no-underline", "font-medium" ]
+  else Ocelot.Block.Format.linkClasses
 
 renderAdapter
   :: forall action f item m
-  . Plus f
+  . Control.Alternate.Plus f
   => Eq item
-  => MonadAff m
+  => Effect.Aff.Class.MonadAff m
   => CompositeComponentRender action f item m
   -> ComponentRender action f item m
 renderAdapter render state =
-  HH.slot _select unit (S.component identity $ spec render)
+  Halogen.HTML.slot _select unit (Select.component identity $ spec render)
     (embeddedInput state)
     (Just <<< PassingOutput)
 
-renderError :: ∀ p i. Boolean -> HH.HTML p i
+renderError :: ∀ p i. Boolean -> Halogen.HTML.HTML p i
 renderError error =
-  conditional error
-    [ css "flex items-center mt-1" ]
-    [ Icon.error
-      [ css "text-2xl text-yellow" ]
-    , HH.p
-      [ css "ml-3 text-grey-50 font-light" ]
-      [ HH.text "Some data could not be retrieved here." ]
+  Ocelot.Block.Conditional.conditional error
+    [ Ocelot.HTML.Properties.css "flex items-center mt-1" ]
+    [ Ocelot.Block.Icon.error
+      [ Ocelot.HTML.Properties.css "text-2xl text-yellow" ]
+    , Halogen.HTML.p
+      [ Ocelot.HTML.Properties.css "ml-3 text-grey-50 font-light" ]
+      [ Halogen.HTML.text "Some data could not be retrieved here." ]
     ]
 
 renderHeaderSearchDropdown
@@ -615,62 +640,62 @@ renderHeaderSearchDropdown
    . Eq item
   => String
   -> String
-  -> (item -> HH.PlainHTML)
-  -> (Fuzzy item -> HH.PlainHTML)
+  -> (item -> Halogen.HTML.PlainHTML)
+  -> (Data.Fuzzy.Fuzzy item -> Halogen.HTML.PlainHTML)
   -> CompositeComponentRender action Maybe item m
 renderHeaderSearchDropdown defaultLabel resetLabel renderItem renderFuzzy st =
   renderSearchDropdown resetLabel label renderFuzzy st
   where
-    label = HH.span
-      [ css "text-white text-3xl font-thin cursor-pointer whitespace-no-wrap" ]
-      [ maybe (HH.text defaultLabel) (HH.fromPlainHTML <<< renderItem) st.selected
-      , Icon.collapse [ css "ml-3 text-xl text-grey-50 align-middle" ]
+    label = Halogen.HTML.span
+      [ Ocelot.HTML.Properties.css "text-white text-3xl font-thin cursor-pointer whitespace-no-wrap" ]
+      [ Data.Maybe.maybe (Halogen.HTML.text defaultLabel) (Halogen.HTML.fromPlainHTML <<< renderItem) st.selected
+      , Ocelot.Block.Icon.collapse [ Ocelot.HTML.Properties.css "ml-3 text-xl text-grey-50 align-middle" ]
       ]
 
 renderMulti
   :: ∀ action item m
-  . Array (HP.IProp HTMLinput (CompositeAction action Array item m))
-  -> (item -> HH.PlainHTML)
+  . Array (Halogen.HTML.Properties.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action Array item m))
+  -> (item -> Halogen.HTML.PlainHTML)
   -> CompositeComponentRender action Array item m
   -> CompositeComponentRender action Array item m
 renderMulti iprops renderItem renderContainer st =
-  HH.div
-    [ css "relative" ]
-    [ if (not disabled && not Array.null st.selected)
+  Halogen.HTML.div
+    [ Ocelot.HTML.Properties.css "relative" ]
+    [ if (not disabled && not Data.Array.null st.selected)
         then
-          HH.a
-            [ css "absolute -mt-7 pin-r underline text-grey-70 cursor-pointer"
-            , HE.onClick $ const <<< Just <<< S.Action $ RemoveAll
+          Halogen.HTML.a
+            [ Ocelot.HTML.Properties.css "absolute -mt-7 pin-r underline text-grey-70 cursor-pointer"
+            , Halogen.HTML.Events.onClick $ const <<< Just <<< Select.Action $ RemoveAll
             ]
-            [ HH.text "Remove All" ]
+            [ Halogen.HTML.text "Remove All" ]
         else
-          HH.text ""
-    , IC.selectionContainer $ st.selected <#>
+          Halogen.HTML.text ""
+    , Ocelot.Block.ItemContainer.selectionContainer $ st.selected <#>
         if disabled
           then
-            HH.fromPlainHTML <<< renderItem
+            Halogen.HTML.fromPlainHTML <<< renderItem
           else
             \selected ->
-              IC.selectionGroup
+              Ocelot.Block.ItemContainer.selectionGroup
                 renderItem
                 []
-                [ HE.onClick $ const <<< Just <<< S.Action $ Remove selected ]
+                [ Halogen.HTML.Events.onClick $ const <<< Just <<< Select.Action $ Remove selected ]
                 selected
-    , Input.inputGroup_
-      [ Input.inputCenter $ inputProps disabled iprops
-      , Input.addonLeft_
-        [ Icon.search_ ]
-      , Input.addonCenter
-        [ css $ if isLoading st.items then "" else "offscreen" ]
+    , Ocelot.Block.Input.inputGroup_
+      [ Ocelot.Block.Input.inputCenter $ inputProps disabled iprops
+      , Ocelot.Block.Input.addonLeft_
+        [ Ocelot.Block.Icon.search_ ]
+      , Ocelot.Block.Input.addonCenter
+        [ Ocelot.HTML.Properties.css $ if Network.RemoteData.isLoading st.items then "" else "offscreen" ]
         [ spinner ]
-      , Input.borderRight
-        [ HP.classes $ linkClasses disabled ]
-        [ HH.text "Browse" ]
+      , Ocelot.Block.Input.borderRight
+        [ Halogen.HTML.Properties.classes $ linkClasses disabled ]
+        [ Halogen.HTML.text "Browse" ]
       ]
-    , conditional (st.visibility == S.On)
-        [ css "relative block" ]
+    , Ocelot.Block.Conditional.conditional (st.visibility == Select.On)
+        [ Ocelot.HTML.Properties.css "relative block" ]
         [ renderContainer st ]
-    , renderError $ isFailure st.items
+    , renderError $ Network.RemoteData.isFailure st.items
     ]
   where
   disabled = st.disabled
@@ -679,141 +704,141 @@ renderSearchDropdown
   :: ∀ action item m
    . Eq item
   => String
-  -> HH.PlainHTML
-  -> (Fuzzy item -> HH.PlainHTML)
+  -> Halogen.HTML.PlainHTML
+  -> (Data.Fuzzy.Fuzzy item -> Halogen.HTML.PlainHTML)
   -> CompositeComponentRender action Maybe item m
 renderSearchDropdown resetLabel label renderFuzzy st =
-  HH.label
-    [ css "relative" ]
-    [ HH.fromPlainHTML label
-    , HH.div
-      [ HP.classes
-        $ HH.ClassName "min-w-80" :
-          if st.visibility == S.Off
-            then [ HH.ClassName "offscreen" ]
+  Halogen.HTML.label
+    [ Ocelot.HTML.Properties.css "relative" ]
+    [ Halogen.HTML.fromPlainHTML label
+    , Halogen.HTML.div
+      [ Halogen.HTML.Properties.classes
+        $ Halogen.HTML.ClassName "min-w-80" :
+          if st.visibility == Select.Off
+            then [ Halogen.HTML.ClassName "offscreen" ]
             else []
       ]
-      [ IC.dropdownContainer
+      [ Ocelot.Block.ItemContainer.dropdownContainer
         [ renderInput, renderReset ]
         renderFuzzy
-        ((==) st.selected <<< Just <<< _.original <<< unwrap)
+        ((==) st.selected <<< Just <<< _.original <<< Data.Newtype.unwrap)
         st.fuzzyItems
         st.highlightedIndex
       ]
     ]
   where
   renderInput =
-    HH.div
-      [ css "m-4 border-b-2 border-blue-88 pb-2 flex" ]
-      [ Icon.search [ css "mr-4 text-xl text-grey-70" ]
-      , HH.input
-        $ inputProps false [ css "no-outline w-full", HP.placeholder "Search" ]
+    Halogen.HTML.div
+      [ Ocelot.HTML.Properties.css "m-4 border-b-2 border-blue-88 pb-2 flex" ]
+      [ Ocelot.Block.Icon.search [ Ocelot.HTML.Properties.css "mr-4 text-xl text-grey-70" ]
+      , Halogen.HTML.input
+        $ inputProps false [ Ocelot.HTML.Properties.css "no-outline w-full", Halogen.HTML.Properties.placeholder "Search" ]
       ]
 
   renderReset =
-    IC.dropdownItem
-      HH.div
-      [ HE.onClick $ const <<< Just <<< S.Action $ RemoveAll
+    Ocelot.Block.ItemContainer.dropdownItem
+      Halogen.HTML.div
+      [ Halogen.HTML.Events.onClick $ const <<< Just <<< Select.Action $ RemoveAll
       ]
-      [ HH.text resetLabel ]
-      ( isNothing st.selected )
+      [ Halogen.HTML.text resetLabel ]
+      ( Data.Maybe.isNothing st.selected )
       false
 
 renderSingle
   :: ∀ action item m
-  . Array (HP.IProp HTMLinput (CompositeAction action Maybe item m))
-  -> (item -> HH.PlainHTML)
+  . Array (Halogen.HTML.Properties.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action Maybe item m))
+  -> (item -> Halogen.HTML.PlainHTML)
   -> CompositeComponentRender action Maybe item m
   -> CompositeComponentRender action Maybe item m
 renderSingle iprops renderItem renderContainer st =
-  HH.div_
-    [ Input.inputGroup' HH.div
-      [ css $ if showSelected then "" else "offscreen" ]
+  Halogen.HTML.div_
+    [ Ocelot.Block.Input.inputGroup' Halogen.HTML.div
+      [ Ocelot.HTML.Properties.css $ if showSelected then "" else "offscreen" ]
       [ if disabled
           then
-            maybe (HH.text "")
-              ( \selected -> HH.div
-                [ HP.classes disabledClasses ]
-                [ HH.fromPlainHTML $ renderItem selected ]
+            Data.Maybe.maybe (Halogen.HTML.text "")
+              ( \selected -> Halogen.HTML.div
+                [ Halogen.HTML.Properties.classes disabledClasses ]
+                [ Halogen.HTML.fromPlainHTML $ renderItem selected ]
               )
             st.selected
           else
-            maybe (HH.text "")
-            ( \selected -> HH.div
-              [ HP.classes Input.mainLeftClasses ]
-              [ IC.selectionGroup renderItem
-                [ HE.onClick $ Just <<< S.ToggleClick ]
-                [ HE.onClick $ const <<< Just <<< S.Action $ Remove selected ]
+            Data.Maybe.maybe (Halogen.HTML.text "")
+            ( \selected -> Halogen.HTML.div
+              [ Halogen.HTML.Properties.classes Ocelot.Block.Input.mainLeftClasses ]
+              [ Ocelot.Block.ItemContainer.selectionGroup renderItem
+                [ Halogen.HTML.Events.onClick $ Just <<< Select.ToggleClick ]
+                [ Halogen.HTML.Events.onClick $ const <<< Just <<< Select.Action $ Remove selected ]
                 selected
               ])
             st.selected
-      , Input.borderRight
-        [ HP.classes $ linkClasses disabled
-        , HE.onClick $ Just <<< S.ToggleClick
+      , Ocelot.Block.Input.borderRight
+        [ Halogen.HTML.Properties.classes $ linkClasses disabled
+        , Halogen.HTML.Events.onClick $ Just <<< Select.ToggleClick
         ]
-        [ HH.text "Change" ]
+        [ Halogen.HTML.text "Change" ]
       ]
-    , Input.inputGroup
-      [ css $ if showSelected then "offscreen" else "" ]
-      [ Input.inputCenter $ inputProps disabled iprops
-      , Input.addonLeft_
-        [ Icon.search_ ]
-      , Input.addonCenter
-        [ css $ if isLoading st.items then "" else "offscreen" ]
+    , Ocelot.Block.Input.inputGroup
+      [ Ocelot.HTML.Properties.css $ if showSelected then "offscreen" else "" ]
+      [ Ocelot.Block.Input.inputCenter $ inputProps disabled iprops
+      , Ocelot.Block.Input.addonLeft_
+        [ Ocelot.Block.Icon.search_ ]
+      , Ocelot.Block.Input.addonCenter
+        [ Ocelot.HTML.Properties.css $ if Network.RemoteData.isLoading st.items then "" else "offscreen" ]
         [ spinner ]
-      , Input.borderRight
-        [ HP.classes $ linkClasses disabled ]
-        [ HH.text "Browse" ]
+      , Ocelot.Block.Input.borderRight
+        [ Halogen.HTML.Properties.classes $ linkClasses disabled ]
+        [ Halogen.HTML.text "Browse" ]
       ]
-    , conditional (st.visibility == S.On)
-        [ css "relative block" ]
+    , Ocelot.Block.Conditional.conditional (st.visibility == Select.On)
+        [ Ocelot.HTML.Properties.css "relative block" ]
         [ renderContainer st ]
-    , renderError $ isFailure st.items
+    , renderError $ Network.RemoteData.isFailure st.items
     ]
   where
   disabled = st.disabled
-  showSelected = isJust st.selected && st.visibility == S.Off
+  showSelected = Data.Maybe.isJust st.selected && st.visibility == Select.Off
 
 renderToolbarSearchDropdown
   :: ∀ action item m
    . Eq item
   => String
   -> String
-  -> (item -> HH.PlainHTML)
-  -> (Fuzzy item -> HH.PlainHTML)
+  -> (item -> Halogen.HTML.PlainHTML)
+  -> (Data.Fuzzy.Fuzzy item -> Halogen.HTML.PlainHTML)
   -> CompositeComponentRender action Maybe item m
 renderToolbarSearchDropdown defaultLabel resetLabel renderItem renderFuzzy st =
   renderSearchDropdown resetLabel label renderFuzzy st
   where
-    label = IC.dropdownButton
-      HH.span
-      [ HP.classes
-        $ HH.ClassName "whitespace-no-wrap"
-        : Button.buttonMainClasses
-        <> Button.buttonClearClasses
+    label = Ocelot.Block.ItemContainer.dropdownButton
+      Halogen.HTML.span
+      [ Halogen.HTML.Properties.classes
+        $ Halogen.HTML.ClassName "whitespace-no-wrap"
+        : Ocelot.Block.Button.buttonMainClasses
+        <> Ocelot.Block.Button.buttonClearClasses
       ]
-      [ maybe (HH.text defaultLabel) (HH.fromPlainHTML <<< renderItem) st.selected ]
+      [ Data.Maybe.maybe (Halogen.HTML.text defaultLabel) (Halogen.HTML.fromPlainHTML <<< renderItem) st.selected ]
 
 replaceSelected
   :: forall action f item m
   . Eq item
-  => MonadAff m
+  => Effect.Aff.Class.MonadAff m
   => f item
   -> CompositeComponentM action f item m Unit
 replaceSelected selected = do
-  st <- H.modify _ { selected = selected }
-  H.raise $ SelectionChanged ReplacementQuery st.selected
+  st <- Halogen.modify _ { selected = selected }
+  Halogen.raise $ SelectionChanged ReplacementQuery st.selected
   synchronize
 
 spec
   :: forall action f item m
-  . Plus f
+  . Control.Alternate.Plus f
   => Eq item
-  => MonadAff m
+  => Effect.Aff.Class.MonadAff m
   => CompositeComponentRender action f item m
   -> Spec action f item m
 spec embeddedRender =
-  S.defaultSpec
+  Select.defaultSpec
   { render = embeddedRender
   , handleAction = embeddedHandleAction
   , handleQuery = embeddedHandleQuery
@@ -821,28 +846,28 @@ spec embeddedRender =
   , initialize = embeddedInitialize
   }
 
-spinner :: ∀ p i. HH.HTML p i
-spinner = Loading.spinner [ css "w-6 text-blue-88" ]
+spinner :: ∀ p i. Halogen.HTML.HTML p i
+spinner = Ocelot.Block.Loading.spinner [ Ocelot.HTML.Properties.css "w-6 text-blue-88" ]
 
 synchronize
   :: forall action f item m
   . Eq item
-  => MonadAff m
+  => Effect.Aff.Class.MonadAff m
   => CompositeComponentM action f item m Unit
 synchronize = do
-  st <- H.get
+  st <- Halogen.get
   case getNewItems st of
-    Success items -> do
-      H.modify_ _ { fuzzyItems = items }
-    Failure err -> do
-      H.modify_
-        _ { visibility = S.Off
+    Network.RemoteData.Success items -> do
+      Halogen.modify_ _ { fuzzyItems = items }
+    Network.RemoteData.Failure err -> do
+      Halogen.modify_
+        _ { visibility = Select.Off
           , fuzzyItems = []
           }
-    NotAsked -> do
-      H.modify_
-        _ { visibility = S.Off
+    Network.RemoteData.NotAsked -> do
+      Halogen.modify_
+        _ { visibility = Select.Off
           , fuzzyItems = []
           }
-    Loading -> do
-      H.modify_ _ { fuzzyItems = [] }
+    Network.RemoteData.Loading -> do
+      Halogen.modify_ _ { fuzzyItems = [] }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,15 +1,16 @@
 module Test.Main where
 
 import Prelude
-
 import Effect (Effect)
 import Test.Ocelot.Data.Currency as Test.Ocelot.Data.Currency
 import Test.Ocelot.HTML.Properties as Test.Ocelot.HTML.Properties
+import Test.Ocelot.Typeahead as Test.Ocelot.Typeahead
 import Test.Unit as Test.Unit
 import Test.Unit.Main as Test.Unit.Main
 
 main :: Effect Unit
 main = Test.Unit.Main.runTest do
   Test.Unit.suite "Ocelet.Data.Currency" Test.Ocelot.Data.Currency.suite
-  Test.Unit.suite "Ocelot.HTML.Properties" Test.Ocelot.HTML.Properties.suite
+  Test.Ocelot.HTML.Properties.suite
+  Test.Ocelot.Typeahead.suite
 

--- a/test/Test/Typeahead.purs
+++ b/test/Test/Typeahead.purs
@@ -26,7 +26,7 @@ suite =
               , search: "foo"
               , selected: ["foo", "bar"]
               }
-              ["foo", "food", "boof", "fooboo", "baz"]
+              ["foo", "boof", "fooboo", "food", "baz"]
 
           expected = ["food", "fooboo"]
         unfuzzyTestResults { actual, expected }

--- a/test/Test/Typeahead.purs
+++ b/test/Test/Typeahead.purs
@@ -30,7 +30,7 @@ suite =
 
           expected = ["food", "fooboo"]
         unfuzzyTestResults { actual, expected }
-      Test.Unit.test "filters out selected Maybeu item and poor matches, and sorts results" do
+      Test.Unit.test "filters out selected Maybe item and poor matches, and sorts results" do
         let
           actual =
             Ocelot.Typeahead.getNewItems'

--- a/test/Test/Typeahead.purs
+++ b/test/Test/Typeahead.purs
@@ -21,7 +21,7 @@ suite =
             Ocelot.Typeahead.getNewItems'
               { insertable: Ocelot.Typeahead.NotInsertable 
               , itemToObject: Foreign.Object.fromHomogeneous <<< { name: _ }
-              , runFilter: Data.Array.difference 
+              , runFilterItems: Data.Array.difference 
               , search: "foo"
               , selected: ["foo", "bar"]
               }
@@ -35,7 +35,7 @@ suite =
             Ocelot.Typeahead.getNewItems'
               { insertable: Ocelot.Typeahead.NotInsertable 
               , itemToObject: Foreign.Object.fromHomogeneous <<< { name: _ }
-              , runFilter: \items -> Data.Maybe.maybe items (\item -> Data.Array.filter (_ /= item) items)
+              , runFilterItems: \items -> Data.Maybe.maybe items (\item -> Data.Array.filter (_ /= item) items)
               , search: "foo"
               , selected: Just "foo"
               }
@@ -49,7 +49,7 @@ suite =
             Ocelot.Typeahead.getNewItems'
               { insertable: Ocelot.Typeahead.Insertable identity
               , itemToObject: Foreign.Object.fromHomogeneous <<< { name: _ }
-              , runFilter: \items _ -> items
+              , runFilterItems: \items _ -> items
               , search: "foo"
               , selected: Nothing 
               }
@@ -63,7 +63,7 @@ suite =
             Ocelot.Typeahead.getNewItems'
               { insertable: Ocelot.Typeahead.Insertable identity
               , itemToObject: Foreign.Object.fromHomogeneous <<< { name: _ }
-              , runFilter: \items _ -> items
+              , runFilterItems: \items _ -> items
               , search: "foo"
               , selected: Nothing 
               }

--- a/test/Test/Typeahead.purs
+++ b/test/Test/Typeahead.purs
@@ -45,6 +45,21 @@ suite =
 
           expected = ["food", "fooboo"]
         unfuzzyTestResults { actual, expected }
+      Test.Unit.test "doesn't filter poor matches or sort results" do
+        let
+          actual =
+            Ocelot.Typeahead.getNewItems'
+              { insertable: Ocelot.Typeahead.NotInsertable 
+              , itemToObject: Foreign.Object.fromHomogeneous <<< { name: _ }
+              , runFilterFuzzy: identity
+              , runFilterItems: Data.Array.difference 
+              , search: "foo"
+              , selected: ["foo", "bar"]
+              }
+              ["foo", "food", "boof", "fooboo", "baz"]
+
+          expected = ["food", "boof", "fooboo", "baz"]
+        unfuzzyTestResults { actual, expected }
       Test.Unit.test "inserts search to results without a perfect match" do
         let
           actual =

--- a/test/Test/Typeahead.purs
+++ b/test/Test/Typeahead.purs
@@ -41,7 +41,7 @@ suite =
               , search: "foo"
               , selected: Just "foo"
               }
-              ["foo", "food", "boof", "fooboo", "baz"]
+              ["foo", "boof", "fooboo", "food", "baz"]
 
           expected = ["food", "fooboo"]
         unfuzzyTestResults { actual, expected }

--- a/test/Test/Typeahead.purs
+++ b/test/Test/Typeahead.purs
@@ -21,6 +21,7 @@ suite =
             Ocelot.Typeahead.getNewItems'
               { insertable: Ocelot.Typeahead.NotInsertable 
               , itemToObject: Foreign.Object.fromHomogeneous <<< { name: _ }
+              , runFilterFuzzy: Ocelot.Typeahead.defFilterFuzzy
               , runFilterItems: Data.Array.difference 
               , search: "foo"
               , selected: ["foo", "bar"]
@@ -35,6 +36,7 @@ suite =
             Ocelot.Typeahead.getNewItems'
               { insertable: Ocelot.Typeahead.NotInsertable 
               , itemToObject: Foreign.Object.fromHomogeneous <<< { name: _ }
+              , runFilterFuzzy: Ocelot.Typeahead.defFilterFuzzy
               , runFilterItems: \items -> Data.Maybe.maybe items (\item -> Data.Array.filter (_ /= item) items)
               , search: "foo"
               , selected: Just "foo"
@@ -49,6 +51,7 @@ suite =
             Ocelot.Typeahead.getNewItems'
               { insertable: Ocelot.Typeahead.Insertable identity
               , itemToObject: Foreign.Object.fromHomogeneous <<< { name: _ }
+              , runFilterFuzzy: Ocelot.Typeahead.defFilterFuzzy
               , runFilterItems: \items _ -> items
               , search: "foo"
               , selected: Nothing 
@@ -63,6 +66,7 @@ suite =
             Ocelot.Typeahead.getNewItems'
               { insertable: Ocelot.Typeahead.Insertable identity
               , itemToObject: Foreign.Object.fromHomogeneous <<< { name: _ }
+              , runFilterFuzzy: Ocelot.Typeahead.defFilterFuzzy
               , runFilterItems: \items _ -> items
               , search: "foo"
               , selected: Nothing 

--- a/test/Test/Typeahead.purs
+++ b/test/Test/Typeahead.purs
@@ -1,0 +1,83 @@
+module Test.Ocelot.Typeahead (suite) where
+
+import Prelude
+import Data.Array as Data.Array
+import Data.Fuzzy as Data.Fuzzy
+import Data.Maybe (Maybe(..))
+import Data.Maybe as Data.Maybe
+import Data.Newtype as Data.Newtype
+import Foreign.Object as Foreign.Object
+import Ocelot.Typeahead as Ocelot.Typeahead
+import Test.Unit as Test.Unit
+import Test.Unit.Assert as Test.Unit.Assert
+  
+suite :: Test.Unit.TestSuite
+suite =
+  Test.Unit.suite "Ocelot.Typeahead" do
+    Test.Unit.suite "getNewItems'" do
+      Test.Unit.test "filters out selected Array items and poor matches, and sorts results" do
+        let
+          actual =
+            Ocelot.Typeahead.getNewItems'
+              { insertable: Ocelot.Typeahead.NotInsertable 
+              , itemToObject: Foreign.Object.fromHomogeneous <<< { name: _ }
+              , runFilter: Data.Array.difference 
+              , search: "foo"
+              , selected: ["foo", "bar"]
+              }
+              ["foo", "food", "boof", "fooboo", "baz"]
+
+          expected = ["food", "fooboo"]
+        unfuzzyTestResults { actual, expected }
+      Test.Unit.test "filters out selected Maybeu item and poor matches, and sorts results" do
+        let
+          actual =
+            Ocelot.Typeahead.getNewItems'
+              { insertable: Ocelot.Typeahead.NotInsertable 
+              , itemToObject: Foreign.Object.fromHomogeneous <<< { name: _ }
+              , runFilter: \items -> Data.Maybe.maybe items (\item -> Data.Array.filter (_ /= item) items)
+              , search: "foo"
+              , selected: Just "foo"
+              }
+              ["foo", "food", "boof", "fooboo", "baz"]
+
+          expected = ["food", "fooboo"]
+        unfuzzyTestResults { actual, expected }
+      Test.Unit.test "inserts search to results without a perfect match" do
+        let
+          actual =
+            Ocelot.Typeahead.getNewItems'
+              { insertable: Ocelot.Typeahead.Insertable identity
+              , itemToObject: Foreign.Object.fromHomogeneous <<< { name: _ }
+              , runFilter: \items _ -> items
+              , search: "foo"
+              , selected: Nothing 
+              }
+              ["food"]
+
+          expected = ["foo", "food"]
+        unfuzzyTestResults { actual, expected }
+      Test.Unit.test "doesn't insert search into non-empty results" do
+        let
+          actual  =
+            Ocelot.Typeahead.getNewItems'
+              { insertable: Ocelot.Typeahead.Insertable identity
+              , itemToObject: Foreign.Object.fromHomogeneous <<< { name: _ }
+              , runFilter: \items _ -> items
+              , search: "foo"
+              , selected: Nothing 
+              }
+              ["foo", "food"]
+
+          expected = ["foo", "food"]
+        unfuzzyTestResults { actual, expected }
+
+unfuzzyTestResults ::
+  { actual :: Array (Data.Fuzzy.Fuzzy String)
+  , expected :: Array String
+  } ->
+  Test.Unit.Test
+unfuzzyTestResults config = Test.Unit.Assert.equal config.expected actual
+  where
+  actual :: Array String
+  actual = map (_.original <<< Data.Newtype.unwrap) config.actual

--- a/ui-guide/Components/Typeaheads.purs
+++ b/ui-guide/Components/Typeaheads.purs
@@ -195,7 +195,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "user"
               }
-              [ HH.slot _singleUser 0 TA.single
+              [ HH.slot _singleUser 0 TA.singleHighlightOnly
                 ( TA.asyncSingle
                   { renderFuzzy: Async.renderFuzzyUser
                   , itemToObject: Async.userToObject
@@ -216,7 +216,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "user-hydrated"
               }
-              [ HH.slot _singleUser 1 TA.single
+              [ HH.slot _singleUser 1 TA.singleHighlightOnly
                 ( TA.asyncSingle
                   { renderFuzzy: Async.renderFuzzyUser
                   , itemToObject: Async.userToObject
@@ -298,7 +298,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "users"
               }
-              [ HH.slot _multiUser 0 TA.multi
+              [ HH.slot _multiUser 0 TA.multiHighlightOnly
                 ( TA.asyncMulti
                   { renderFuzzy: Async.renderFuzzyUser
                   , itemToObject: Async.userToObject
@@ -319,7 +319,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "users-hydrated"
               }
-              [ HH.slot _multiUser 1 TA.multi
+              [ HH.slot _multiUser 1 TA.multiHighlightOnly
                 ( TA.asyncMulti
                   { renderFuzzy: Async.renderFuzzyUser
                   , itemToObject: Async.userToObject
@@ -443,7 +443,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "disabled-users-empty"
               }
-              [ HH.slot _multiUser 2 TA.multi
+              [ HH.slot _multiUser 2 TA.multiHighlightOnly
                 ( TA.asyncMulti
                   { renderFuzzy: Async.renderFuzzyUser
                   , itemToObject: Async.userToObject
@@ -465,7 +465,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "disabled-users-hydrated"
               }
-              [ HH.slot _multiUser 3 TA.multi
+              [ HH.slot _multiUser 3 TA.multiHighlightOnly
                 ( TA.asyncMulti
                   { renderFuzzy: Async.renderFuzzyUser
                   , itemToObject: Async.userToObject
@@ -487,7 +487,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "error-users"
               }
-              [ HH.slot _multiUser 4 TA.multi
+              [ HH.slot _multiUser 4 TA.multiHighlightOnly
                 ( TA.asyncMulti
                   { renderFuzzy: Async.renderFuzzyUser
                   , itemToObject: Async.userToObject
@@ -508,7 +508,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "loading-users"
               }
-              [ HH.slot _multiUser 5 TA.multi
+              [ HH.slot _multiUser 5 TA.multiHighlightOnly
                 ( TA.asyncMulti
                   { renderFuzzy: Async.renderFuzzyUser
                   , itemToObject: Async.userToObject
@@ -543,7 +543,8 @@ cnDocumentationBlocks =
                 ( TA.component
                   { runSelect: const <<< Just
                   , runRemove: const (const Nothing)
-                  , runFilter: const
+                  , runFilterFuzzy: identity
+                  , runFilterItems: const
                   }
                 )
                 { items: NotAsked
@@ -573,7 +574,8 @@ cnDocumentationBlocks =
               ( TA.component
                 { runSelect: const <<< Just
                 , runRemove: const (const Nothing)
-                , runFilter: const
+                , runFilterFuzzy: identity
+                , runFilterItems: const
                 }
               )
               { items: NotAsked


### PR DESCRIPTION
## What does this pull request do?

We've run into a scenario where the filtering and sorting our typeaheads do on results actually gets in the way. The filtering and sorting is very useful for synchronous data, or even asynchronous data when the endpoint doesn't have very good search functionality, but some endpoints will have the context to perform much better search than we can. We've run into one such example with FBCM-4107. When searching for Facebook pages, Facebook can take into account information that isn't returned, like recent name changes, or what the friendly URL is. If the user searches for one of these things but they're not present in the data Facebook returns, we'll end up filtering them out. To address this, we our Typeahead's filtering configurable.

## How should this be manually tested?

The tests should provide enough confidence, but if you want to go a step further and have a deployment of Ocelot:
- [ ] Load up `https://<your-hostname>/ocelot/#typeaheads` and verify the User typeaheads behave as expected

## Other notes

I'm not going to have the chance to wrap up [FBCM-4100](https://citizennet.atlassian.net/browse/FBCM-4100) this sprint, but assuming this passes review, the rest should be straightforward. We'll just to need update the Form DSL typeaheads to use `Ocelot.Typeahead.singleHighlightOnly` (if I remember correctly, the Custom Audiences endpoint doesn't allow querying, so we'd still use `Ocelot.Typeahead.multi` for that one).
