### PR TITLE
fix CircleCI config file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
           name: Prepare branches locally
           command: |
             git checkout gh-pages
-            git checkout master
+            git checkout main
 
       - run:
           name: Set up gh-pages in worktree for easy artifact copying
@@ -122,11 +122,11 @@ workflows:
             branches:
               ignore: gh-pages
 
-      # On master branch, rebuild documentation site
+      # On main branch, rebuild documentation site
       - docs:
           filters:
             branches:
-              only: master
+              only: main
 
           requires:
             - test


### PR DESCRIPTION
## What does this pull request do?

Looks like we forgot to update `master` to `main` in `.circleci/config.yml` when migrating the branch so the branch name doesn't line up, which is probably why documentation site rebuild step hasn't been triggered lately.