### PR TITLE
AS-1146 Add Slider Component

### DIFF
--- a/spago.dhall
+++ b/spago.dhall
@@ -27,6 +27,7 @@ Authors:
   , "halogen-renderless"
   , "halogen-select"
   , "halogen-storybook"
+  , "halogen-svg-elems"
   , "html-parser-halogen"
   , "js-timers"
   , "numbers"

--- a/src/Data/IntervalTree.purs
+++ b/src/Data/IntervalTree.purs
@@ -1,0 +1,197 @@
+-- | An optimal data structure for storing **closed** intervals
+-- |
+-- | Implementation is inspired by [Data structure for handling intervals](https://stackoverflow.com/questions/1982409/data-structure-for-handling-intervals)
+module Ocelot.Data.IntervalTree
+  ( IntervalPoint(..)
+  , IntervalTree
+  , findGreatestLowerBound
+  , findLeastUpperBound
+  , fromIntervals
+  , insertInterval
+  , lookupInterval
+  , toIntervals
+  ) where
+
+import Prelude
+
+import Data.Array as Data.Array
+import Data.FoldableWithIndex as Data.FoldableWithIndex
+import Data.Generic.Rep as Data.Generic.Rep
+import Data.Generic.Rep.Show as Data.Generic.Rep.Show
+import Data.Map as Data.Map
+import Data.Maybe (Maybe(..))
+import Data.Tuple as Data.Tuple
+
+type IntervalTree a = Data.Map.Map a IntervalPoint
+
+data IntervalPoint
+  = StartPoint
+  | EndPoint
+
+derive instance eqIntervalPoint :: Eq IntervalPoint
+
+derive instance genericIntervalPoint :: Data.Generic.Rep.Generic IntervalPoint _
+
+instance showIntervalPoint :: Show IntervalPoint where
+  show = Data.Generic.Rep.Show.genericShow
+
+-- | O(n log n)
+fromIntervals ::
+  forall a.
+  Ord a =>
+  Array { start :: a, end :: a } ->
+  IntervalTree a
+fromIntervals = Data.Array.foldl insertInterval mempty
+
+-- | O(log n)
+-- |
+-- | example: insert (4 9) into [ (1 4) (8 10) (12 15) ]
+-- | 1. mergeStart: merge StartPoint of the interval into the tree
+-- |   * 4 already exists but as an EndPoint so we remove it from the tree
+-- |   * result: [ (1 (8 10) (12 15) ]
+-- |     * NOTE temporarily invalid pairings will be fixed when clearBetween
+-- | 2. mergeEnd: merge EndPoint of the interval into the tree
+-- |   * 9 doesn't exist so we insert it into the tree as an EndPoint
+-- |   * result: [ (1 (8 9) 10) (12 15) ]
+-- | 3. clearBetween: remove values lying within the interval from the tree
+-- |   * lower bound of (4 is (1 in the original tree
+-- |   * upper bound of 9) is 10) in the original tree
+-- |   * 8 and 9 are within (1 10) so we remove them from the tree
+-- |   * result: [ (1 10) (12 15) ]
+insertInterval ::
+  forall a.
+  Ord a =>
+  IntervalTree a ->
+  { start :: a, end :: a } ->
+  IntervalTree a
+insertInterval old { start, end }
+  | start >= end = old
+  | otherwise = old # mergeStart >>> mergeEnd >>> clearBetween
+  where
+  mergeStart :: IntervalTree a -> IntervalTree a
+  mergeStart xs = case Data.Map.lookup start xs of
+    Nothing -> Data.Map.insert start StartPoint  xs
+    Just intervalPoint -> case intervalPoint of
+      StartPoint -> xs
+      EndPoint -> Data.Map.delete start xs
+
+  mergeEnd :: IntervalTree a -> IntervalTree a
+  mergeEnd xs = case Data.Map.lookup end xs of
+    Nothing -> Data.Map.insert end EndPoint xs
+    Just intervalPoint -> case intervalPoint of
+      StartPoint -> Data.Map.delete end xs
+      EndPoint -> xs
+
+  clearBetween :: IntervalTree a -> IntervalTree a
+  clearBetween xs =
+    Data.Map.submap Nothing (Just lowerBound) xs
+      <> Data.Map.submap (Just upperBound) Nothing xs
+
+  lowerBound :: a
+  lowerBound = case findGreatestLowerBound start old of
+    Nothing -> start
+    Just greatestLowerBound -> case greatestLowerBound.value of
+      StartPoint -> greatestLowerBound.key
+      EndPoint -> start
+
+  upperBound :: a
+  upperBound = case findLeastUpperBound end old of
+    Nothing -> end
+    Just leastUpperBound -> case leastUpperBound.value of
+      StartPoint -> end
+      EndPoint -> leastUpperBound.key
+
+-- | Get immediate interval around a point
+-- | O(log n)
+-- |
+-- | example: [ (1 3) (5 7) ]
+-- | * around 0: __ (1
+-- | * around 1: (1 3)
+-- | * around 2: (1 3)
+-- | * around 3: (1 3)
+-- | * around 4: 3) (5
+-- | * around 5: (5 7)
+-- | * around 6: (5 7)
+-- | * around 7: (5 7)
+-- | * around 8: 7) __
+lookupInterval ::
+  forall a.
+  Ord a =>
+  a ->
+  IntervalTree a ->
+  { left :: Maybe { key :: a, value :: IntervalPoint }
+  , right :: Maybe { key :: a, value :: IntervalPoint }
+  }
+lookupInterval x xs = case Data.Map.lookup x xs of
+  Nothing ->
+    { left: findGreatestLowerBound x xs
+    , right: findLeastUpperBound x xs
+    }
+  Just intervalPoint -> case intervalPoint of
+    StartPoint ->
+      { left: Just { key: x, value: StartPoint }
+      , right: findLeastUpperBound x xs
+      }
+    EndPoint ->
+      { left: findGreatestLowerBound x xs
+      , right: Just { key: x, value: EndPoint }
+      }
+
+-- | O(log n)
+findGreatestLowerBound ::
+  forall a.
+  Ord a =>
+  a ->
+  IntervalTree a ->
+  Maybe { key :: a, value :: IntervalPoint }
+findGreatestLowerBound x =
+  Data.Map.findMax
+    <<< Data.Map.delete x
+    <<< Data.Map.submap Nothing (Just x)
+
+-- | O(log n)
+findLeastUpperBound ::
+  forall a.
+  Ord a =>
+  a ->
+  IntervalTree a ->
+  Maybe { key :: a, value :: IntervalPoint }
+findLeastUpperBound x =
+  Data.Map.findMin
+    <<< Data.Map.delete x
+    <<< Data.Map.submap (Just x) Nothing
+
+-- | O(n)
+toIntervals ::
+  forall a.
+  IntervalTree a ->
+  Array { start :: a, end :: a }
+toIntervals = partitionsToIntervals <<< partitionIntervalTree
+  where
+  partitionsToIntervals ::
+    { start :: Array a , end :: Array a } ->
+    Array { start :: a, end :: a }
+  partitionsToIntervals partition =
+    map (Data.Tuple.uncurry { start: _, end: _ })
+      $ Data.Array.zip partition.start partition.end
+
+  partitionIntervalTree ::
+    IntervalTree a ->
+    { start :: Array a
+    , end :: Array a
+    }
+  partitionIntervalTree =
+    Data.FoldableWithIndex.foldlWithIndex reducer { start: [], end: [] }
+
+  reducer ::
+    a ->
+    { start :: Array a
+    , end :: Array a
+    } ->
+    IntervalPoint ->
+    { start :: Array a
+    , end :: Array a
+    }
+  reducer x old = case _ of
+    StartPoint -> old { start = Data.Array.snoc old.start x }
+    EndPoint -> old { end = Data.Array.snoc old.end x }

--- a/src/Slider.purs
+++ b/src/Slider.purs
@@ -1,0 +1,382 @@
+-- | * track = background track + interval(s)
+-- |   * thumb: draggable node on track
+-- |   * mark: static node on track
+-- | * axis
+module Ocelot.Slider
+  ( Interval(..)
+  , Output
+  , Query(..)
+  , Slot
+  , component
+  ) where
+
+import Prelude
+
+import Data.Array as Data.Array
+import Data.Int as Data.Int
+import Data.Maybe (Maybe(..))
+import Data.Monoid as Data.Monoid
+import Effect.Aff.Class (class MonadAff)
+import Effect.Class.Console as Effect.Class.Console
+import Halogen as Halogen
+import Halogen.HTML as Halogen.HTML
+import Halogen.HTML.Events as Halogen.HTML.Events
+import Halogen.Query.EventSource as Halogen.Query.EventSource
+import Halogen.Svg.Attributes as Halogen.Svg.Attributes
+import Ocelot.Slider.Render as Ocelot.Slider.Render
+import Web.Event.Event as Web.Event.Event
+import Web.HTML as Web.HTML
+import Web.HTML.Window as Web.HTML.Window
+import Web.UIEvent.MouseEvent as Web.UIEvent.MouseEvent
+import Web.UIEvent.MouseEvent.EventTypes as Web.UIEvent.MouseEvent.EventTypes
+
+type Slot = Halogen.Slot Query Output
+
+type Component m = Halogen.Component Halogen.HTML.HTML Query Input Output m
+type ComponentHTML m = Halogen.ComponentHTML Action ChildSlots m
+type ComponentM m a = Halogen.HalogenM State Action ChildSlots Output m a
+
+type State =
+  { input :: Input
+  , thumbs :: ThumbStatus
+  }
+
+data ThumbStatus
+  = Idle IdleState
+  | Editing EditingState
+
+type IdleState =
+  Array { percent :: Number }
+
+type EditingState =
+  { start ::
+      { positionX :: { px :: Number }
+      , value :: { percent :: Number }
+      }
+  , static :: Array { percent :: Number }
+  , moving :: { percent :: Number }
+  , subscriptions ::
+      { onMouseMove :: Halogen.SubscriptionId
+      , onMouseUp :: Halogen.SubscriptionId
+      }
+  }
+
+getThumbs :: ThumbStatus -> Array { percent :: Number }
+getThumbs = case _ of
+  Idle xs -> xs
+  Editing { static, moving } -> Data.Array.sort (static <> [ moving ])
+
+data Action
+  = MouseDownOnThumb Int Web.UIEvent.MouseEvent.MouseEvent
+  | MouseMoveWithThumb Web.UIEvent.MouseEvent.MouseEvent
+  | MouseUpFromThumb Web.UIEvent.MouseEvent.MouseEvent
+
+data Query a
+  = SetThumbCount Int a
+
+-- | * axis: a list of labels positioned under the track
+-- | * layout: see comments in Ocelot.Slider.Render
+-- | * marks
+-- |   * Nothing: thumbs can slide continuously
+-- |   * Just: thumbs can only sit on discrete positions specified by marks
+-- | * minDistance:
+-- |   * Nothing: allow overlapping thumbs
+-- |   * Just: minimal distance between any pair of thumbs
+-- | * renderIntervals: customized render for intervals between thumbs
+type Input =
+  { axis :: Maybe (Array { label :: String, percent :: Number })
+  , layout :: Ocelot.Slider.Render.Config
+  , marks :: Maybe (Array { percent :: Number })
+  , minDistance :: Maybe { percent :: Number }
+  , renderIntervals ::
+      Array Interval ->
+      Array Halogen.HTML.PlainHTML
+  }
+
+data Interval
+  = StartToThumb { start :: { percent :: Number }, thumb :: { percent :: Number } }
+  | BetweenThumbs { left :: { percent :: Number }, right :: { percent :: Number } }
+  | ThumbToEnd { thumb :: { percent :: Number }, end :: { percent :: Number } }
+
+data Output
+  = ValueChanged (Array { percent :: Number })
+
+type ChildSlots =
+  ()
+
+component ::
+  forall m.
+  MonadAff m =>
+  Component m
+component =
+  Halogen.mkComponent
+    { initialState
+    , render
+    , eval:
+        Halogen.mkEval
+          Halogen.defaultEval
+            { handleAction = handleAction
+            }
+    }
+
+initialState :: Input -> State
+initialState input =
+  { input
+  , thumbs: Idle [ { percent: 0.0 }, { percent: 50.0 } ] -- TODO AS-1146 leave one at 0.0 to start
+  }
+
+handleAction ::
+  forall m.
+  MonadAff m =>
+  Action ->
+  ComponentM m Unit
+handleAction = case _ of
+  MouseDownOnThumb index mouseEvent -> do
+    pauseEvent mouseEvent
+    Effect.Class.Console.log $ "MouseDown: " <> show index
+    state <- Halogen.get
+    case state.thumbs of
+      Editing _ -> pure unit
+      Idle idleState -> handleMouseDownOnThumb index mouseEvent idleState
+  MouseMoveWithThumb mouseEvent -> do
+    pauseEvent mouseEvent
+    state <- Halogen.get
+    case state.thumbs of
+      Idle _ -> pure unit
+      Editing editingState -> do
+        handleMouseMoveWithThumb mouseEvent state editingState
+  MouseUpFromThumb mouseEvent -> do
+    pauseEvent mouseEvent
+    Effect.Class.Console.log $ "MouseUp"
+    state <- Halogen.get
+    case state.thumbs of
+      Idle _ -> pure unit
+      Editing editingState -> handleMouseUpFromThumb mouseEvent editingState
+
+handleMouseDownOnThumb ::
+  forall m.
+  MonadAff m =>
+  Int ->
+  Web.UIEvent.MouseEvent.MouseEvent ->
+  IdleState ->
+  ComponentM m Unit
+handleMouseDownOnThumb index mouseEvent thumbs = case unsnocAt index thumbs of
+  Nothing -> pure unit
+  Just { item, rest } -> do
+    subscriptions <- listenAll
+    Halogen.modify_ _
+      { thumbs =
+          Editing
+            { start:
+              { positionX: getPositionX mouseEvent
+              , value: item
+              }
+            , static: rest
+            , moving: item
+            , subscriptions
+            }
+      }
+
+handleMouseMoveWithThumb ::
+  forall m.
+  MonadAff m =>
+  Web.UIEvent.MouseEvent.MouseEvent ->
+  State ->
+  EditingState ->
+  ComponentM m Unit
+handleMouseMoveWithThumb mouseEvent state old@{ start } = do
+  let
+    endPositionX :: { px :: Number }
+    endPositionX = getPositionX mouseEvent
+
+    diff :: { percent :: Number }
+    diff =
+      Ocelot.Slider.Render.pixelToPercent state.input.layout
+        (endPositionX - start.positionX)
+  Effect.Class.Console.log $ "MouseMove: " <> show diff.percent <> "%"
+  Halogen.modify_ _
+    { thumbs = Editing old { moving = start.value + diff } }
+
+handleMouseUpFromThumb ::
+  forall m.
+  Web.UIEvent.MouseEvent.MouseEvent ->
+  EditingState ->
+  ComponentM m Unit
+handleMouseUpFromThumb mouseEvent { static, moving, subscriptions } = do
+  muteAllListeners subscriptions
+  Halogen.modify_ \old ->
+    old { thumbs = Idle (Data.Array.sort (static <> [ moving ]))}
+
+getPositionX :: Web.UIEvent.MouseEvent.MouseEvent -> { px :: Number }
+getPositionX mouseEvent =
+  { px: _ } <<< Data.Int.toNumber
+    $ Web.UIEvent.MouseEvent.pageX mouseEvent
+
+listenAll ::
+  forall m.
+  MonadAff m =>
+  ComponentM m
+    { onMouseMove :: Halogen.SubscriptionId
+    , onMouseUp :: Halogen.SubscriptionId
+    }
+listenAll = do
+  window <- Halogen.liftEffect Web.HTML.window
+  onMouseMove <- listenOnMouseMove window
+  onMouseUp <- listenOnMouseUp window
+  pure { onMouseMove, onMouseUp }
+
+listenOnMouseMove ::
+  forall m.
+  MonadAff m =>
+  Web.HTML.Window.Window ->
+  ComponentM m Halogen.SubscriptionId
+listenOnMouseMove window = do
+  Halogen.subscribe
+    $ Halogen.Query.EventSource.eventListenerEventSource
+        Web.UIEvent.MouseEvent.EventTypes.mousemove
+        (Web.HTML.Window.toEventTarget window)
+        toAction
+  where
+  toAction :: Web.Event.Event.Event -> Maybe Action
+  toAction = map MouseMoveWithThumb <<< Web.UIEvent.MouseEvent.fromEvent
+
+listenOnMouseUp ::
+  forall m.
+  MonadAff m =>
+  Web.HTML.Window.Window ->
+  ComponentM m Halogen.SubscriptionId
+listenOnMouseUp window = do
+  Halogen.subscribe
+    $ Halogen.Query.EventSource.eventListenerEventSource
+        Web.UIEvent.MouseEvent.EventTypes.mouseup
+        (Web.HTML.Window.toEventTarget window)
+        toAction
+  where
+  toAction :: Web.Event.Event.Event -> Maybe Action
+  toAction = map MouseUpFromThumb <<< Web.UIEvent.MouseEvent.fromEvent
+
+muteAllListeners ::
+  forall m.
+  { onMouseMove :: Halogen.SubscriptionId
+  , onMouseUp :: Halogen.SubscriptionId
+  } ->
+  ComponentM m Unit
+muteAllListeners subscriptions = do
+  Halogen.unsubscribe subscriptions.onMouseMove
+  Halogen.unsubscribe subscriptions.onMouseUp
+
+pauseEvent ::
+  forall m.
+  MonadAff m =>
+  Web.UIEvent.MouseEvent.MouseEvent ->
+  ComponentM m Unit
+pauseEvent mouseEvent = do
+  let
+    event :: Web.Event.Event.Event
+    event = Web.UIEvent.MouseEvent.toEvent mouseEvent
+  Halogen.liftEffect
+    $ Web.Event.Event.stopPropagation event
+  Halogen.liftEffect
+    $ Web.Event.Event.preventDefault event
+
+render :: forall m. State -> ComponentHTML m
+render state =
+  Ocelot.Slider.Render.frame state.input.layout []
+    [ renderTrack state
+    , renderAxis state
+    , renderThumbs state
+    ]
+
+renderAxis :: forall m. State -> ComponentHTML m
+renderAxis state = case state.input.axis of
+  Nothing -> Halogen.HTML.text ""
+  Just axisData ->
+    Ocelot.Slider.Render.axisContainer state.input.layout
+      (Ocelot.Slider.Render.axis state.input.layout axisData)
+
+renderMarks :: forall m. State -> ComponentHTML m
+renderMarks state = case state.input.marks of
+  Nothing -> Halogen.HTML.text ""
+  Just marks ->
+    Ocelot.Slider.Render.markContainer state.input.layout
+      (renderMark state <$> marks)
+
+renderMark :: forall m. State -> { percent :: Number } -> ComponentHTML m
+renderMark state percent =
+  Ocelot.Slider.Render.mark state.input.layout percent
+    []
+
+renderThumbs :: forall m. State -> ComponentHTML m
+renderThumbs state =
+  Ocelot.Slider.Render.thumbContainer state.input.layout
+    (Data.Array.mapWithIndex (renderThumb state) (getThumbs state.thumbs))
+
+renderThumb :: forall m. State -> Int -> { percent :: Number } -> ComponentHTML m
+renderThumb state index percent =
+  Ocelot.Slider.Render.thumb state.input.layout percent
+    [ Halogen.HTML.Events.onMouseDown  (Just <<< MouseDownOnThumb index)
+    ]
+
+renderTrack :: forall m. State -> ComponentHTML m
+renderTrack state =
+  Ocelot.Slider.Render.trackContainer state.input.layout
+    ( [ Ocelot.Slider.Render.track state.input.layout
+        [ Halogen.Svg.Attributes.fill
+            (Just (Halogen.Svg.Attributes.RGB 229 229 229))
+        ]
+      , renderMarks state
+      ]
+        <> renderIntervals state
+    )
+
+renderIntervals :: forall m. State -> Array (ComponentHTML m)
+renderIntervals state =
+  map Halogen.HTML.fromPlainHTML
+    <<< state.input.renderIntervals
+    $ getIntervals (getThumbs state.thumbs)
+  where
+  getIntervals ::
+    Array { percent :: Number } ->
+    Array Interval
+  getIntervals xs = case Data.Array.uncons xs of
+    Nothing -> []
+    Just { head: firstThumb, tail: xs1 } -> do
+      case Data.Array.unsnoc xs1 of
+        Nothing ->
+          [ Data.Monoid.guard (boundary.start /= firstThumb)
+              [ StartToThumb { start: boundary.start, thumb: firstThumb } ]
+          , Data.Monoid.guard (firstThumb /= boundary.end)
+              [ ThumbToEnd { thumb: firstThumb, end: boundary.end } ]
+          ]
+            # join
+        Just { init: middle, last: lastThumb } ->
+          [ Data.Monoid.guard (boundary.start /= firstThumb)
+              [ StartToThumb { start: boundary.start, thumb: firstThumb } ]
+          , betweenThumbs firstThumb middle lastThumb
+          , Data.Monoid.guard (lastThumb /= boundary.end)
+              [ ThumbToEnd { thumb: lastThumb, end: boundary.end } ]
+          ]
+            # join
+
+  betweenThumbs ::
+    { percent :: Number } ->
+    Array { percent :: Number } ->
+    { percent :: Number } ->
+    Array Interval
+  betweenThumbs first middle last =
+    Data.Array.zipWith
+      (\left right -> BetweenThumbs { left, right })
+      ([ first ] <> middle)
+      (middle <> [ last ])
+
+unsnocAt :: forall a. Int -> Array a -> Maybe { item :: a , rest :: Array a }
+unsnocAt index xs = do
+  item <- Data.Array.index xs index
+  rest <- Data.Array.deleteAt index xs
+  pure { item, rest }
+
+---------------
+-- Constants --
+---------------
+boundary :: { start :: { percent :: Number }, end :: { percent :: Number } }
+boundary = { start: { percent: 0.0 }, end: { percent: 100.0 } }

--- a/src/Slider.purs
+++ b/src/Slider.purs
@@ -193,9 +193,16 @@ handleMouseMoveWithThumb mouseEvent state old@{ start } = do
     diff =
       Ocelot.Slider.Render.pixelToPercent state.input.layout
         (endPositionX - start.positionX)
+
+    end :: { percent :: Number }
+    end = start.value + diff
+
+    calibrated :: { percent :: Number }
+    calibrated = calibrateValue state { start: start.value, end }
+
   Effect.Class.Console.log $ "MouseMove: " <> show diff.percent <> "%"
   Halogen.modify_ _
-    { thumbs = Editing old { moving = start.value + diff } }
+    { thumbs = Editing old { moving = calibrated } }
 
 handleMouseUpFromThumb ::
   forall m.
@@ -211,6 +218,19 @@ getPositionX :: Web.UIEvent.MouseEvent.MouseEvent -> { px :: Number }
 getPositionX mouseEvent =
   { px: _ } <<< Data.Int.toNumber
     $ Web.UIEvent.MouseEvent.pageX mouseEvent
+
+calibrateValue ::
+  State ->
+  { start :: { percent :: Number }
+  , end :: { percent :: Number }
+  } ->
+  { percent :: Number }
+calibrateValue state { start, end } = trimBoundary end
+
+trimBoundary ::
+  { percent :: Number } ->
+  { percent :: Number }
+trimBoundary x = clamp boundary.start boundary.end x
 
 listenAll ::
   forall m.

--- a/src/Slider/Render.purs
+++ b/src/Slider/Render.purs
@@ -1,0 +1,178 @@
+module Ocelot.Slider.Render where
+
+import Prelude
+
+import Halogen.HTML as Halogen.HTML
+import Halogen.Svg.Attributes as Halogen.Svg.Attributes
+import Halogen.Svg.Elements as Halogen.Svg.Elements
+import Halogen.Svg.Indexed as Halogen.Svg.Indexed
+
+type Config =
+  { axisHeight :: Number
+  , betweenThumbAndAxis :: Number
+  , betweenTopAndThumb :: Number
+  , margin :: Number
+  , thumbRadius :: Number
+  , trackRadius :: Number
+  , trackWidth :: Number
+  }
+
+axisContainer ::
+  forall a config p.
+  { betweenThumbAndAxis :: Number
+  , betweenTopAndThumb :: Number
+  , thumbRadius :: Number
+  , trackWidth :: Number
+  | config
+  } ->
+  Array (Halogen.HTML.HTML p a) ->
+  Halogen.HTML.HTML p a
+axisContainer { betweenThumbAndAxis, betweenTopAndThumb, trackWidth, thumbRadius }  =
+  Halogen.Svg.Elements.g
+    [ Halogen.Svg.Attributes.transform
+      [ Halogen.Svg.Attributes.Translate
+        thumbRadius
+        (betweenTopAndThumb + thumbRadius * 2.0 + betweenThumbAndAxis)
+      ]
+    ]
+
+axis ::
+  forall a config p.
+  { trackWidth :: Number
+  | config
+  } ->
+  Array { label :: String, percent :: Number } ->
+  Array (Halogen.HTML.HTML p a)
+axis { trackWidth } = map mapper
+  where
+  mapper :: { label :: String, percent :: Number } -> Halogen.HTML.HTML p a
+  mapper { label, percent } = axisLabel label (trackWidth * percent / 100.0)
+
+axisLabel ::
+  forall a p.
+  String ->
+  Number ->
+  Halogen.HTML.HTML p a
+axisLabel label x =
+  Halogen.Svg.Elements.text
+    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
+    , Halogen.Svg.Attributes.transform
+      [ Halogen.Svg.Attributes.Translate x 0.0 ]
+    ]
+    [ Halogen.HTML.text label ]
+
+-- | NOTE assume thumbRadius > trackRadius
+frame ::
+  forall a config p.
+  { axisHeight :: Number
+  , betweenThumbAndAxis :: Number
+  , betweenTopAndThumb :: Number
+  , margin :: Number
+  , thumbRadius :: Number
+  , trackWidth :: Number
+  | config
+  } ->
+  Array (Halogen.HTML.IProp Halogen.Svg.Indexed.SVGsvg a) ->
+  Array (Halogen.HTML.HTML p a) ->
+  Halogen.HTML.HTML p a
+frame { axisHeight, betweenThumbAndAxis, betweenTopAndThumb, margin, trackWidth, thumbRadius } iprops html =
+  Halogen.Svg.Elements.svg
+    ( [ Halogen.Svg.Attributes.viewBox 0.0 0.0 viewBoxWidth viewBoxHeight
+      ]
+        <> iprops
+    )
+    [ Halogen.Svg.Elements.g
+      [ Halogen.Svg.Attributes.transform
+        [ Halogen.Svg.Attributes.Translate margin margin ]
+      ]
+      html
+    ]
+  where
+  viewBoxHeight :: Number
+  viewBoxHeight = margin + betweenTopAndThumb + thumbRadius * 2.0 + betweenThumbAndAxis + axisHeight + margin
+
+  viewBoxWidth :: Number
+  viewBoxWidth = margin + thumbRadius + trackWidth + thumbRadius + margin
+
+interval ::
+  forall a config p.
+  { trackRadius :: Number
+  , trackWidth :: Number
+  | config
+  } ->
+  { end :: Number
+  , start :: Number
+  } ->
+  Array (Halogen.HTML.IProp Halogen.Svg.Indexed.SVGrect a) ->
+  Halogen.HTML.HTML p a
+interval { trackRadius, trackWidth } percent iprops =
+  Halogen.Svg.Elements.rect
+    ( [ Halogen.Svg.Attributes.height (trackRadius * 2.0)
+      , Halogen.Svg.Attributes.width (trackWidth * (percent.end - percent.start) / 100.0)
+      , Halogen.Svg.Attributes.transform
+        [ Halogen.Svg.Attributes.Translate (trackWidth * percent.start / 100.0) 0.0 ]
+      ]
+        <> iprops
+    )
+
+thumbContainer ::
+  forall a config p.
+  { betweenTopAndThumb :: Number
+  , thumbRadius :: Number
+  | config
+  } ->
+  Array (Halogen.HTML.HTML p a) ->
+  Halogen.HTML.HTML p a
+thumbContainer { betweenTopAndThumb, thumbRadius }=
+  Halogen.Svg.Elements.g
+    [ Halogen.Svg.Attributes.transform
+      [ Halogen.Svg.Attributes.Translate
+        thumbRadius
+        (betweenTopAndThumb + thumbRadius)
+      ]
+    ]
+
+thumb ::
+  forall a config p.
+  { thumbRadius :: Number
+  , trackWidth :: Number
+  | config
+  } ->
+  { percent :: Number } ->
+  Array (Halogen.HTML.IProp Halogen.Svg.Indexed.SVGcircle a) ->
+  Halogen.HTML.HTML p a
+thumb { trackWidth, thumbRadius } { percent } iprops =
+  Halogen.Svg.Elements.circle
+    ( [ Halogen.Svg.Attributes.r thumbRadius
+      , Halogen.Svg.Attributes.fill (pure (Halogen.Svg.Attributes.RGB 255 255 255))
+      , Halogen.Svg.Attributes.stroke (pure (Halogen.Svg.Attributes.RGB 0 0 0))
+      , Halogen.Svg.Attributes.transform
+        [ Halogen.Svg.Attributes.Translate (trackWidth * percent / 100.0) 0.0 ]
+      ]
+        <> iprops
+    )
+
+trackContainer ::
+  forall a config p.
+  { betweenTopAndThumb :: Number
+  , thumbRadius :: Number
+  , trackRadius :: Number
+  | config
+  } ->
+  Array (Halogen.HTML.HTML p a) ->
+  Halogen.HTML.HTML p a
+trackContainer { betweenTopAndThumb, thumbRadius, trackRadius } =
+  Halogen.Svg.Elements.g
+    [ Halogen.Svg.Attributes.transform
+      [ Halogen.Svg.Attributes.Translate thumbRadius (betweenTopAndThumb + thumbRadius - trackRadius) ]
+    ]
+
+track ::
+  forall a config p.
+  { trackRadius :: Number
+  , trackWidth :: Number
+  | config
+  } ->
+  Array (Halogen.HTML.IProp Halogen.Svg.Indexed.SVGrect a) ->
+  Halogen.HTML.HTML p a
+track config = interval config { start: 0.0, end: 100.0 }

--- a/src/Slider/Render.purs
+++ b/src/Slider/Render.purs
@@ -11,6 +11,7 @@ type Config =
   { axisHeight :: Number
   , betweenThumbAndAxis :: Number
   , betweenTopAndThumb :: Number
+  , frameWidth :: { px :: Number }
   , margin :: Number
   , thumbRadius :: Number
   , trackRadius :: Number
@@ -67,6 +68,7 @@ frame ::
   { axisHeight :: Number
   , betweenThumbAndAxis :: Number
   , betweenTopAndThumb :: Number
+  , frameWidth :: { px :: Number }
   , margin :: Number
   , thumbRadius :: Number
   , trackWidth :: Number
@@ -75,9 +77,10 @@ frame ::
   Array (Halogen.HTML.IProp Halogen.Svg.Indexed.SVGsvg a) ->
   Array (Halogen.HTML.HTML p a) ->
   Halogen.HTML.HTML p a
-frame { axisHeight, betweenThumbAndAxis, betweenTopAndThumb, margin, trackWidth, thumbRadius } iprops html =
+frame { axisHeight, betweenThumbAndAxis, betweenTopAndThumb, frameWidth, margin, trackWidth, thumbRadius } iprops html =
   Halogen.Svg.Elements.svg
     ( [ Halogen.Svg.Attributes.viewBox 0.0 0.0 viewBoxWidth viewBoxHeight
+      , Halogen.Svg.Attributes.width frameWidth.px
       ]
         <> iprops
     )
@@ -100,17 +103,17 @@ interval ::
   , trackWidth :: Number
   | config
   } ->
-  { end :: Number
-  , start :: Number
+  { end :: { percent :: Number }
+  , start :: { percent :: Number }
   } ->
   Array (Halogen.HTML.IProp Halogen.Svg.Indexed.SVGrect a) ->
   Halogen.HTML.HTML p a
 interval { trackRadius, trackWidth } percent iprops =
   Halogen.Svg.Elements.rect
     ( [ Halogen.Svg.Attributes.height (trackRadius * 2.0)
-      , Halogen.Svg.Attributes.width (trackWidth * (percent.end - percent.start) / 100.0)
+      , Halogen.Svg.Attributes.width (trackWidth * (percent.end.percent - percent.start.percent) / 100.0)
       , Halogen.Svg.Attributes.transform
-        [ Halogen.Svg.Attributes.Translate (trackWidth * percent.start / 100.0) 0.0 ]
+        [ Halogen.Svg.Attributes.Translate (trackWidth * percent.start.percent / 100.0) 0.0 ]
       ]
         <> iprops
     )
@@ -206,4 +209,5 @@ track ::
   } ->
   Array (Halogen.HTML.IProp Halogen.Svg.Indexed.SVGrect a) ->
   Halogen.HTML.HTML p a
-track config = interval config { start: 0.0, end: 100.0 }
+track config = interval config { start: { percent: 0.0 }, end: { percent: 100.0 } }
+

--- a/src/Slider/Render.purs
+++ b/src/Slider/Render.purs
@@ -115,6 +115,37 @@ interval { trackRadius, trackWidth } percent iprops =
         <> iprops
     )
 
+markContainer ::
+  forall a config p.
+  { trackRadius :: Number
+  | config
+  } ->
+  Array (Halogen.HTML.HTML p a) ->
+  Halogen.HTML.HTML p a
+markContainer { trackRadius } =
+  Halogen.Svg.Elements.g
+    [ Halogen.Svg.Attributes.transform
+      [ Halogen.Svg.Attributes.Translate 0.0 trackRadius ]
+    ]
+
+mark ::
+  forall a config p.
+  { trackRadius :: Number
+  , trackWidth :: Number
+  | config
+  } ->
+  { percent :: Number } ->
+  Array (Halogen.HTML.IProp Halogen.Svg.Indexed.SVGcircle a) ->
+  Halogen.HTML.HTML p a
+mark { trackRadius, trackWidth } { percent } iprops =
+  Halogen.Svg.Elements.circle
+    ( [ Halogen.Svg.Attributes.r trackRadius
+      , Halogen.Svg.Attributes.transform
+        [ Halogen.Svg.Attributes.Translate (trackWidth * percent / 100.0) 0.0 ]
+      ]
+        <> iprops
+    )
+
 thumbContainer ::
   forall a config p.
   { betweenTopAndThumb :: Number
@@ -123,7 +154,7 @@ thumbContainer ::
   } ->
   Array (Halogen.HTML.HTML p a) ->
   Halogen.HTML.HTML p a
-thumbContainer { betweenTopAndThumb, thumbRadius }=
+thumbContainer { betweenTopAndThumb, thumbRadius } =
   Halogen.Svg.Elements.g
     [ Halogen.Svg.Attributes.transform
       [ Halogen.Svg.Attributes.Translate

--- a/src/Slider/Render.purs
+++ b/src/Slider/Render.purs
@@ -7,6 +7,12 @@ import Halogen.Svg.Attributes as Halogen.Svg.Attributes
 import Halogen.Svg.Elements as Halogen.Svg.Elements
 import Halogen.Svg.Indexed as Halogen.Svg.Indexed
 
+-- | frameWidth: the width of the SVG in pixel
+-- |
+-- | SVG layout (in user space unit)
+-- | * top to bottom: margin, betweenTopAndThumb, thumbRadius * 2.0,
+-- |   betweenThumbAndAxis, axisHeight, margin
+-- | * left to right: margin, thumbRadius, trackWidth, thumbRadius, margin
 type Config =
   { axisHeight :: Number
   , betweenThumbAndAxis :: Number
@@ -210,4 +216,26 @@ track ::
   Array (Halogen.HTML.IProp Halogen.Svg.Indexed.SVGrect a) ->
   Halogen.HTML.HTML p a
 track config = interval config { start: { percent: 0.0 }, end: { percent: 100.0 } }
+
+pixelToPercent ::
+  forall config.
+  { frameWidth :: { px :: Number }
+  , margin :: Number
+  , thumbRadius :: Number
+  , trackWidth :: Number
+  | config
+  } ->
+  { px :: Number } ->
+  { percent :: Number }
+pixelToPercent { frameWidth, margin, thumbRadius, trackWidth } x = { percent }
+  where
+  frameWidthInUnit :: Number
+  frameWidthInUnit = margin + thumbRadius + trackWidth + thumbRadius + margin
+
+  scale :: Number
+  scale = frameWidthInUnit / frameWidth.px
+
+  percent :: Number
+  percent = x.px * scale / trackWidth * 100.0
+
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,6 +3,7 @@ module Test.Main where
 import Prelude
 import Effect (Effect)
 import Test.Ocelot.Data.Currency as Test.Ocelot.Data.Currency
+import Test.Ocelot.Data.IntervalTree as Test.Ocelot.Data.IntervalTree
 import Test.Ocelot.HTML.Properties as Test.Ocelot.HTML.Properties
 import Test.Ocelot.Typeahead as Test.Ocelot.Typeahead
 import Test.Unit as Test.Unit
@@ -11,6 +12,7 @@ import Test.Unit.Main as Test.Unit.Main
 main :: Effect Unit
 main = Test.Unit.Main.runTest do
   Test.Unit.suite "Ocelet.Data.Currency" Test.Ocelot.Data.Currency.suite
+  Test.Ocelot.Data.IntervalTree.suite
   Test.Ocelot.HTML.Properties.suite
   Test.Ocelot.Typeahead.suite
 

--- a/test/Test/Data/IntervalTree.purs
+++ b/test/Test/Data/IntervalTree.purs
@@ -1,0 +1,398 @@
+module Test.Ocelot.Data.IntervalTree (suite) where
+
+import Prelude
+
+import Data.Map as Data.Map
+import Data.Maybe (Maybe(..))
+import Data.Tuple.Nested ((/\))
+import Ocelot.Data.IntervalTree as Ocelot.Data.IntervalTree
+import Test.Unit as Test.Unit
+import Test.Unit.Assert as Test.Unit.Assert
+
+suite :: Test.Unit.TestSuite
+suite =
+  Test.Unit.suite "Ocelot.Data.IntervalTree" do
+    findGreatestLowerBoundTests
+    findLeastUpperBoundTests
+    insertIntervalTests
+    fromIntervalsTests
+    toIntervalsTests
+    lookupIntervalTests
+
+insertIntervalTests :: Test.Unit.TestSuite
+insertIntervalTests =
+  Test.Unit.suite "insertIntervals" do
+    let
+      -- (1 3) (5 7)
+      intervalTree :: Ocelot.Data.IntervalTree.IntervalTree Int
+      intervalTree =
+        Data.Map.fromFoldable
+          [ 1 /\ Ocelot.Data.IntervalTree.StartPoint
+          , 3 /\ Ocelot.Data.IntervalTree.EndPoint
+          , 5 /\ Ocelot.Data.IntervalTree.StartPoint
+          , 7 /\ Ocelot.Data.IntervalTree.EndPoint
+          ]
+    Test.Unit.test "non-overlapping" do
+      let
+        -- (1 3) (5 7)
+        --             (9 11)
+        interval :: { start :: Int, end :: Int }
+        interval = { start: 9, end: 11 }
+
+        -- (1 3) (5 7) (9 11)
+        expected :: Ocelot.Data.IntervalTree.IntervalTree Int
+        expected =
+          Data.Map.fromFoldable
+            [ 1 /\ Ocelot.Data.IntervalTree.StartPoint
+            , 3 /\ Ocelot.Data.IntervalTree.EndPoint
+            , 5 /\ Ocelot.Data.IntervalTree.StartPoint
+            , 7 /\ Ocelot.Data.IntervalTree.EndPoint
+            , 9 /\ Ocelot.Data.IntervalTree.StartPoint
+            , 11 /\ Ocelot.Data.IntervalTree.EndPoint
+            ]
+
+        actual :: Ocelot.Data.IntervalTree.IntervalTree Int
+        actual = Ocelot.Data.IntervalTree.insertInterval intervalTree interval
+      Test.Unit.Assert.equal expected actual
+    Test.Unit.test "overlapping" do
+      let
+        -- (1 3) (5 7)
+        --   (3    6)
+        interval :: { start :: Int, end :: Int }
+        interval = { start: 3, end: 6 }
+
+        -- (1       7)
+        expected :: Ocelot.Data.IntervalTree.IntervalTree Int
+        expected =
+          Data.Map.fromFoldable
+          [ 1 /\ Ocelot.Data.IntervalTree.StartPoint
+          , 7 /\ Ocelot.Data.IntervalTree.EndPoint
+          ]
+
+        actual :: Ocelot.Data.IntervalTree.IntervalTree Int
+        actual = Ocelot.Data.IntervalTree.insertInterval intervalTree interval
+      Test.Unit.Assert.equal expected actual
+
+fromIntervalsTests :: Test.Unit.TestSuite
+fromIntervalsTests =
+  Test.Unit.suite "fromIntervals" do
+    Test.Unit.test "non-overlapping" do
+      let
+        intervals :: Array { start :: Int, end :: Int }
+        intervals =
+          [ { start: 1, end: 4 }
+          , { start: 8, end: 10 }
+          , { start: 12, end: 15 }
+          ]
+
+        expected :: Ocelot.Data.IntervalTree.IntervalTree Int
+        expected =
+          Data.Map.fromFoldable
+            [ 1 /\ Ocelot.Data.IntervalTree.StartPoint
+            , 4 /\ Ocelot.Data.IntervalTree.EndPoint
+            , 8 /\ Ocelot.Data.IntervalTree.StartPoint
+            , 10 /\ Ocelot.Data.IntervalTree.EndPoint
+            , 12 /\ Ocelot.Data.IntervalTree.StartPoint
+            , 15 /\ Ocelot.Data.IntervalTree.EndPoint
+            ]
+
+        actual :: Ocelot.Data.IntervalTree.IntervalTree Int
+        actual = Ocelot.Data.IntervalTree.fromIntervals intervals
+      Test.Unit.Assert.equal expected actual
+    Test.Unit.test "overlapping" do
+      let
+        intervals :: Array { start :: Int, end :: Int }
+        intervals =
+          [ { start: 1, end: 4 }
+          , { start: 4, end: 14 }
+          , { start: 12, end: 15 }
+          ]
+
+        expected :: Ocelot.Data.IntervalTree.IntervalTree Int
+        expected =
+          Data.Map.fromFoldable
+            [ 1 /\ Ocelot.Data.IntervalTree.StartPoint
+            , 15 /\ Ocelot.Data.IntervalTree.EndPoint
+            ]
+
+        actual :: Ocelot.Data.IntervalTree.IntervalTree Int
+        actual = Ocelot.Data.IntervalTree.fromIntervals intervals
+      Test.Unit.Assert.equal expected actual
+
+toIntervalsTests :: Test.Unit.TestSuite
+toIntervalsTests =
+  Test.Unit.test "toIntervals" do
+    let
+      intervalTree :: Ocelot.Data.IntervalTree.IntervalTree Int
+      intervalTree =
+        Data.Map.fromFoldable
+          [ 1 /\ Ocelot.Data.IntervalTree.StartPoint
+          , 4 /\ Ocelot.Data.IntervalTree.EndPoint
+          , 8 /\ Ocelot.Data.IntervalTree.StartPoint
+          , 10 /\ Ocelot.Data.IntervalTree.EndPoint
+          , 12 /\ Ocelot.Data.IntervalTree.StartPoint
+          , 15 /\ Ocelot.Data.IntervalTree.EndPoint
+          ]
+
+      expected :: Array { start :: Int, end :: Int }
+      expected =
+        [ { start: 1, end: 4 }
+        , { start: 8, end: 10 }
+        , { start: 12, end: 15 }
+        ]
+
+      actual :: Array { start :: Int, end :: Int }
+      actual = Ocelot.Data.IntervalTree.toIntervals intervalTree
+    Test.Unit.Assert.equal expected actual
+
+findGreatestLowerBoundTests :: Test.Unit.TestSuite
+findGreatestLowerBoundTests =
+  Test.Unit.suite "findGreatestLowerBound" do
+    let
+      -- (1 4) (8 10) (12 15)
+      intervalTree :: Ocelot.Data.IntervalTree.IntervalTree Int
+      intervalTree =
+        Data.Map.fromFoldable
+          [ 1 /\ Ocelot.Data.IntervalTree.StartPoint
+          , 4 /\ Ocelot.Data.IntervalTree.EndPoint
+          , 8 /\ Ocelot.Data.IntervalTree.StartPoint
+          , 10 /\ Ocelot.Data.IntervalTree.EndPoint
+          , 12 /\ Ocelot.Data.IntervalTree.StartPoint
+          , 15 /\ Ocelot.Data.IntervalTree.EndPoint
+          ]
+    Test.Unit.test "Just" do
+      let
+        -- (1 4) (8 10) (12 15)
+        --       <- ^^
+        point :: Int
+        point = 10
+
+        expected :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+        expected = Just { key: 8, value: Ocelot.Data.IntervalTree.StartPoint }
+
+        actual :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+        actual = Ocelot.Data.IntervalTree.findGreatestLowerBound point intervalTree
+      Test.Unit.Assert.equal expected actual
+    Test.Unit.test "Nothing" do
+      let
+        --   (1 4) (8 10) (12 15)
+        -- <- ^
+        point :: Int
+        point = 1
+
+        expected :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+        expected = Nothing
+
+        actual :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+        actual = Ocelot.Data.IntervalTree.findGreatestLowerBound point intervalTree
+      Test.Unit.Assert.equal expected actual
+
+findLeastUpperBoundTests :: Test.Unit.TestSuite
+findLeastUpperBoundTests =
+  Test.Unit.suite "findLeastUpperBound" do
+    let
+      -- (1 4) (8 10) (12 15)
+      intervalTree :: Ocelot.Data.IntervalTree.IntervalTree Int
+      intervalTree =
+        Data.Map.fromFoldable
+        [ 1 /\ Ocelot.Data.IntervalTree.StartPoint
+        , 4 /\ Ocelot.Data.IntervalTree.EndPoint
+        , 8 /\ Ocelot.Data.IntervalTree.StartPoint
+        , 10 /\ Ocelot.Data.IntervalTree.EndPoint
+        , 12 /\ Ocelot.Data.IntervalTree.StartPoint
+        , 15 /\ Ocelot.Data.IntervalTree.EndPoint
+        ]
+    Test.Unit.test "Just" do
+      let
+        -- (1 4) (8 10) (12 15)
+        --          ^^ ->
+        point :: Int
+        point = 10
+
+        expected :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+        expected = Just { key: 12, value: Ocelot.Data.IntervalTree.StartPoint }
+
+        actual :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+        actual = Ocelot.Data.IntervalTree.findLeastUpperBound point intervalTree
+      Test.Unit.Assert.equal expected actual
+    Test.Unit.test "Nothing" do
+      let
+        -- (1 4) (8 10) (12 15)
+        --                  ^^ ->
+        point :: Int
+        point = 15
+
+        expected :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+        expected = Nothing
+
+        actual :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+        actual = Ocelot.Data.IntervalTree.findLeastUpperBound point intervalTree
+      Test.Unit.Assert.equal expected actual
+
+lookupIntervalTests :: Test.Unit.TestSuite
+lookupIntervalTests =
+  Test.Unit.suite "lookupInterval" do
+    Test.Unit.test "empty tree" do
+      let
+        emptyTree :: Ocelot.Data.IntervalTree.IntervalTree Int
+        emptyTree = mempty
+
+        expected ::
+          { left :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          , right :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          }
+        expected =
+          { left: Nothing
+          , right: Nothing
+          }
+
+        actual ::
+          { left :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          , right :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          }
+        actual = Ocelot.Data.IntervalTree.lookupInterval 0 emptyTree
+      Test.Unit.Assert.equal expected actual
+
+    let
+      -- (1 3) (5 7)
+      intervalTree :: Ocelot.Data.IntervalTree.IntervalTree Int
+      intervalTree =
+        Data.Map.fromFoldable
+          [ 1 /\ Ocelot.Data.IntervalTree.StartPoint
+          , 3 /\ Ocelot.Data.IntervalTree.EndPoint
+          , 5 /\ Ocelot.Data.IntervalTree.StartPoint
+          , 7 /\ Ocelot.Data.IntervalTree.EndPoint
+          ]
+    Test.Unit.test "lower than all interval points in the tree" do
+      let
+        --   (1 3) (5 7)
+        -- ^
+        point :: Int
+        point = 0
+
+        expected ::
+          { left :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          , right :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          }
+        expected =
+          { left: Nothing
+          , right: Just { key: 1, value: Ocelot.Data.IntervalTree.StartPoint }
+          }
+
+        actual ::
+          { left :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          , right :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          }
+        actual = Ocelot.Data.IntervalTree.lookupInterval point intervalTree
+      Test.Unit.Assert.equal expected actual
+    Test.Unit.test "overlaps with a StartPoint in the tree" do
+      let
+        -- (1 3) (5 7)
+        --  ^
+        point :: Int
+        point = 1
+
+        expected ::
+          { left :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          , right :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          }
+        expected =
+          { left: Just { key: 1, value: Ocelot.Data.IntervalTree.StartPoint }
+          , right: Just { key: 3, value: Ocelot.Data.IntervalTree.EndPoint }
+          }
+
+        actual ::
+          { left :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          , right :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          }
+        actual = Ocelot.Data.IntervalTree.lookupInterval point intervalTree
+      Test.Unit.Assert.equal expected actual
+    Test.Unit.test "lying within an interval in the tree" do
+      let
+        -- (1 3) (5 7)
+        --   ^
+        point :: Int
+        point = 2
+
+        expected ::
+          { left :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          , right :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          }
+        expected =
+          { left: Just { key: 1, value: Ocelot.Data.IntervalTree.StartPoint }
+          , right: Just { key: 3, value: Ocelot.Data.IntervalTree.EndPoint }
+          }
+
+        actual ::
+          { left :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          , right :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          }
+        actual = Ocelot.Data.IntervalTree.lookupInterval point intervalTree
+      Test.Unit.Assert.equal expected actual
+    Test.Unit.test "overlaps with an EndPoint in the tree" do
+      let
+        -- (1 3) (5 7)
+        --    ^
+        point :: Int
+        point = 3
+
+        expected ::
+          { left :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          , right :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          }
+        expected =
+          { left: Just { key: 1, value: Ocelot.Data.IntervalTree.StartPoint }
+          , right: Just { key: 3, value: Ocelot.Data.IntervalTree.EndPoint }
+          }
+
+        actual ::
+          { left :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          , right :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          }
+        actual = Ocelot.Data.IntervalTree.lookupInterval point intervalTree
+      Test.Unit.Assert.equal expected actual
+    Test.Unit.test "lying outsides all intervals in the tree" do
+      let
+        -- (1 3) (5 7)
+        --      ^
+        point :: Int
+        point = 4
+
+        expected ::
+          { left :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          , right :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          }
+        expected =
+          { left: Just { key: 3, value: Ocelot.Data.IntervalTree.EndPoint }
+          , right: Just { key: 5, value: Ocelot.Data.IntervalTree.StartPoint }
+          }
+
+        actual ::
+          { left :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          , right :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          }
+        actual = Ocelot.Data.IntervalTree.lookupInterval point intervalTree
+      Test.Unit.Assert.equal expected actual
+    Test.Unit.test "greater than all interval points in the tree" do
+      let
+        -- (1 3) (5 7)
+        --             ^
+        point :: Int
+        point = 8
+
+        expected ::
+          { left :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          , right :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          }
+        expected =
+          { left: Just { key: 7, value: Ocelot.Data.IntervalTree.EndPoint }
+          , right: Nothing
+          }
+
+        actual ::
+          { left :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          , right :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }
+          }
+        actual = Ocelot.Data.IntervalTree.lookupInterval point intervalTree
+      Test.Unit.Assert.equal expected actual
+

--- a/ui-guide/Components/Diagram.purs
+++ b/ui-guide/Components/Diagram.purs
@@ -2,12 +2,14 @@ module UIGuide.Component.Diagram where
 
 import Prelude
 
+import Data.Array as Data.Array
+import Data.Int as Data.Int
 import Halogen as Halogen
 import Halogen.HTML as Halogen.HTML
 import Halogen.Svg.Attributes as Halogen.Svg.Attributes
-import Halogen.Svg.Elements as Halogen.Svg.Elements
 import Ocelot.Block.Card as Card
 import Ocelot.Block.Diagram as Ocelot.Block.Diagram
+import Ocelot.Slider.Render as Ocelot.Slider.Render
 import Ocelot.HTML.Properties as Ocelot.HTML.Properties
 import UIGuide.Block.Backdrop as Backdrop
 import UIGuide.Block.Documentation as Documentation
@@ -80,123 +82,23 @@ render _ =
         , Card.card_
           [ Halogen.HTML.p
             [ Ocelot.HTML.Properties.css "flex items-center" ]
-            [ Halogen.Svg.Elements.svg
-              [ Halogen.Svg.Attributes.width 400.0
-              , Halogen.Svg.Attributes.viewBox 0.0 0.0 viewBoxWidth viewBoxHeight
-              ]
-              [ Halogen.Svg.Elements.g
-                [ Halogen.Svg.Attributes.transform
-                  [ Halogen.Svg.Attributes.Translate margin margin ]
-                ]
-                [ Halogen.Svg.Elements.g
-                  [ Halogen.Svg.Attributes.transform
-                    [ Halogen.Svg.Attributes.Translate thumbRadius (betweenTopAndThumb + thumbRadius - trackRadius) ]
-                  ]
-                  [ Halogen.Svg.Elements.rect
+            [ Ocelot.Slider.Render.frame config
+                [ Halogen.Svg.Attributes.width 400.0 ]
+                [ Ocelot.Slider.Render.trackContainer config
+                  [ Ocelot.Slider.Render.track config
                     [ Halogen.Svg.Attributes.fill (pure (Halogen.Svg.Attributes.RGB 229 229 229))
-                    , Halogen.Svg.Attributes.height trackHeight
-                    , Halogen.Svg.Attributes.width trackWidth
                     ]
-                  , Halogen.Svg.Elements.rect
-                    [ Halogen.Svg.Attributes.fill (pure (Halogen.Svg.Attributes.RGB 126 135 148))
-                    , Halogen.Svg.Attributes.height trackHeight
-                    , Halogen.Svg.Attributes.width (trackWidth * (percentB - percentA) / 100.0)
-                    , Halogen.Svg.Attributes.transform
-                      [ Halogen.Svg.Attributes.Translate (trackWidth * percentA / 100.0) 0.0 ]
-                    ]
+                  , Ocelot.Slider.Render.interval config
+                      { start: percentA , end: percentB }
+                      [ Halogen.Svg.Attributes.fill (pure (Halogen.Svg.Attributes.RGB 126 135 148)) ]
                   ]
-                , Halogen.Svg.Elements.g
-                  [ Halogen.Svg.Attributes.transform
-                    [ Halogen.Svg.Attributes.Translate thumbRadius (betweenTopAndThumb + thumbRadius) ]
+                , Ocelot.Slider.Render.thumbContainer config
+                  [ Ocelot.Slider.Render.thumb config { percent: percentA } []
+                  , Ocelot.Slider.Render.thumb config { percent: percentB } []
                   ]
-                  [ Halogen.Svg.Elements.circle
-                    [ Halogen.Svg.Attributes.r 12.5
-                    , Halogen.Svg.Attributes.fill (pure (Halogen.Svg.Attributes.RGB 255 255 255))
-                    , Halogen.Svg.Attributes.stroke (pure (Halogen.Svg.Attributes.RGB 0 0 0))
-                    , Halogen.Svg.Attributes.transform
-                      [ Halogen.Svg.Attributes.Translate (trackWidth * percentA / 100.0) 0.0 ]
-                    ]
-                  , Halogen.Svg.Elements.circle
-                    [ Halogen.Svg.Attributes.r 12.5
-                    , Halogen.Svg.Attributes.fill (pure (Halogen.Svg.Attributes.RGB 255 255 255))
-                    , Halogen.Svg.Attributes.stroke (pure (Halogen.Svg.Attributes.RGB 0 0 0))
-                    , Halogen.Svg.Attributes.transform
-                      [ Halogen.Svg.Attributes.Translate (trackWidth * percentB / 100.0) 0.0 ]
-                    ]
-                  ]
-                , Halogen.Svg.Elements.g
-                  [ Halogen.Svg.Attributes.transform
-                    [ Halogen.Svg.Attributes.Translate thumbRadius (betweenTopAndThumb + thumbRadius * 2.0 + betweenThumbAndAxis) ]
-                  ]
-                  [ Halogen.Svg.Elements.text
-                    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
-                    , Halogen.Svg.Attributes.transform
-                      [ Halogen.Svg.Attributes.Translate 0.0 0.0 ]
-                    ]
-                    [ Halogen.HTML.text "0%" ]
-                  , Halogen.Svg.Elements.text
-                    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
-                    , Halogen.Svg.Attributes.transform
-                      [ Halogen.Svg.Attributes.Translate 40.0 0.0 ]
-                    ]
-                    [ Halogen.HTML.text "1%" ]
-                  , Halogen.Svg.Elements.text
-                    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
-                    , Halogen.Svg.Attributes.transform
-                      [ Halogen.Svg.Attributes.Translate 80.0 0.0 ]
-                    ]
-                    [ Halogen.HTML.text "2%" ]
-                  , Halogen.Svg.Elements.text
-                    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
-                    , Halogen.Svg.Attributes.transform
-                      [ Halogen.Svg.Attributes.Translate 120.0 0.0 ]
-                    ]
-                    [ Halogen.HTML.text "3%" ]
-                  , Halogen.Svg.Elements.text
-                    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
-                    , Halogen.Svg.Attributes.transform
-                      [ Halogen.Svg.Attributes.Translate 160.0 0.0 ]
-                    ]
-                    [ Halogen.HTML.text "4%" ]
-                  , Halogen.Svg.Elements.text
-                    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
-                    , Halogen.Svg.Attributes.transform
-                      [ Halogen.Svg.Attributes.Translate 200.0 0.0 ]
-                    ]
-                    [ Halogen.HTML.text "5%" ]
-                  , Halogen.Svg.Elements.text
-                    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
-                    , Halogen.Svg.Attributes.transform
-                      [ Halogen.Svg.Attributes.Translate 240.0 0.0 ]
-                    ]
-                    [ Halogen.HTML.text "6%" ]
-                  , Halogen.Svg.Elements.text
-                    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
-                    , Halogen.Svg.Attributes.transform
-                      [ Halogen.Svg.Attributes.Translate 280.0 0.0 ]
-                    ]
-                    [ Halogen.HTML.text "7%" ]
-                  , Halogen.Svg.Elements.text
-                    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
-                    , Halogen.Svg.Attributes.transform
-                      [ Halogen.Svg.Attributes.Translate 320.0 0.0 ]
-                    ]
-                    [ Halogen.HTML.text "8%" ]
-                  , Halogen.Svg.Elements.text
-                    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
-                    , Halogen.Svg.Attributes.transform
-                      [ Halogen.Svg.Attributes.Translate 360.0 0.0 ]
-                    ]
-                    [ Halogen.HTML.text "9%" ]
-                  , Halogen.Svg.Elements.text
-                    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
-                    , Halogen.Svg.Attributes.transform
-                      [ Halogen.Svg.Attributes.Translate 400.0 0.0 ]
-                    ]
-                    [ Halogen.HTML.text "10%" ]
-                  ]
+                , Ocelot.Slider.Render.axisContainer config
+                    (Ocelot.Slider.Render.axis config axisData)
                 ]
