### PR TITLE
FBCM-4152 Add Set disabled query for datetime

### DIFF
--- a/src/Components/DatePicker/Component.purs
+++ b/src/Components/DatePicker/Component.purs
@@ -74,6 +74,7 @@ data EmbeddedAction
 
 data Query a -- NOTE the container and the embedded components share the same query algebra
   = GetSelection (Date -> a)
+  | SetDisabled Boolean a
   | SetSelection (Maybe Date) a
 
 data Output
@@ -185,6 +186,8 @@ handleQuery = case _ of
   GetSelection reply -> do
     response <- H.query _select unit (S.Query $ H.request GetSelection)
     pure $ reply <$> response
+  SetDisabled disabled a -> Just a <$ do
+    H.query _select unit (S.Query $ H.tell $ SetDisabled disabled)
   SetSelection selection a -> Just a <$ do
     H.query _select unit (S.Query $ H.tell $ SetSelection selection)
 
@@ -312,6 +315,8 @@ embeddedHandleQuery = case _ of
   GetSelection reply -> do
     { selection }  <- H.get
     pure $ reply <$> selection
+  SetDisabled disabled a -> Just a <$ do
+    H.modify_ _ { disabled = disabled }
   SetSelection selection a -> Just a <$ do
     setSelection selection
 

--- a/src/Components/DateTimePicker/Component.purs
+++ b/src/Components/DateTimePicker/Component.purs
@@ -50,6 +50,7 @@ data Query a
   | SetSelection (Maybe DateTime) a
   | SendDateQuery (DatePicker.Query Unit) a
   | SendTimeQuery (TimePicker.Query Unit) a
+  | SetDisabled Boolean a
 
 data Output
   = SelectionChanged (Maybe DateTime)
@@ -125,6 +126,11 @@ handleQuery = case _ of
   GetSelection reply -> do
     { time, date } <- H.get
     pure $ reply <$> (DateTime <$> date <*> time)
+
+  SetDisabled disabled a -> Just a <$ do
+    H.modify_ _ { disabled = disabled }
+    void $ H.query _datepicker unit $ H.tell $ DatePicker.SetDisabled disabled
+    void $ H.query _timepicker unit $ H.tell $ TimePicker.SetDisabled disabled
 
   SetSelection dateTime a -> Just a <$ do
     let date' = date <$> dateTime

--- a/src/Components/TimePicker/Component.purs
+++ b/src/Components/TimePicker/Component.purs
@@ -57,6 +57,7 @@ data EmbeddedAction
 
 data Query a
   = GetSelection (Time -> a)
+  | SetDisabled Boolean a
   | SetSelection (Maybe Time) a
 
 data Output
@@ -147,6 +148,9 @@ handleQuery = case _ of
     response <- H.query _select unit (S.Query $ H.request GetSelection)
     pure $ reply <$> response
 
+  SetDisabled disabled a -> Just a <$ do
+    void $ H.query _select unit (S.Query $ H.tell $ SetDisabled disabled)
+
   SetSelection selection a -> Just a <$ do
     H.query _select unit (S.Query $ H.tell $ SetSelection selection)
 
@@ -223,6 +227,9 @@ embeddedHandleQuery = case _ of
   GetSelection reply -> do
     { selection } <- H.get
     pure $ reply <$> selection
+
+  SetDisabled disabled a -> Just a <$ do
+    H.modify_ _ { disabled = disabled }
 
   SetSelection selection a -> Just a <$ do
     setSelection selection

--- a/ui-guide/Components/DatePickers.purs
+++ b/ui-guide/Components/DatePickers.purs
@@ -23,10 +23,13 @@ import UIGuide.Block.Documentation as Documentation
 ----------
 -- Component Types
 
-type State = Unit
+type State = 
+  { disabled :: Boolean -- | Global enable/disable toggle
+  }
 
 data Query a
-type Action = Unit
+data Action 
+  = ToggleDisabled
 
 ----------
 -- Child paths
@@ -49,11 +52,14 @@ component :: ∀ m
  => H.Component HH.HTML Query Unit Void m
 component =
   H.mkComponent
-  { initialState: const unit
+  { initialState
   , render
   , eval: H.mkEval H.defaultEval
   }
   where
+    initialState :: Unit -> State
+    initialState _ = { disabled: false }
+
     render
       :: State
       -> H.ComponentHTML Action ChildSlot m
@@ -90,7 +96,7 @@ cnDocumentationBlocks =
                 , selection: Nothing
                 , disabled: false
                 }
-                (const $ Just unit)
+                (const Nothing)
               ]
             , Format.caption_ [ HH.text "Standard Disabled" ]
             , FormField.fieldMid_

--- a/ui-guide/Components/DatePickers.purs
+++ b/ui-guide/Components/DatePickers.purs
@@ -8,6 +8,8 @@ import Data.Symbol (SProxy(..))
 import Effect.Aff.Class (class MonadAff)
 import Halogen as H
 import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Ocelot.Block.Button as Button
 import Ocelot.Block.Card as Card
 import Ocelot.Block.FormField as FormField
 import Ocelot.Block.Format as Format
@@ -55,8 +57,20 @@ component =
   { initialState
   , render
   , eval: H.mkEval H.defaultEval
+    { handleAction = handleAction
+    }
   }
   where
+    handleAction = case _ of  
+      ToggleDisabled -> do
+        st <- H.modify \s -> s { disabled = not s.disabled }
+        void $ H.query _datePicker 0 $ H.tell $ DatePicker.SetDisabled st.disabled
+        void $ H.query _datePicker 1 $ H.tell $ DatePicker.SetDisabled st.disabled
+        void $ H.query _timePicker 0 $ H.tell $ TimePicker.SetDisabled st.disabled
+        void $ H.query _timePicker 1 $ H.tell $ TimePicker.SetDisabled st.disabled
+        void $ H.query _dtp 0 $ H.tell $ DateTimePicker.SetDisabled st.disabled
+        void $ H.query _dtp 1 $ H.tell $ DateTimePicker.SetDisabled st.disabled
+        
     initialState :: Unit -> State
     initialState _ = { disabled: false }
 
@@ -76,10 +90,22 @@ cnDocumentationBlocks :: ∀ m
  => H.ComponentHTML Action ChildSlot m
 cnDocumentationBlocks =
   HH.div_
-    [ Documentation.block_
-      { header: "Date Pickers"
-      , subheader: "It's a date picker. Deal with it."
-      }
+    [ HH.h1
+      [ css "font-normal mb-6" ] 
+      [ HH.text "Date Pickers" ]
+    , HH.h2
+      [ css "font-medium text-grey-50 text-xl mb-6" ]
+      [ HH.text "It's a date picker. Deal with it" ]
+    , HH.div
+      [ css "mb-6" ]
+      [ HH.p
+        [ css "inline mr-4" ]
+        [ HH.text "You can toggle between enabled/disabled states" ]
+      , Button.button
+        [ HE.onClick $ const $ Just ToggleDisabled ]
+        [ HH.text "Toggle" ]
+      ]
+    , HH.div_
       [ Backdrop.backdrop_
         [ content
           [ Card.card


### PR DESCRIPTION
## What does this pull request do?
We add a SetDisabled query for the 3 date time related components: DateTimePicker, DatePicker, and TimePicker.

Requesting a review from @davezuch since he's already working in a similar space

### Other Notes:
Should I bump the version here? Or should we wait for the dropdown change as well and bump the version all at once?