### PR TITLE
AS-1164 Add ReplaceThumbs query and disabled prop to Slider

### DIFF
--- a/src/Slider.purs
+++ b/src/Slider.purs
@@ -76,7 +76,8 @@ data Action
   | MouseUpFromThumb Web.UIEvent.MouseEvent.MouseEvent
 
 data Query a
-  = SetDisabled Boolean a
+  = ReplaceThumbs (Array { percent :: Number }) a
+  | SetDisabled Boolean a
   | SetThumbCount Int a
 
 -- | * axis: a list of labels positioned under the track
@@ -163,6 +164,13 @@ handleQuery ::
   Query a ->
   ComponentM m (Maybe a)
 handleQuery = case _ of
+  ReplaceThumbs thumbs a -> do
+    state <- Halogen.get
+    case state.thumbs of
+      Idle _ -> pure unit
+      Editing { subscriptions } -> muteAllListeners subscriptions
+    Halogen.modify_ _ { thumbs = Idle thumbs }
+    pure (Just a)
   SetDisabled disabled a -> do
     Halogen.modify_ _ { input { disabled = disabled } }
     pure (Just a)

--- a/ui-guide/Components/FormControl.purs
+++ b/ui-guide/Components/FormControl.purs
@@ -40,9 +40,10 @@ type State =
 data Query a
 data Action
   = HandleFormHeaderClick MouseEvent
-  | ToggleFormPanel MouseEvent
   | HandleSlider Ocelot.Slider.Output
   | HandleThumbCount Int String
+  | Initialize
+  | ToggleFormPanel MouseEvent
 
 type Input = Unit
 
@@ -61,7 +62,12 @@ component =
   Halogen.mkComponent
     { initialState: const { formPanelIsOpen: false }
     , render
-    , eval: Halogen.mkEval $ Halogen.defaultEval { handleAction = handleAction }
+    , eval:
+      Halogen.mkEval
+        Halogen.defaultEval
+          { handleAction = handleAction
+          , initialize = Just Initialize
+          }
     }
 
 handleAction ::
@@ -80,6 +86,10 @@ handleAction = case _ of
   HandleThumbCount n slotKey -> do
     void $ Halogen.query _slider slotKey <<< Halogen.tell
       $ Ocelot.Slider.SetThumbCount n
+
+  Initialize -> do
+    void <<< Halogen.query _slider "disabled" <<< Halogen.tell
+      $ Ocelot.Slider.ReplaceThumbs [ { percent: 30.0 }, { percent: 70.0 } ]
 
   ToggleFormPanel _ -> do
     state <- Halogen.get

--- a/ui-guide/Components/FormControl.purs
+++ b/ui-guide/Components/FormControl.purs
@@ -165,6 +165,7 @@ render state =
             , Halogen.HTML.slot _slider "discrete"
               Ocelot.Slider.component
               { axis: Just axisData
+              , disabled: false
               , layout: config
               , marks: Just marksData
               , minDistance: Just { percent: 9.9 }
@@ -220,6 +221,23 @@ render state =
             , Halogen.HTML.slot _slider "continuous"
               Ocelot.Slider.component
               { axis: Just axisData
+              , disabled: false
+              , layout: config
+              , marks: Nothing
+              , minDistance: Just { percent: 10.0 }
+              , renderIntervals: Data.Array.foldMap renderInterval
+              }
+              (Just <<< HandleSlider)
+            ]
+          , Card.card
+            [ css "flex-1" ]
+            [ Halogen.HTML.h3
+              [ Halogen.HTML.Propreties.classes Ocelot.Block.Format.captionClasses ]
+              [ Halogen.HTML.text "Disabled" ]
+            , Halogen.HTML.slot _slider "disabled"
+              Ocelot.Slider.component
+              { axis: Just axisData
+              , disabled: true
               , layout: config
               , marks: Nothing
               , minDistance: Just { percent: 10.0 }


### PR DESCRIPTION
## What does this pull request do?

Improvements to Slider component
* allow replacing thumbs by `ReplaceThumbs` query
* allow disabling the component by setting `disabled: true` from initial `Input` or using `SetDisabled` query
  * mouse events over thumbs will be muted