-              ]
             ]
           ]
         ]
@@ -210,12 +112,12 @@ render _ =
   percentB :: Number
   percentB = 100.0
 
-  -- | NOTE assume thumbRadius > trackRadius
-  viewBoxHeight :: Number
-  viewBoxHeight = margin + betweenTopAndThumb + thumbRadius * 2.0 + betweenThumbAndAxis + axisHeight + margin
+  trackHeight :: Number
+  trackHeight = trackRadius * 2.0
 
-  viewBoxWidth :: Number
-  viewBoxWidth = margin + thumbRadius + trackWidth + thumbRadius + margin
+  -- | NOTE assume thumbRadius > trackRadius
+  config :: Ocelot.Slider.Render.Config
+  config = { axisHeight, betweenThumbAndAxis, betweenTopAndThumb, margin, trackWidth, trackRadius, thumbRadius }
 
   margin :: Number
   margin = 5.0
@@ -235,8 +137,14 @@ render _ =
   trackWidth :: Number
   trackWidth = 400.0
 
-  trackHeight :: Number
-  trackHeight = trackRadius * 2.0
-
   trackRadius :: Number
   trackRadius = 2.5
+
+axisData :: Array { label :: String, percent :: Number }
+axisData = toLabel <$> Data.Array.range 0 10
+  where
+  toLabel :: Int -> { label :: String, percent :: Number }
+  toLabel index =
+    { label: show index <> "%"
+    , percent: (Data.Int.toNumber index) * 10.0
+    }

