### PR TITLE
FBCM-4170 Don't raise from a query

### DIFF
--- a/src/Components/DatePicker/Component.purs
+++ b/src/Components/DatePicker/Component.purs
@@ -241,6 +241,13 @@ setSelection selection = do
   H.raise $ SelectionChanged selection
   synchronize
 
+setSelectionWithoutRaising :: forall m. MonadAff m => Maybe Date -> CompositeComponentM m Unit
+setSelectionWithoutRaising selection = do
+  st <- H.get
+  let targetDate = maybe st.targetDate (\d -> (year d) /\ (month d)) selection
+  H.modify_ _ { selection = selection, targetDate = targetDate }
+  synchronize
+
 --------------------------
 -- Embedded > handleAction
 
@@ -318,7 +325,7 @@ embeddedHandleQuery = case _ of
   SetDisabled disabled a -> Just a <$ do
     H.modify_ _ { disabled = disabled }
   SetSelection selection a -> Just a <$ do
-    setSelection selection
+    setSelectionWithoutRaising selection
 
 ---------------------------
 -- Embedded > handleMessage

--- a/src/Components/DatePicker/Component.purs
+++ b/src/Components/DatePicker/Component.purs
@@ -235,11 +235,8 @@ synchronize = do
 
 setSelection :: forall m. MonadAff m => Maybe Date -> CompositeComponentM m Unit
 setSelection selection = do
-  st <- H.get
-  let targetDate = maybe st.targetDate (\d -> (year d) /\ (month d)) selection
-  H.modify_ _ { selection = selection, targetDate = targetDate }
+  setSelectionWithoutRaising selection
   H.raise $ SelectionChanged selection
-  synchronize
 
 setSelectionWithoutRaising :: forall m. MonadAff m => Maybe Date -> CompositeComponentM m Unit
 setSelectionWithoutRaising selection = do

--- a/src/Components/TimePicker/Component.purs
+++ b/src/Components/TimePicker/Component.purs
@@ -234,7 +234,7 @@ embeddedHandleQuery = case _ of
     H.modify_ _ { disabled = disabled }
 
   SetSelection selection a -> Just a <$ do
-    setSelection selection
+    setSelectionWithoutRaising selection
 
 embeddedRender :: forall m. CompositeComponentRender m
 embeddedRender s =
@@ -353,4 +353,9 @@ setSelection :: forall m. Maybe Time -> CompositeComponentM m Unit
 setSelection selection = do
   H.modify_ _ { selection = selection }
   H.raise $ SelectionChanged selection
+  synchronize
+
+setSelectionWithoutRaising :: forall m. Maybe Time -> CompositeComponentM m Unit
+setSelectionWithoutRaising selection = do
+  H.modify_ _ { selection = selection }
   synchronize

--- a/src/Components/TimePicker/Component.purs
+++ b/src/Components/TimePicker/Component.purs
@@ -351,9 +351,8 @@ synchronize = do
 
 setSelection :: forall m. Maybe Time -> CompositeComponentM m Unit
 setSelection selection = do
-  H.modify_ _ { selection = selection }
+  setSelectionWithoutRaising selection
   H.raise $ SelectionChanged selection
-  synchronize
 
 setSelectionWithoutRaising :: forall m. Maybe Time -> CompositeComponentM m Unit
 setSelectionWithoutRaising selection = do


### PR DESCRIPTION
## What does this pull request do?

We stop raising the query we just responded to when we receive it in the `Ocelot.Components.DatePicker.Component` and `Ocelot.Components.TimePicker.Component` components.

## Where should the reviewer start?

- This seems like it's going to fix the issue we had when trying to diagnose https://citizennet.atlassian.net/browse/FBCM-4170, but I'd like another set of eyes on the change. Primarily, I'm not sure I totally understand how this whole `purescript-halogen-select` thing works.
- Since this could potentially cause problems in both the `orders` and `wildcat` repos, requesting a review from both teams.