--- a/ui-guide/Components/Diagram.purs
+++ b/ui-guide/Components/Diagram.purs
@@ -82,8 +82,7 @@ render _ =
         , Card.card_
           [ Halogen.HTML.p
             [ Ocelot.HTML.Properties.css "flex items-center" ]
-            [ Ocelot.Slider.Render.frame config
-                [ Halogen.Svg.Attributes.width 400.0 ]
+            [ Ocelot.Slider.Render.frame config []
                 [ Ocelot.Slider.Render.trackContainer config
                   [ Ocelot.Slider.Render.track config
                     [ Halogen.Svg.Attributes.fill (pure (Halogen.Svg.Attributes.RGB 229 229 229))
@@ -95,7 +94,7 @@ render _ =
 
                     ]
                   , Ocelot.Slider.Render.interval config
-                      { start: percentA , end: percentB }
+                      { start: { percent: percentA } , end: { percent: percentB } }
                       [ Halogen.Svg.Attributes.fill (pure (Halogen.Svg.Attributes.RGB 126 135 148)) ]
                   ]
                 , Ocelot.Slider.Render.thumbContainer config
@@ -123,7 +122,10 @@ render _ =
 
   -- | NOTE assume thumbRadius > trackRadius
   config :: Ocelot.Slider.Render.Config
-  config = { axisHeight, betweenThumbAndAxis, betweenTopAndThumb, margin, trackWidth, trackRadius, thumbRadius }
+  config = { axisHeight, betweenThumbAndAxis, betweenTopAndThumb, frameWidth, margin, trackWidth, trackRadius, thumbRadius }
+
+  frameWidth :: { px :: Number }
+  frameWidth = { px: 400.0 }
 
   margin :: Number
   margin = 5.0

--- a/ui-guide/Components/Diagram.purs
+++ b/ui-guide/Components/Diagram.purs
@@ -4,6 +4,8 @@ import Prelude
 
 import Halogen as Halogen
 import Halogen.HTML as Halogen.HTML
+import Halogen.Svg.Attributes as Halogen.Svg.Attributes
+import Halogen.Svg.Elements as Halogen.Svg.Elements
 import Ocelot.Block.Card as Card
 import Ocelot.Block.Diagram as Ocelot.Block.Diagram
 import Ocelot.HTML.Properties as Ocelot.HTML.Properties
@@ -75,6 +77,128 @@ render _ =
               [ Halogen.HTML.text (show percentB <> "%")]
             ]
           ]
+        , Card.card_
+          [ Halogen.HTML.p
+            [ Ocelot.HTML.Properties.css "flex items-center" ]
+            [ Halogen.Svg.Elements.svg
+              [ Halogen.Svg.Attributes.width 400.0
+              , Halogen.Svg.Attributes.viewBox 0.0 0.0 viewBoxWidth viewBoxHeight
+              ]
+              [ Halogen.Svg.Elements.g
+                [ Halogen.Svg.Attributes.transform
+                  [ Halogen.Svg.Attributes.Translate margin margin ]
+                ]
+                [ Halogen.Svg.Elements.g
+                  [ Halogen.Svg.Attributes.transform
+                    [ Halogen.Svg.Attributes.Translate thumbRadius (betweenTopAndThumb + thumbRadius - trackRadius) ]
+                  ]
+                  [ Halogen.Svg.Elements.rect
+                    [ Halogen.Svg.Attributes.fill (pure (Halogen.Svg.Attributes.RGB 229 229 229))
+                    , Halogen.Svg.Attributes.height trackHeight
+                    , Halogen.Svg.Attributes.width trackWidth
+                    ]
+                  , Halogen.Svg.Elements.rect
+                    [ Halogen.Svg.Attributes.fill (pure (Halogen.Svg.Attributes.RGB 126 135 148))
+                    , Halogen.Svg.Attributes.height trackHeight
+                    , Halogen.Svg.Attributes.width (trackWidth * (percentB - percentA) / 100.0)
+                    , Halogen.Svg.Attributes.transform
+                      [ Halogen.Svg.Attributes.Translate (trackWidth * percentA / 100.0) 0.0 ]
+                    ]
+                  ]
+                , Halogen.Svg.Elements.g
+                  [ Halogen.Svg.Attributes.transform
+                    [ Halogen.Svg.Attributes.Translate thumbRadius (betweenTopAndThumb + thumbRadius) ]
+                  ]
+                  [ Halogen.Svg.Elements.circle
+                    [ Halogen.Svg.Attributes.r 12.5
+                    , Halogen.Svg.Attributes.fill (pure (Halogen.Svg.Attributes.RGB 255 255 255))
+                    , Halogen.Svg.Attributes.stroke (pure (Halogen.Svg.Attributes.RGB 0 0 0))
+                    , Halogen.Svg.Attributes.transform
+                      [ Halogen.Svg.Attributes.Translate (trackWidth * percentA / 100.0) 0.0 ]
+                    ]
+                  , Halogen.Svg.Elements.circle
+                    [ Halogen.Svg.Attributes.r 12.5
+                    , Halogen.Svg.Attributes.fill (pure (Halogen.Svg.Attributes.RGB 255 255 255))
+                    , Halogen.Svg.Attributes.stroke (pure (Halogen.Svg.Attributes.RGB 0 0 0))
+                    , Halogen.Svg.Attributes.transform
+                      [ Halogen.Svg.Attributes.Translate (trackWidth * percentB / 100.0) 0.0 ]
+                    ]
+                  ]
+                , Halogen.Svg.Elements.g
+                  [ Halogen.Svg.Attributes.transform
+                    [ Halogen.Svg.Attributes.Translate thumbRadius (betweenTopAndThumb + thumbRadius * 2.0 + betweenThumbAndAxis) ]
+                  ]
+                  [ Halogen.Svg.Elements.text
+                    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
+                    , Halogen.Svg.Attributes.transform
+                      [ Halogen.Svg.Attributes.Translate 0.0 0.0 ]
+                    ]
+                    [ Halogen.HTML.text "0%" ]
+                  , Halogen.Svg.Elements.text
+                    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
+                    , Halogen.Svg.Attributes.transform
+                      [ Halogen.Svg.Attributes.Translate 40.0 0.0 ]
+                    ]
+                    [ Halogen.HTML.text "1%" ]
+                  , Halogen.Svg.Elements.text
+                    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
+                    , Halogen.Svg.Attributes.transform
+                      [ Halogen.Svg.Attributes.Translate 80.0 0.0 ]
+                    ]
+                    [ Halogen.HTML.text "2%" ]
+                  , Halogen.Svg.Elements.text
+                    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
+                    , Halogen.Svg.Attributes.transform
+                      [ Halogen.Svg.Attributes.Translate 120.0 0.0 ]
+                    ]
+                    [ Halogen.HTML.text "3%" ]
+                  , Halogen.Svg.Elements.text
+                    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
+                    , Halogen.Svg.Attributes.transform
+                      [ Halogen.Svg.Attributes.Translate 160.0 0.0 ]
+                    ]
+                    [ Halogen.HTML.text "4%" ]
+                  , Halogen.Svg.Elements.text
+                    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
+                    , Halogen.Svg.Attributes.transform
+                      [ Halogen.Svg.Attributes.Translate 200.0 0.0 ]
+                    ]
+                    [ Halogen.HTML.text "5%" ]
+                  , Halogen.Svg.Elements.text
+                    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
+                    , Halogen.Svg.Attributes.transform
+                      [ Halogen.Svg.Attributes.Translate 240.0 0.0 ]
+                    ]
+                    [ Halogen.HTML.text "6%" ]
+                  , Halogen.Svg.Elements.text
+                    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
+                    , Halogen.Svg.Attributes.transform
+                      [ Halogen.Svg.Attributes.Translate 280.0 0.0 ]
+                    ]
+                    [ Halogen.HTML.text "7%" ]
+                  , Halogen.Svg.Elements.text
+                    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
+                    , Halogen.Svg.Attributes.transform
+                      [ Halogen.Svg.Attributes.Translate 320.0 0.0 ]
+                    ]
+                    [ Halogen.HTML.text "8%" ]
+                  , Halogen.Svg.Elements.text
+                    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
+                    , Halogen.Svg.Attributes.transform
+                      [ Halogen.Svg.Attributes.Translate 360.0 0.0 ]
+                    ]
+                    [ Halogen.HTML.text "9%" ]
+                  , Halogen.Svg.Elements.text
+                    [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
+                    , Halogen.Svg.Attributes.transform
+                      [ Halogen.Svg.Attributes.Translate 400.0 0.0 ]
+                    ]
+                    [ Halogen.HTML.text "10%" ]
+                  ]
+                ]
+              ]
+            ]
+          ]
         ]
       ]
     ]
@@ -85,3 +209,34 @@ render _ =
 
   percentB :: Number
   percentB = 100.0
+
+  -- | NOTE assume thumbRadius > trackRadius
+  viewBoxHeight :: Number
+  viewBoxHeight = margin + betweenTopAndThumb + thumbRadius * 2.0 + betweenThumbAndAxis + axisHeight + margin
+
+  viewBoxWidth :: Number
+  viewBoxWidth = margin + thumbRadius + trackWidth + thumbRadius + margin
+
+  margin :: Number
+  margin = 5.0
+
+  betweenTopAndThumb :: Number
+  betweenTopAndThumb = 20.0
+
+  betweenThumbAndAxis :: Number
+  betweenThumbAndAxis = 20.0
+
+  axisHeight :: Number
+  axisHeight = 20.0
+
+  thumbRadius :: Number
+  thumbRadius = 10.0
+
+  trackWidth :: Number
+  trackWidth = 400.0
+
+  trackHeight :: Number
+  trackHeight = trackRadius * 2.0
+
+  trackRadius :: Number
+  trackRadius = 2.5

--- a/ui-guide/Components/Diagram.purs
+++ b/ui-guide/Components/Diagram.purs
@@ -88,6 +88,12 @@ render _ =
                   [ Ocelot.Slider.Render.track config
                     [ Halogen.Svg.Attributes.fill (pure (Halogen.Svg.Attributes.RGB 229 229 229))
                     ]
+                  , Ocelot.Slider.Render.markContainer config
+                    [ Ocelot.Slider.Render.mark config { percent: 0.0 } []
+                    , Ocelot.Slider.Render.mark config { percent: 10.0 } []
+                    , Ocelot.Slider.Render.mark config { percent: 20.0 } []
+
+                    ]
                   , Ocelot.Slider.Render.interval config
                       { start: percentA , end: percentB }
                       [ Halogen.Svg.Attributes.fill (pure (Halogen.Svg.Attributes.RGB 126 135 148)) ]

--- a/ui-guide/Components/FormControl.purs
+++ b/ui-guide/Components/FormControl.purs
@@ -40,6 +40,7 @@ data Query a
 data Action
   = HandleFormHeaderClick MouseEvent
   | ToggleFormPanel MouseEvent
+  | HandleSlider Ocelot.Slider.Output
 
 type Input = Unit
 
@@ -69,6 +70,10 @@ handleAction ::
 handleAction = case _ of
   HandleFormHeaderClick _ -> do
     Halogen.liftEffect (log "submit form")
+
+  HandleSlider output -> case output of
+    Ocelot.Slider.ValueChanged xs -> do
+      Halogen.liftEffect (log ("slider: " <> show xs))
 
   ToggleFormPanel _ -> do
     state <- Halogen.get
@@ -119,7 +124,7 @@ render state =
               , minDistance: Just { percent: 10.0 }
               , renderIntervals: Data.Array.foldMap renderInterval
               }
-              (const Nothing)
+              (Just <<< HandleSlider)
             ]
           , Card.card
             [ css "flex-1" ]
@@ -134,7 +139,7 @@ render state =
               , minDistance: Just { percent: 10.0 }
               , renderIntervals: Data.Array.foldMap renderInterval
               }
-              (const Nothing)
+              (Just <<< HandleSlider)
             ]
           ]
         ]

--- a/ui-guide/Components/FormControl.purs
+++ b/ui-guide/Components/FormControl.purs
@@ -2,11 +2,11 @@ module UIGuide.Component.FormControl where
 
 import Prelude
 
-import Effect.Aff (Aff)
+import Effect.Aff.Class (class MonadAff)
 import Effect.Console (log)
-import Halogen as H
-import Halogen.HTML as HH
-import Halogen.HTML.Properties as HP
+import Halogen as Halogen
+import Halogen.HTML as Halogen.HTML
+import Halogen.HTML.Properties as Halogen.HTML.Propreties
 import Ocelot.Block.Checkbox as Checkbox
 import Ocelot.Block.FormField as FormField
 import Ocelot.Block.Format as Format
@@ -16,6 +16,13 @@ import Ocelot.HTML.Properties (css)
 import UIGuide.Block.Backdrop as Backdrop
 import UIGuide.Block.Documentation as Documentation
 import Web.UIEvent.MouseEvent (MouseEvent)
+
+type Component m = Halogen.Component Halogen.HTML.HTML Query Input Output m
+
+type ComponentHTML m = Halogen.ComponentHTML Action ChildSlots m
+
+type ComponentM m a = Halogen.HalogenM State Action ChildSlots Output m a
+
 
 type State =
   { formPanelIsOpen :: Boolean }
@@ -27,357 +34,367 @@ data Action
 
 type Input = Unit
 
-type Message = Void
+type Output = Void
 
-component :: H.Component HH.HTML Query Input Message Aff
+type ChildSlots =
+  ()
+
+component ::
+  forall m.
+  MonadAff m =>
+  Component m
 component =
-  H.mkComponent
+  Halogen.mkComponent
     { initialState: const { formPanelIsOpen: false }
     , render
-    , eval: H.mkEval $ H.defaultEval { handleAction = handleAction }
+    , eval: Halogen.mkEval $ Halogen.defaultEval { handleAction = handleAction }
     }
-  where
-    handleAction :: Action -> H.HalogenM State Action () Message Aff Unit
-    handleAction = case _ of
-      HandleFormHeaderClick _ -> do
-        H.liftEffect (log "submit form")
 
-      ToggleFormPanel _ -> do
-        state <- H.get
-        H.modify_ (_ { formPanelIsOpen = not state.formPanelIsOpen })
+handleAction ::
+  forall m.
+  MonadAff m =>
+  Action ->
+  ComponentM m Unit
+handleAction = case _ of
+  HandleFormHeaderClick _ -> do
+    Halogen.liftEffect (log "submit form")
 
-    render :: State -> H.ComponentHTML Action () Aff
-    render state =
-      let content = Backdrop.content [ css "flex" ]
-          accessibilityCallout =
-            Documentation.callout_
-              [ Backdrop.backdropWhite
-                [ css "flex-col" ]
-                [ Format.subHeading_
-                  [ Icon.tip [ css "text-yellow pr-2" ]
-                  , HH.text "Accessibility Note"
-                  ]
-                , HH.p_
-                  [ HH.text "Make sure to use "
-                  , HH.code_ [ HH.text "FormField.fieldset" ]
-                  , HH.text " instead of "
-                  , HH.code_ [ HH.text "FormField.field" ]
-                  , HH.text " with groups of radios and checkboxes."
-                  ]
-                ]
+  ToggleFormPanel _ -> do
+    state <- Halogen.get
+    Halogen.modify_ (_ { formPanelIsOpen = not state.formPanelIsOpen })
+
+render :: forall m. State -> ComponentHTML m
+render state =
+  let content = Backdrop.content [ css "flex" ]
+      accessibilityCallout =
+        Documentation.callout_
+          [ Backdrop.backdropWhite
+            [ css "flex-col" ]
+            [ Format.subHeading_
+              [ Icon.tip [ css "text-yellow pr-2" ]
+              , Halogen.HTML.text "Accessibility Note"
               ]
-        in
-      HH.div_
-        [ Documentation.customBlock_
-          { header: "Checkboxes"
-          , subheader: "Select one or more options."
-          }
-          [ accessibilityCallout
-          , Documentation.callout_
-            [ Backdrop.backdrop_
-              [ content
-                [ HH.div
-                  [ css "flex-1" ]
-                  [ HH.h3
-                    [ HP.classes Format.captionClasses ]
-                    [ HH.text "Vertical List" ]
-                  , FormField.fieldset_
-                    { label: HH.text "Platform"
-                    , inputId: "checkbox-vertical"
-                    , helpText: [ HH.text "Where do you want your ad to appear?" ]
-                    , error: []
-                    }
-                    [ HH.div_
-                      [ Checkbox.checkbox_
-                        [ HP.name "platform"
-                        , HP.checked true
-                        ]
-                        [ HH.text "Facebook" ]
-                      , Checkbox.checkbox_
-                        [ HP.name "platform" ]
-                        [ HH.text "Instagram" ]
-                      , Checkbox.checkbox_
-                        [ HP.name "platform" ]
-                        [ HH.text "Twitter" ]
-                      ]
-                    ]
-                  ]
-                , HH.div
-                  [ css "flex-1" ]
-                  [ HH.h3
-                    [ HP.classes Format.captionClasses ]
-                    [ HH.text "Horizontal List" ]
-                  , FormField.fieldset_
-                    { label: HH.text "Platform"
-                    , inputId: "checkbox-horizontal"
-                    , helpText: [ HH.text "Where do you want your ad to appear?" ]
-                    , error: []
-                    }
-                    [ HH.div
-                      [ css "flex" ]
-                      [ Checkbox.checkbox
-                        [ css "pr-6" ]
-                        [ HP.name "platform"
-                        , HP.checked true
-                        ]
-                        [ HH.text "Facebook" ]
-                      , Checkbox.checkbox
-                        [ css "pr-6" ]
-                        [ HP.name "platform" ]
-                        [ HH.text "Instagram" ]
-                      , Checkbox.checkbox
-                        [ css "pr-6" ]
-                        [ HP.name "platform" ]
-                        [ HH.text "Twitter" ]
-                      ]
-                    ]
-                  ]
-                ]
+            , Halogen.HTML.p_
+              [ Halogen.HTML.text "Make sure to use "
+              , Halogen.HTML.code_ [ Halogen.HTML.text "FormField.fieldset" ]
+              , Halogen.HTML.text " instead of "
+              , Halogen.HTML.code_ [ Halogen.HTML.text "FormField.field" ]
+              , Halogen.HTML.text " with groups of radios and checkboxes."
               ]
             ]
-          , Documentation.callout_
-            [ Backdrop.backdrop_
-              [ content
-                [ HH.div
-                  [ css "flex-1" ]
-                  [ HH.h3
-                    [ HP.classes Format.captionClasses ]
-                    [ HH.text "Disabled Vertical List" ]
-                  , FormField.fieldset_
-                    { label: HH.text "Platform"
-                    , inputId: "checkbox-vertical-disabled"
-                    , helpText: [ HH.text "Where do you want your ad to appear?" ]
-                    , error: []
-                    }
-                    [ HH.div_
-                      [ Checkbox.checkbox_
-                        [ HP.name "platform-disabled"
-                        , HP.checked true
-                        , HP.disabled true
-                        ]
-                        [ HH.text "Facebook" ]
-                      , Checkbox.checkbox_
-                        [ HP.name "platform-disabled"
-                        , HP.disabled true
-                        ]
-                        [ HH.text "Instagram" ]
-                      , Checkbox.checkbox_
-                        [ HP.name "platform-disabled"
-                        , HP.disabled true
-                        ]
-                        [ HH.text "Twitter" ]
-                      ]
+          ]
+    in
+  Halogen.HTML.div_
+    [ Documentation.customBlock_
+      { header: "Checkboxes"
+      , subheader: "Select one or more options."
+      }
+      [ accessibilityCallout
+      , Documentation.callout_
+        [ Backdrop.backdrop_
+          [ content
+            [ Halogen.HTML.div
+              [ css "flex-1" ]
+              [ Halogen.HTML.h3
+                [ Halogen.HTML.Propreties.classes Format.captionClasses ]
+                [ Halogen.HTML.text "Vertical List" ]
+              , FormField.fieldset_
+                { label: Halogen.HTML.text "Platform"
+                , inputId: "checkbox-vertical"
+                , helpText: [ Halogen.HTML.text "Where do you want your ad to appear?" ]
+                , error: []
+                }
+                [ Halogen.HTML.div_
+                  [ Checkbox.checkbox_
+                    [ Halogen.HTML.Propreties.name "platform"
+                    , Halogen.HTML.Propreties.checked true
                     ]
+                    [ Halogen.HTML.text "Facebook" ]
+                  , Checkbox.checkbox_
+                    [ Halogen.HTML.Propreties.name "platform" ]
+                    [ Halogen.HTML.text "Instagram" ]
+                  , Checkbox.checkbox_
+                    [ Halogen.HTML.Propreties.name "platform" ]
+                    [ Halogen.HTML.text "Twitter" ]
                   ]
-                , HH.div
-                  [ css "flex-1" ]
-                  [ HH.h3
-                    [ HP.classes Format.captionClasses ]
-                    [ HH.text "Disabled Horizontal List" ]
-                  , FormField.fieldset_
-                    { label: HH.text "Platform"
-                    , inputId: "checkbox-horizontal-disabled"
-                    , helpText: [ HH.text "Where do you want your ad to appear?" ]
-                    , error: []
-                    }
-                    [ HH.div
-                      [ css "flex" ]
-                      [ Checkbox.checkbox
-                        [ css "pr-6" ]
-                        [ HP.name "platform-disabled"
-                        , HP.checked true
-                        , HP.disabled true
-                        ]
-                        [ HH.text "Facebook" ]
-                      , Checkbox.checkbox
-                        [ css "pr-6" ]
-                        [ HP.name "platform-disabled"
-                        , HP.disabled true
-                        ]
-                        [ HH.text "Instagram" ]
-                      , Checkbox.checkbox
-                        [ css "pr-6" ]
-                        [ HP.name "platform-disabled"
-                        , HP.disabled true
-                        ]
-                        [ HH.text "Twitter" ]
-                      ]
+                ]
+              ]
+            , Halogen.HTML.div
+              [ css "flex-1" ]
+              [ Halogen.HTML.h3
+                [ Halogen.HTML.Propreties.classes Format.captionClasses ]
+                [ Halogen.HTML.text "Horizontal List" ]
+              , FormField.fieldset_
+                { label: Halogen.HTML.text "Platform"
+                , inputId: "checkbox-horizontal"
+                , helpText: [ Halogen.HTML.text "Where do you want your ad to appear?" ]
+                , error: []
+                }
+                [ Halogen.HTML.div
+                  [ css "flex" ]
+                  [ Checkbox.checkbox
+                    [ css "pr-6" ]
+                    [ Halogen.HTML.Propreties.name "platform"
+                    , Halogen.HTML.Propreties.checked true
                     ]
+                    [ Halogen.HTML.text "Facebook" ]
+                  , Checkbox.checkbox
+                    [ css "pr-6" ]
+                    [ Halogen.HTML.Propreties.name "platform" ]
+                    [ Halogen.HTML.text "Instagram" ]
+                  , Checkbox.checkbox
+                    [ css "pr-6" ]
+                    [ Halogen.HTML.Propreties.name "platform" ]
+                    [ Halogen.HTML.text "Twitter" ]
                   ]
                 ]
               ]
             ]
           ]
-        , Documentation.customBlock_
-          { header: "Radios"
-          , subheader: "Select one option."
-          }
-          [ accessibilityCallout
-          , Documentation.callout_
-            [ Backdrop.backdrop_
-              [ content
-                [ HH.div
-                  [ css "flex-1" ]
-                  [ HH.h3
-                    [ HP.classes Format.captionClasses ]
-                    [ HH.text "Vertical List" ]
-                  , FormField.fieldset_
-                    { label: HH.text "Optimization Goal"
-                    , inputId: "radio-vertical"
-                    , helpText: [ HH.text "What do you want to optimize for?" ]
-                    , error: []
-                    }
-                    [ HH.div_
-                      [ Radio.radio_
-                        [ HP.name "goal"
-                        , HP.checked true
-                        ]
-                        [ HH.text "Page Likes" ]
-                      , Radio.radio_
-                        [ HP.name "goal" ]
-                        [ HH.text "Impressions" ]
-                      , Radio.radio_
-                        [ HP.name "goal" ]
-                        [ HH.text "Page Engagement" ]
-                      ]
+        ]
+      , Documentation.callout_
+        [ Backdrop.backdrop_
+          [ content
+            [ Halogen.HTML.div
+              [ css "flex-1" ]
+              [ Halogen.HTML.h3
+                [ Halogen.HTML.Propreties.classes Format.captionClasses ]
+                [ Halogen.HTML.text "Disabled Vertical List" ]
+              , FormField.fieldset_
+                { label: Halogen.HTML.text "Platform"
+                , inputId: "checkbox-vertical-disabled"
+                , helpText: [ Halogen.HTML.text "Where do you want your ad to appear?" ]
+                , error: []
+                }
+                [ Halogen.HTML.div_
+                  [ Checkbox.checkbox_
+                    [ Halogen.HTML.Propreties.name "platform-disabled"
+                    , Halogen.HTML.Propreties.checked true
+                    , Halogen.HTML.Propreties.disabled true
                     ]
-                  ]
-                , HH.div
-                  [ css "flex-1" ]
-                  [ HH.h3
-                    [ HP.classes Format.captionClasses ]
-                    [ HH.text "Horizontal List" ]
-                  , FormField.fieldset_
-                    { label: HH.text "Previews"
-                    , inputId: "radio-horizontal"
-                    , helpText: [ HH.text "What kind of preview do you want to see?" ]
-                    , error: []
-                    }
-                    [ HH.div
-                      [ css "flex" ]
-                      [ Radio.radio
-                        [ css "pr-6" ]
-                        [ HP.name "preview"
-                        , HP.checked true
-                        ]
-                        [ HH.text "Desktop" ]
-                      , Radio.radio
-                        [ css "pr-6" ]
-                        [ HP.name "preview" ]
-                        [ HH.text "Story" ]
-                      , Radio.radio
-                        [ css "pr-6" ]
-                        [ HP.name "preview" ]
-                        [ HH.text "Mobile" ]
-                      ]
+                    [ Halogen.HTML.text "Facebook" ]
+                  , Checkbox.checkbox_
+                    [ Halogen.HTML.Propreties.name "platform-disabled"
+                    , Halogen.HTML.Propreties.disabled true
                     ]
+                    [ Halogen.HTML.text "Instagram" ]
+                  , Checkbox.checkbox_
+                    [ Halogen.HTML.Propreties.name "platform-disabled"
+                    , Halogen.HTML.Propreties.disabled true
+                    ]
+                    [ Halogen.HTML.text "Twitter" ]
                   ]
                 ]
               ]
-            ]
-          , Documentation.callout_
-            [ Backdrop.backdrop_
-              [ content
-                [ HH.div
-                  [ css "flex-1" ]
-                  [ HH.h3
-                    [ HP.classes Format.captionClasses ]
-                    [ HH.text "Disabled Vertical List" ]
-                  , FormField.fieldset_
-                    { label: HH.text "Optimization Goal"
-                    , inputId: "radio-vertical-disabled"
-                    , helpText: [ HH.text "What do you want to optimize for?" ]
-                    , error: []
-                    }
-                    [ HH.div_
-                      [ Radio.radio_
-                        [ HP.name "goal-disabled"
-                        , HP.checked true
-                        , HP.disabled true
-                        ]
-                        [ HH.text "Page Likes" ]
-                      , Radio.radio_
-                        [ HP.name "goal-disabled"
-                        , HP.disabled true
-                        ]
-                        [ HH.text "Impressions" ]
-                      , Radio.radio_
-                        [ HP.name "goal-disabled"
-                        , HP.disabled true
-                        ]
-                        [ HH.text "Page Engagement" ]
-                      ]
+            , Halogen.HTML.div
+              [ css "flex-1" ]
+              [ Halogen.HTML.h3
+                [ Halogen.HTML.Propreties.classes Format.captionClasses ]
+                [ Halogen.HTML.text "Disabled Horizontal List" ]
+              , FormField.fieldset_
+                { label: Halogen.HTML.text "Platform"
+                , inputId: "checkbox-horizontal-disabled"
+                , helpText: [ Halogen.HTML.text "Where do you want your ad to appear?" ]
+                , error: []
+                }
+                [ Halogen.HTML.div
+                  [ css "flex" ]
+                  [ Checkbox.checkbox
+                    [ css "pr-6" ]
+                    [ Halogen.HTML.Propreties.name "platform-disabled"
+                    , Halogen.HTML.Propreties.checked true
+                    , Halogen.HTML.Propreties.disabled true
                     ]
-                  ]
-                , HH.div
-                  [ css "flex-1" ]
-                  [ HH.h3
-                    [ HP.classes Format.captionClasses ]
-                    [ HH.text "Horizontal List" ]
-                  , FormField.fieldset_
-                    { label: HH.text "Disabled Previews"
-                    , inputId: "radio-horizontal-disabled"
-                    , helpText: [ HH.text "What kind of preview do you want to see?" ]
-                    , error: []
-                    }
-                    [ HH.div
-                      [ css "flex" ]
-                      [ Radio.radio
-                        [ css "pr-6" ]
-                        [ HP.name "preview-disabled"
-                        , HP.checked true
-                        , HP.disabled true
-                        ]
-                        [ HH.text "Desktop" ]
-                      , Radio.radio
-                        [ css "pr-6" ]
-                        [ HP.name "preview-disabled"
-                        , HP.disabled true
-                        ]
-                        [ HH.text "Story" ]
-                      , Radio.radio
-                        [ css "pr-6" ]
-                        [ HP.name "preview-disabled"
-                        , HP.disabled true
-                        ]
-                        [ HH.text "Mobile" ]
-                      ]
+                    [ Halogen.HTML.text "Facebook" ]
+                  , Checkbox.checkbox
+                    [ css "pr-6" ]
+                    [ Halogen.HTML.Propreties.name "platform-disabled"
+                    , Halogen.HTML.Propreties.disabled true
                     ]
+                    [ Halogen.HTML.text "Instagram" ]
+                  , Checkbox.checkbox
+                    [ css "pr-6" ]
+                    [ Halogen.HTML.Propreties.name "platform-disabled"
+                    , Halogen.HTML.Propreties.disabled true
+                    ]
+                    [ Halogen.HTML.text "Twitter" ]
                   ]
                 ]
               ]
             ]
           ]
-        -- TODO
-        -- , Documentation.block_
-          -- { header: "Ranges"
-          -- , subheader: "Select a numeric value between a min and max" }
-          -- [ Backdrop.backdrop_
-            -- [ HH.h3
-              -- [ HP.classes Format.captionClasses ]
-              -- [ HH.text "Standalone Range Input" ]
-            -- , Range.range
-              -- [ HP.id_ "range_"
-              -- , HP.min 0.0
-              -- , HP.max 100.0
-              -- ]
-            -- ]
-          -- , Backdrop.backdrop_
-            -- [ HH.h3
-              -- [ HP.classes Format.captionClasses ]
-              -- [ HH.text "Range Input with Form Control" ]
-            -- , FormField.field_
-              -- { label: HH.text "Dave's OO Emails"
-              -- , helpText: [ HH.text "How many do you want?" ]
-              -- , error: []
-              -- , inputId: "range"
-              -- }
-              -- [ Range.range
-                -- [ HP.id_ "range"
-                -- , HP.min 0.0
-                -- , HP.max 100.0
-                -- ]
-              -- ]
+        ]
+      ]
+    , Documentation.customBlock_
+      { header: "Radios"
+      , subheader: "Select one option."
+      }
+      [ accessibilityCallout
+      , Documentation.callout_
+        [ Backdrop.backdrop_
+          [ content
+            [ Halogen.HTML.div
+              [ css "flex-1" ]
+              [ Halogen.HTML.h3
+                [ Halogen.HTML.Propreties.classes Format.captionClasses ]
+                [ Halogen.HTML.text "Vertical List" ]
+              , FormField.fieldset_
+                { label: Halogen.HTML.text "Optimization Goal"
+                , inputId: "radio-vertical"
+                , helpText: [ Halogen.HTML.text "What do you want to optimize for?" ]
+                , error: []
+                }
+                [ Halogen.HTML.div_
+                  [ Radio.radio_
+                    [ Halogen.HTML.Propreties.name "goal"
+                    , Halogen.HTML.Propreties.checked true
+                    ]
+                    [ Halogen.HTML.text "Page Likes" ]
+                  , Radio.radio_
+                    [ Halogen.HTML.Propreties.name "goal" ]
+                    [ Halogen.HTML.text "Impressions" ]
+                  , Radio.radio_
+                    [ Halogen.HTML.Propreties.name "goal" ]
+                    [ Halogen.HTML.text "Page Engagement" ]
+                  ]
+                ]
+              ]
+            , Halogen.HTML.div
+              [ css "flex-1" ]
+              [ Halogen.HTML.h3
+                [ Halogen.HTML.Propreties.classes Format.captionClasses ]
+                [ Halogen.HTML.text "Horizontal List" ]
+              , FormField.fieldset_
+                { label: Halogen.HTML.text "Previews"
+                , inputId: "radio-horizontal"
+                , helpText: [ Halogen.HTML.text "What kind of preview do you want to see?" ]
+                , error: []
+                }
+                [ Halogen.HTML.div
+                  [ css "flex" ]
+                  [ Radio.radio
+                    [ css "pr-6" ]
+                    [ Halogen.HTML.Propreties.name "preview"
+                    , Halogen.HTML.Propreties.checked true
+                    ]
+                    [ Halogen.HTML.text "Desktop" ]
+                  , Radio.radio
+                    [ css "pr-6" ]
+                    [ Halogen.HTML.Propreties.name "preview" ]
+                    [ Halogen.HTML.text "Story" ]
+                  , Radio.radio
+                    [ css "pr-6" ]
+                    [ Halogen.HTML.Propreties.name "preview" ]
+                    [ Halogen.HTML.text "Mobile" ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      , Documentation.callout_
+        [ Backdrop.backdrop_
+          [ content
+            [ Halogen.HTML.div
+              [ css "flex-1" ]
+              [ Halogen.HTML.h3
+                [ Halogen.HTML.Propreties.classes Format.captionClasses ]
+                [ Halogen.HTML.text "Disabled Vertical List" ]
+              , FormField.fieldset_
+                { label: Halogen.HTML.text "Optimization Goal"
+                , inputId: "radio-vertical-disabled"
+                , helpText: [ Halogen.HTML.text "What do you want to optimize for?" ]
+                , error: []
+                }
+                [ Halogen.HTML.div_
+                  [ Radio.radio_
+                    [ Halogen.HTML.Propreties.name "goal-disabled"
+                    , Halogen.HTML.Propreties.checked true
+                    , Halogen.HTML.Propreties.disabled true
+                    ]
+                    [ Halogen.HTML.text "Page Likes" ]
+                  , Radio.radio_
+                    [ Halogen.HTML.Propreties.name "goal-disabled"
+                    , Halogen.HTML.Propreties.disabled true
+                    ]
+                    [ Halogen.HTML.text "Impressions" ]
+                  , Radio.radio_
+                    [ Halogen.HTML.Propreties.name "goal-disabled"
+                    , Halogen.HTML.Propreties.disabled true
+                    ]
+                    [ Halogen.HTML.text "Page Engagement" ]
+                  ]
+                ]
+              ]
+            , Halogen.HTML.div
+              [ css "flex-1" ]
+              [ Halogen.HTML.h3
+                [ Halogen.HTML.Propreties.classes Format.captionClasses ]
+                [ Halogen.HTML.text "Horizontal List" ]
+              , FormField.fieldset_
+                { label: Halogen.HTML.text "Disabled Previews"
+                , inputId: "radio-horizontal-disabled"
+                , helpText: [ Halogen.HTML.text "What kind of preview do you want to see?" ]
+                , error: []
+                }
+                [ Halogen.HTML.div
+                  [ css "flex" ]
+                  [ Radio.radio
+                    [ css "pr-6" ]
+                    [ Halogen.HTML.Propreties.name "preview-disabled"
+                    , Halogen.HTML.Propreties.checked true
+                    , Halogen.HTML.Propreties.disabled true
+                    ]
+                    [ Halogen.HTML.text "Desktop" ]
+                  , Radio.radio
+                    [ css "pr-6" ]
+                    [ Halogen.HTML.Propreties.name "preview-disabled"
+                    , Halogen.HTML.Propreties.disabled true
+                    ]
+                    [ Halogen.HTML.text "Story" ]
+                  , Radio.radio
+                    [ css "pr-6" ]
+                    [ Halogen.HTML.Propreties.name "preview-disabled"
+                    , Halogen.HTML.Propreties.disabled true
+                    ]
+                    [ Halogen.HTML.text "Mobile" ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    -- TODO
+    -- , Documentation.block_
+      -- { header: "Ranges"
+      -- , subheader: "Select a numeric value between a min and max" }
+      -- [ Backdrop.backdrop_
+        -- [ Halogen.HTML.h3
+          -- [ Halogen.HTML.Propreties.classes Format.captionClasses ]
+          -- [ Halogen.HTML.text "Standalone Range Input" ]
+        -- , Range.range
+          -- [ Halogen.HTML.Propreties.id_ "range_"
+          -- , Halogen.HTML.Propreties.min 0.0
+          -- , Halogen.HTML.Propreties.max 100.0
+          -- ]
+        -- ]
+      -- , Backdrop.backdrop_
+        -- [ Halogen.HTML.h3
+          -- [ Halogen.HTML.Propreties.classes Format.captionClasses ]
+          -- [ Halogen.HTML.text "Range Input with Form Control" ]
+        -- , FormField.field_
+          -- { label: Halogen.HTML.text "Dave's OO Emails"
+          -- , helpText: [ Halogen.HTML.text "How many do you want?" ]
+          -- , error: []
+          -- , inputId: "range"
+          -- }
+          -- [ Range.range
+            -- [ Halogen.HTML.Propreties.id_ "range"
+            -- , Halogen.HTML.Propreties.min 0.0
+            -- , Halogen.HTML.Propreties.max 100.0
             -- ]
           -- ]
-        ]
+        -- ]
+      -- ]
+    ]

--- a/ui-guide/Components/FormControl.purs
+++ b/ui-guide/Components/FormControl.purs
@@ -177,6 +177,46 @@ render state =
             [ Halogen.HTML.h3
               [ Halogen.HTML.Propreties.classes Ocelot.Block.Format.captionClasses ]
               [ Halogen.HTML.text "Continuous" ]
+            , Halogen.HTML.div
+              [ css "flex" ]
+              [ Radio.radio
+                [ css "pr-6" ]
+                [ Halogen.HTML.Propreties.name "slider-continuous"
+                , Halogen.HTML.Propreties.checked true
+                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 1 "continuous")
+                ]
+                [ Halogen.HTML.text "1" ]
+              , Radio.radio
+                [ css "pr-6" ]
+                [ Halogen.HTML.Propreties.name "slider-continuous"
+                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 2 "continuous")
+                ]
+                [ Halogen.HTML.text "2" ]
+              , Radio.radio
+                [ css "pr-6" ]
+                [ Halogen.HTML.Propreties.name "slider-continuous"
+                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 3 "continuous")
+                ]
+                [ Halogen.HTML.text "3" ]
+              , Radio.radio
+                [ css "pr-6" ]
+                [ Halogen.HTML.Propreties.name "slider-continuous"
+                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 4 "continuous")
+                ]
+                [ Halogen.HTML.text "4" ]
+              , Radio.radio
+                [ css "pr-6" ]
+                [ Halogen.HTML.Propreties.name "slider-continuous"
+                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 5 "continuous")
+                ]
+                [ Halogen.HTML.text "5" ]
+              , Radio.radio
+                [ css "pr-6" ]
+                [ Halogen.HTML.Propreties.name "slider-continuous"
+                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 6 "continuous")
+                ]
+                [ Halogen.HTML.text "6" ]
+              ]
             , Halogen.HTML.slot _slider "continuous"
               Ocelot.Slider.component
               { axis: Just axisData

--- a/ui-guide/Components/FormControl.purs
+++ b/ui-guide/Components/FormControl.purs
@@ -111,7 +111,7 @@ render state =
               { axis: Just axisData
               , layout: config
               , marks: Just marksData
-              , minDistance: Nothing
+              , minDistance: Just { percent: 10.0 }
               , renderIntervals: Data.Array.foldMap renderInterval
               }
               (const Nothing)

--- a/ui-guide/Components/FormControl.purs
+++ b/ui-guide/Components/FormControl.purs
@@ -16,11 +16,12 @@ import Ocelot.Block.Card as Card
 import Ocelot.Block.Checkbox as Checkbox
 import Ocelot.Block.FormField as FormField
 import Ocelot.Block.Format as Format
+import Ocelot.Block.Format as Ocelot.Block.Format
 import Ocelot.Block.Icon as Icon
 import Ocelot.Block.Radio as Radio
+import Ocelot.HTML.Properties (css)
 import Ocelot.Slider as Ocelot.Slider
 import Ocelot.Slider.Render as Ocelot.Slider.Render
-import Ocelot.HTML.Properties (css)
 import UIGuide.Block.Backdrop as Backdrop
 import UIGuide.Block.Documentation as Documentation
 import Web.UIEvent.MouseEvent (MouseEvent)
@@ -45,7 +46,7 @@ type Input = Unit
 type Output = Void
 
 type ChildSlots =
-  ( slider :: Ocelot.Slider.Slot Unit )
+  ( slider :: Ocelot.Slider.Slot String )
 
 _slider = SProxy :: SProxy "slider"
 
@@ -104,13 +105,32 @@ render state =
       , subheader: "Select one or more values in percentage."
       }
       [ Backdrop.backdrop_
-        [ content
-          [ Card.card_
-            [ Halogen.HTML.slot _slider unit
+        [ Backdrop.content_
+          [ Card.card
+            [ css "flex-1" ]
+            [ Halogen.HTML.h3
+                [ Halogen.HTML.Propreties.classes Ocelot.Block.Format.captionClasses ]
+                [ Halogen.HTML.text "Discrete" ]
+            , Halogen.HTML.slot _slider "discrete"
               Ocelot.Slider.component
               { axis: Just axisData
               , layout: config
               , marks: Just marksData
+              , minDistance: Just { percent: 10.0 }
+              , renderIntervals: Data.Array.foldMap renderInterval
+              }
+              (const Nothing)
+            ]
+          , Card.card
+            [ css "flex-1" ]
+            [ Halogen.HTML.h3
+              [ Halogen.HTML.Propreties.classes Ocelot.Block.Format.captionClasses ]
+              [ Halogen.HTML.text "Continuous" ]
+            , Halogen.HTML.slot _slider "continuous"
+              Ocelot.Slider.component
+              { axis: Just axisData
+              , layout: config
+              , marks: Nothing
               , minDistance: Just { percent: 10.0 }
               , renderIntervals: Data.Array.foldMap renderInterval
               }

--- a/ui-guide/Components/FormControl.purs
+++ b/ui-guide/Components/FormControl.purs
@@ -10,6 +10,7 @@ import Effect.Aff.Class (class MonadAff)
 import Effect.Console (log)
 import Halogen as Halogen
 import Halogen.HTML as Halogen.HTML
+import Halogen.HTML.Events as Halogen.HTML.Events
 import Halogen.HTML.Properties as Halogen.HTML.Propreties
 import Halogen.Svg.Attributes as Halogen.Svg.Attributes
 import Ocelot.Block.Card as Card
@@ -41,6 +42,7 @@ data Action
   = HandleFormHeaderClick MouseEvent
   | ToggleFormPanel MouseEvent
   | HandleSlider Ocelot.Slider.Output
+  | HandleThumbCount Int String
 
 type Input = Unit
 
@@ -74,6 +76,10 @@ handleAction = case _ of
   HandleSlider output -> case output of
     Ocelot.Slider.ValueChanged xs -> do
       Halogen.liftEffect (log ("slider: " <> show xs))
+
+  HandleThumbCount n slotKey -> do
+    void $ Halogen.query _slider slotKey <<< Halogen.tell
+      $ Ocelot.Slider.SetThumbCount n
 
   ToggleFormPanel _ -> do
     state <- Halogen.get
@@ -116,12 +122,52 @@ render state =
             [ Halogen.HTML.h3
                 [ Halogen.HTML.Propreties.classes Ocelot.Block.Format.captionClasses ]
                 [ Halogen.HTML.text "Discrete" ]
+            , Halogen.HTML.div
+              [ css "flex" ]
+              [ Radio.radio
+                [ css "pr-6" ]
+                [ Halogen.HTML.Propreties.name "slider-discrete"
+                , Halogen.HTML.Propreties.checked true
+                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 1 "discrete")
+                ]
+                [ Halogen.HTML.text "1" ]
+              , Radio.radio
+                [ css "pr-6" ]
+                [ Halogen.HTML.Propreties.name "slider-discrete"
+                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 2 "discrete")
+                ]
+                [ Halogen.HTML.text "2" ]
+              , Radio.radio
+                [ css "pr-6" ]
+                [ Halogen.HTML.Propreties.name "slider-discrete"
+                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 3 "discrete")
+                ]
+                [ Halogen.HTML.text "3" ]
+              , Radio.radio
+                [ css "pr-6" ]
+                [ Halogen.HTML.Propreties.name "slider-discrete"
+                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 4 "discrete")
+                ]
+                [ Halogen.HTML.text "4" ]
+              , Radio.radio
+                [ css "pr-6" ]
+                [ Halogen.HTML.Propreties.name "slider-discrete"
+                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 5 "discrete")
+                ]
+                [ Halogen.HTML.text "5" ]
+              , Radio.radio
+                [ css "pr-6" ]
+                [ Halogen.HTML.Propreties.name "slider-discrete"
+                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 6 "discrete")
+                ]
+                [ Halogen.HTML.text "6" ]
+              ]
             , Halogen.HTML.slot _slider "discrete"
               Ocelot.Slider.component
               { axis: Just axisData
               , layout: config
               , marks: Just marksData
-              , minDistance: Just { percent: 10.0 }
+              , minDistance: Just { percent: 9.9 }
               , renderIntervals: Data.Array.foldMap renderInterval
               }
               (Just <<< HandleSlider)


### PR DESCRIPTION
## What does this pull request do?

Add slider component
- supports multiple values/thumbs
- allows changing the number of thumbs by query
- has two general modes depending on whether `marks` are specified
  - discrete (if `marks` are specified): thumbs can only sit on given set of values
  - continuous (if `marks` are left empty): thumbs can slide freely
- able to maintain minimal distance between thumbs if specified
- configurable layout (currently in limited form, see `Ocelot.Slider.Render.Config`)
- customizable render for intervals between thumbs

Features we may add in the future
- clicking on track teleports the closest thumb to the mouse position
- customizable render for marks
- indicator of thumb value when hovering over (especially in continuous setting)

## How should this be manually tested?

Kind of hard to put everything into words given there are enormous amount of edge cases. You have to play with it yourself a bit.

- [x] `make`
- [x] go to `dist/index.html#controls`
  - open console log to see current values
- [x] click on radio buttons to increase the number of thumbs
  - for example, click on `5` and spread the thumbs a bit and then click `6`
  - the new thumb will be added to a position that doesn't violate minimal distance constraint
- [x] click on radio buttons to lower the number of thumbs
  - extra thumbs should be removed from the right
- [x] have at least two thumbs and slide one against another
  - they can slide through each other but the minimal distance is always preserved
