### PR TITLE
AS-1264 Add FilePicker Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-ocelot",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "private": true,
   "scripts": {
     "build-all": "make build",

--- a/src/Data/InputAcceptType.purs
+++ b/src/Data/InputAcceptType.purs
@@ -1,0 +1,87 @@
+module Ocelot.Data.InputAcceptType
+  ( allAudios
+  , allImages
+  , allVideos
+  , validate
+  ) where
+
+import Prelude
+
+import DOM.HTML.Indexed.InputAcceptType as DOM.HTML.Indexed.InputAcceptType
+import Data.Array as Data.Array
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
+import Data.MediaType as Data.MediaType
+import Data.String as Data.String
+import Data.String.CodeUnits as Data.String.CodeUnits
+import Data.String.Regex as Data.String.Regex
+import Web.File.File as Web.File.File
+
+allAudios :: DOM.HTML.Indexed.InputAcceptType.InputAcceptType
+allAudios = DOM.HTML.Indexed.InputAcceptType.mediaType (Data.MediaType.MediaType "audio/*")
+
+allImages :: DOM.HTML.Indexed.InputAcceptType.InputAcceptType
+allImages = DOM.HTML.Indexed.InputAcceptType.mediaType (Data.MediaType.MediaType "image/*")
+
+allVideos :: DOM.HTML.Indexed.InputAcceptType.InputAcceptType
+allVideos = DOM.HTML.Indexed.InputAcceptType.mediaType (Data.MediaType.MediaType "video/*")
+
+-- | Adapted from [attr-accept](https://github.com/react-dropzone/attr-accept)
+validate ::
+  DOM.HTML.Indexed.InputAcceptType.InputAcceptType ->
+  Web.File.File.File ->
+  Boolean
+validate (DOM.HTML.Indexed.InputAcceptType.InputAcceptType xs) file =
+  Data.Array.any (validateInputAcceptTypeAtom file) xs
+
+validateInputAcceptTypeAtom ::
+  Web.File.File.File ->
+  DOM.HTML.Indexed.InputAcceptType.InputAcceptTypeAtom ->
+  Boolean
+validateInputAcceptTypeAtom file = case _ of
+  DOM.HTML.Indexed.InputAcceptType.AcceptFileExtension extension ->
+    validateFileExtension file extension
+  DOM.HTML.Indexed.InputAcceptType.AcceptMediaType mediaType ->
+    validateMediaType file mediaType
+
+validateFileExtension ::
+  Web.File.File.File ->
+  String ->
+  Boolean
+validateFileExtension file accept =
+  case Data.String.CodeUnits.stripSuffix (Data.String.Pattern (normalize accept)) (normalize (Web.File.File.name file)) of
+    Nothing -> false
+    Just _ -> true
+  where
+  normalize :: String -> String
+  normalize =
+    Data.String.toLower
+      <<< Data.String.trim
+
+validateMediaType ::
+  Web.File.File.File ->
+  Data.MediaType.MediaType ->
+  Boolean
+validateMediaType file (Data.MediaType.MediaType accept) =
+  case Data.String.CodeUnits.stripSuffix (Data.String.Pattern "/*") validType of
+    Nothing -> mimeType == validType
+    Just baseValidType -> baseMimeType == baseValidType
+  where
+  mimeType :: String
+  mimeType = normalize case Web.File.File.type_ file of
+    Nothing -> ""
+    Just (Data.MediaType.MediaType x) -> x
+
+  baseMimeType :: String
+  baseMimeType = case Data.String.Regex.regex "/.*$" mempty of
+    Left _ -> mimeType
+    Right regex -> Data.String.Regex.replace regex "" mimeType
+
+  validType :: String
+  validType = normalize accept
+
+  normalize :: String -> String
+  normalize =
+    Data.String.toLower
+      <<< Data.String.trim
+

--- a/src/FilePicker.purs
+++ b/src/FilePicker.purs
@@ -1,0 +1,54 @@
+module Ocelot.FilePicker
+  ( Output(..)
+  , Query(..)
+  , Slot
+  , component
+  ) where
+
+import Prelude
+
+import Effect.Aff.Class (class MonadAff)
+import Halogen as Halogen
+import Halogen.HTML as Halogen.HTML
+
+type Slot = Halogen.Slot Query Output
+
+type Component m = Halogen.Component Halogen.HTML.HTML Query Input Output m
+type ComponentHTML m = Halogen.ComponentHTML Action ChildSlots m
+type ComponentM m a = Halogen.HalogenM State Action ChildSlots Output m a
+
+type State = Unit
+
+data Action
+
+data Query a
+
+type Input = Unit
+
+type Output = Void
+
+type ChildSlots = ()
+
+
+component ::
+  forall m.
+  MonadAff m =>
+  Component m
+component =
+  Halogen.mkComponent
+    { initialState
+    , render
+    , eval:
+        Halogen.mkEval
+          Halogen.defaultEval
+    }
+
+initialState :: Input -> State
+initialState input = unit
+
+render ::
+  forall m.
+  State ->
+  ComponentHTML m
+render state = Halogen.HTML.text ""
+

--- a/src/FilePicker.purs
+++ b/src/FilePicker.purs
@@ -7,13 +7,22 @@ module Ocelot.FilePicker
 
 import Prelude
 
+import DOM.HTML.Indexed (HTMLdiv)
+import Data.Maybe (Maybe(..))
 import Effect.Aff.Class (class MonadAff)
+import Effect.Class.Console as Effect.Class.Console
 import Foreign.Object as Foreign.Object
 import Halogen as Halogen
 import Halogen.HTML as Halogen.HTML
+import Halogen.HTML.Events as Ocelot.HTML.Events
 import Halogen.HTML.Properties as Halogen.HTML.Properties
 import Ocelot.Block.Icon as Ocelot.Block.Icon
 import Ocelot.HTML.Properties as Ocelot.HTMl.Properties
+import Web.Event.Event as Web.Event.Event
+import Web.File.File as Web.File.File
+import Web.File.FileList as Web.File.FileList
+import Web.HTML.Event.DataTransfer as Web.HTML.Event.DataTransfer
+import Web.HTML.Event.DragEvent as Web.HTML.Event.DragEvent
 
 type Slot = Halogen.Slot Query Output
 
@@ -21,9 +30,15 @@ type Component m = Halogen.Component Halogen.HTML.HTML Query Input Output m
 type ComponentHTML m = Halogen.ComponentHTML Action ChildSlots m
 type ComponentM m a = Halogen.HalogenM State Action ChildSlots Output m a
 
-type State = Unit
+type State =
+  { dragOver :: Boolean
+  }
 
 data Action
+  = DragEnter Web.HTML.Event.DragEvent.DragEvent
+  | DragLeave Web.HTML.Event.DragEvent.DragEvent
+  | DropFile Web.HTML.Event.DragEvent.DragEvent
+  | PreventDefault Web.Event.Event.Event
 
 data Query a
 
@@ -45,10 +60,73 @@ component =
     , eval:
         Halogen.mkEval
           Halogen.defaultEval
+            { handleAction = handleAction
+            }
     }
 
 initialState :: Input -> State
-initialState input = unit
+initialState input =
+  { dragOver: false
+  }
+
+handleAction ::
+  forall m.
+  MonadAff m =>
+  Action ->
+  ComponentM m Unit
+handleAction = case _ of
+  DragEnter dragEvent -> dragEnter dragEvent
+  DragLeave dragEvent -> dragLeave dragEvent
+  DropFile dragEvent -> dropFile dragEvent
+  PreventDefault event -> preventDefault event
+
+dragEnter ::
+  forall m.
+  MonadAff m =>
+  Web.HTML.Event.DragEvent.DragEvent ->
+  ComponentM m Unit
+dragEnter dragEvent = do
+  preventDefault (Web.HTML.Event.DragEvent.toEvent dragEvent)
+  Halogen.modify_ _ { dragOver = true }
+
+dragLeave ::
+  forall m.
+  MonadAff m =>
+  Web.HTML.Event.DragEvent.DragEvent ->
+  ComponentM m Unit
+dragLeave dragEvent = do
+  preventDefault (Web.HTML.Event.DragEvent.toEvent dragEvent)
+  Halogen.modify_ _ { dragOver = false }
+
+dropFile ::
+  forall m.
+  MonadAff m =>
+  Web.HTML.Event.DragEvent.DragEvent ->
+  ComponentM m Unit
+dropFile dragEvent = do
+  preventDefault (Web.HTML.Event.DragEvent.toEvent dragEvent)
+  Halogen.modify_ _ { dragOver = false }
+  case Web.HTML.Event.DataTransfer.files (Web.HTML.Event.DragEvent.dataTransfer dragEvent) of
+    Nothing -> pure unit
+    Just fileList -> do
+      let
+        files :: Array Web.File.File.File
+        files = Web.File.FileList.items fileList
+      Halogen.liftEffect -- TODO debug
+        $ Effect.Class.Console.logShow
+        $ map Web.File.File.name
+        $ files
+      pure unit -- TODO handle file
+
+preventDefault ::
+  forall m.
+  MonadAff m =>
+  Web.Event.Event.Event ->
+  ComponentM m Unit
+preventDefault event =
+  Halogen.liftEffect do
+    Web.Event.Event.preventDefault event
+    Web.Event.Event.stopPropagation event
 
 render ::
   forall m.
@@ -56,25 +134,77 @@ render ::
   ComponentHTML m
 render state =
   Halogen.HTML.div_
-    [ renderDropBox
+    [ renderDropBox state
     , renderInput
     ]
 
 renderDropBox ::
   forall m.
+  State ->
   ComponentHTML m
-renderDropBox =
-  Halogen.HTML.div
-    [ Ocelot.HTMl.Properties.css "bg-grey-70-a40 p-10"
-    , Ocelot.HTMl.Properties.style <<< Foreign.Object.fromHomogeneous $
-        { outline: "2px dashed #8f9eb3"
-        , "outline-offset": "-10px"
-        , transition: "outline-offset .15s ease-in-out, background-color .15s linear"
-        }
-    ]
-    [ renderIcon
-    , renderLabel
-    ]
+renderDropBox state
+  | state.dragOver =
+    Halogen.HTML.div ipropDragOver
+      [ Halogen.HTML.div
+          [ Ocelot.HTMl.Properties.style <<< Foreign.Object.fromHomogeneous $
+            { "pointer-events": "none" } -- NOTE prevent event firing from children
+          ]
+          renderContent
+      ]
+  | otherwise =
+    Halogen.HTML.div ipropIdle
+      renderContent
+
+ipropIdle :: Array (Halogen.HTML.Properties.IProp HTMLdiv Action)
+ipropIdle =
+  [ Ocelot.HTMl.Properties.css cssIdle
+  , Ocelot.HTMl.Properties.style styleIdle
+  , Ocelot.HTML.Events.onDrag (Just <<< PreventDefault <<< Web.HTML.Event.DragEvent.toEvent)
+  , Ocelot.HTML.Events.onDragEnter (Just <<< DragEnter)
+  , Ocelot.HTML.Events.onDragOver (Just <<< PreventDefault <<< Web.HTML.Event.DragEvent.toEvent)
+  , Ocelot.HTML.Events.onDragStart (Just <<< PreventDefault <<< Web.HTML.Event.DragEvent.toEvent)
+  ]
+  where
+  cssIdle :: String
+  cssIdle = "bg-grey-70-a40 p-10"
+
+  styleIdle :: Foreign.Object.Object String
+  styleIdle =
+    Foreign.Object.fromHomogeneous
+      { outline: "2px dashed #8f9eb3"
+      , "outline-offset": "-10px"
+      , transition: "outline-offset .15s ease-in-out, background-color .15s linear"
+      }
+
+ipropDragOver :: Array (Halogen.HTML.Properties.IProp HTMLdiv Action)
+ipropDragOver =
+  [ Ocelot.HTMl.Properties.css cssDragOver
+  , Ocelot.HTMl.Properties.style styleDragOver
+  , Ocelot.HTML.Events.onDragEnd (Just <<< PreventDefault <<< Web.HTML.Event.DragEvent.toEvent)
+  , Ocelot.HTML.Events.onDragLeave (Just <<< DragLeave)
+  , Ocelot.HTML.Events.onDragOver (Just <<< PreventDefault <<< Web.HTML.Event.DragEvent.toEvent)
+  , Ocelot.HTML.Events.onDrop (Just <<< DropFile)
+  ]
+  where
+  cssDragOver :: String
+  cssDragOver = "bg-grey-95 p-10"
+
+  styleDragOver :: Foreign.Object.Object String
+  styleDragOver =
+    Foreign.Object.fromHomogeneous
+    { outline: "2px dashed #8f9eb3"
+    , "outline-offset": "-20px"
+    , transition: "outline-offset .15s ease-in-out, background-color .15s linear"
+    }
+
+renderContent ::
+  forall m.
+  Array (ComponentHTML m)
+renderContent =
+  [ renderIcon
+  , renderLabel
+  ]
+
 
 renderIcon ::
   forall m.

--- a/src/FilePicker.purs
+++ b/src/FilePicker.purs
@@ -8,8 +8,12 @@ module Ocelot.FilePicker
 import Prelude
 
 import Effect.Aff.Class (class MonadAff)
+import Foreign.Object as Foreign.Object
 import Halogen as Halogen
 import Halogen.HTML as Halogen.HTML
+import Halogen.HTML.Properties as Halogen.HTML.Properties
+import Ocelot.Block.Icon as Ocelot.Block.Icon
+import Ocelot.HTML.Properties as Ocelot.HTMl.Properties
 
 type Slot = Halogen.Slot Query Output
 
@@ -50,5 +54,60 @@ render ::
   forall m.
   State ->
   ComponentHTML m
-render state = Halogen.HTML.text ""
+render state =
+  Halogen.HTML.div_
+    [ renderDropBox
+    , renderInput
+    ]
 
+renderDropBox ::
+  forall m.
+  ComponentHTML m
+renderDropBox =
+  Halogen.HTML.div
+    [ Ocelot.HTMl.Properties.css "bg-grey-70-a40 p-10"
+    , Ocelot.HTMl.Properties.style <<< Foreign.Object.fromHomogeneous $
+        { outline: "2px dashed #8f9eb3"
+        , "outline-offset": "-10px"
+        , transition: "outline-offset .15s ease-in-out, background-color .15s linear"
+        }
+    ]
+    [ renderIcon
+    , renderLabel
+    ]
+
+renderIcon ::
+  forall m.
+  ComponentHTML m
+renderIcon =
+  Halogen.HTML.div
+    [ Ocelot.HTMl.Properties.css "text-grey-50 text-center w-full" ]
+    [ Ocelot.Block.Icon.download
+      [ Ocelot.HTMl.Properties.css "text-5xl" ]
+    ]
+
+renderInput ::
+  forall m.
+  ComponentHTML m
+renderInput =
+  Halogen.HTML.input
+    [ Ocelot.HTMl.Properties.css "hidden"
+    , Halogen.HTML.Properties.id_ _file
+    , Halogen.HTML.Properties.type_ Halogen.HTML.Properties.InputFile
+    ]
+
+renderLabel ::
+  forall m.
+  ComponentHTML m
+renderLabel =
+  Halogen.HTML.label
+    [ Ocelot.HTMl.Properties.css "group text-center"
+    , Halogen.HTML.Properties.for _file
+    ]
+    [ Halogen.HTML.span
+      [ Ocelot.HTMl.Properties.css "group-hover:text-blue-88" ]
+      [ Halogen.HTML.text "Choose a file" ]
+    , Halogen.HTML.text " or drag it here."
+    ]
+
+_file = "file" :: String

--- a/ui-guide/App/Routes.purs
+++ b/ui-guide/App/Routes.purs
@@ -17,6 +17,7 @@ import UIGuide.Component.Diagram as Diagram
 import UIGuide.Component.Dialogs as Dialogs
 import UIGuide.Component.Dropdown as Dropdown
 import UIGuide.Component.ExpansionCards as ExpansionCards
+import UIGuide.Component.FilePicker as FilePicker
 import UIGuide.Component.FormControl as FormControl
 import UIGuide.Component.Icons as Icons
 import UIGuide.Component.Modals as Modals
@@ -128,5 +129,10 @@ routes = fromFoldable
     { anchor: "Diagram"
     , component: proxy Diagram.component
     , group: Basics
+    }
+  , Tuple "file-picker"
+    { anchor: "File Picker"
+    , component: proxy FilePicker.component
+    , group: Components
     }
   ]

--- a/ui-guide/Components/FilePicker.purs
+++ b/ui-guide/Components/FilePicker.purs
@@ -38,7 +38,7 @@ type Output
   = Void
 
 type ChildSlots =
-  ( filePicker :: Ocelot.FilePicker.Slot Unit
+  ( filePicker :: Ocelot.FilePicker.Slot String
   )
 
 _filePicker = SProxy :: SProxy "filePicker"
@@ -88,10 +88,28 @@ render state =
         [ Card.card
           [ Ocelot.HTML.Properties.css "flex-1" ]
           [ Halogen.HTML.h3
+            [ Halogen.HTML.Properties.classes Format.captionClasses ]
+            [ Halogen.HTML.text "Single" ]
+          , Halogen.HTML.slot _filePicker "Single"
+            ( Ocelot.FilePicker.component
+              { id: "file-single"
+              , multiple: false
+              }
+            )
+            unit
+            (Just <<< HandleFilePicker)
+          ]
+        , Card.card
+          [ Ocelot.HTML.Properties.css "flex-1" ]
+          [ Halogen.HTML.h3
               [ Halogen.HTML.Properties.classes Format.captionClasses ]
-              [ Halogen.HTML.text "Single" ]
-          , Halogen.HTML.slot _filePicker unit
-              Ocelot.FilePicker.component
+              [ Halogen.HTML.text "Multiple" ]
+          , Halogen.HTML.slot _filePicker "Multiple"
+              ( Ocelot.FilePicker.component
+                  { id: "file-multiple"
+                  , multiple: true
+                  }
+              )
               unit
               (Just <<< HandleFilePicker)
           ]

--- a/ui-guide/Components/FilePicker.purs
+++ b/ui-guide/Components/FilePicker.purs
@@ -2,7 +2,9 @@ module UIGuide.Component.FilePicker where
 
 import Prelude
 
+import DOM.HTML.Indexed.InputAcceptType as DOM.HTML.Indexed.InputAcceptType
 import Data.Maybe (Maybe(..))
+import Data.MediaType.Common as Data.MediaType.Common
 import Data.Symbol (SProxy(..))
 import Effect.Aff.Class (class MonadAff)
 import Effect.Class.Console as Effect.Class.Console
@@ -11,6 +13,7 @@ import Halogen.HTML as Halogen.HTML
 import Halogen.HTML.Properties as Halogen.HTML.Properties
 import Ocelot.Block.Card as Card
 import Ocelot.Block.Format as Format
+import Ocelot.Data.InputAcceptType as Ocelot.Data.InputAcceptType
 import Ocelot.FilePicker as Ocelot.FilePicker
 import Ocelot.HTML.Properties as Ocelot.HTML.Properties
 import UIGuide.Block.Backdrop as Backdrop
@@ -92,8 +95,42 @@ render state =
             [ Halogen.HTML.text "Single" ]
           , Halogen.HTML.slot _filePicker "Single"
             ( Ocelot.FilePicker.component
-              { id: "file-single"
-              , multiple: false
+                { accept: Nothing
+                , id: "file-single"
+                , multiple: false
+                }
+            )
+            unit
+            (Just <<< HandleFilePicker)
+          ]
+        , Card.card
+          [ Ocelot.HTML.Properties.css "flex-1" ]
+          [ Halogen.HTML.h3
+            [ Halogen.HTML.Properties.classes Format.captionClasses ]
+            [ Halogen.HTML.text "Multiple" ]
+          , Halogen.HTML.slot _filePicker "Multiple"
+            ( Ocelot.FilePicker.component
+                { accept: Nothing
+                , id: "file-multiple"
+                , multiple: true
+                }
+            )
+            unit
+            (Just <<< HandleFilePicker)
+          ]
+        , Card.card
+          [ Ocelot.HTML.Properties.css "flex-1" ]
+          [ Halogen.HTML.h3
+            [ Halogen.HTML.Properties.classes Format.captionClasses ]
+            [ Halogen.HTML.text "Single - CSV" ]
+          , Halogen.HTML.slot _filePicker "Single - CSV"
+            ( Ocelot.FilePicker.component
+              { accept:
+                  Just
+                    $ DOM.HTML.Indexed.InputAcceptType.mediaType
+                        Data.MediaType.Common.textCSV
+              , id: "file-single-csv"
+              , multiple: true
               }
             )
             unit
@@ -102,16 +139,17 @@ render state =
         , Card.card
           [ Ocelot.HTML.Properties.css "flex-1" ]
           [ Halogen.HTML.h3
-              [ Halogen.HTML.Properties.classes Format.captionClasses ]
-              [ Halogen.HTML.text "Multiple" ]
-          , Halogen.HTML.slot _filePicker "Multiple"
-              ( Ocelot.FilePicker.component
-                  { id: "file-multiple"
-                  , multiple: true
-                  }
-              )
-              unit
-              (Just <<< HandleFilePicker)
+            [ Halogen.HTML.Properties.classes Format.captionClasses ]
+            [ Halogen.HTML.text "Multiple - Image" ]
+          , Halogen.HTML.slot _filePicker "Multiple - Image"
+            ( Ocelot.FilePicker.component
+              { accept: Just Ocelot.Data.InputAcceptType.allImages
+              , id: "file-multiple-image"
+              , multiple: true
+              }
+            )
+            unit
+            (Just <<< HandleFilePicker)
           ]
         ]
       ]

--- a/ui-guide/Components/FilePicker.purs
+++ b/ui-guide/Components/FilePicker.purs
@@ -1,0 +1,86 @@
+module UIGuide.Component.FilePicker where
+
+import Prelude
+
+import Data.Maybe (Maybe(..))
+import Data.Symbol (SProxy(..))
+import Effect.Aff.Class (class MonadAff)
+import Halogen as Halogen
+import Halogen.HTML as Halogen.HTML
+import Halogen.HTML.Properties as Halogen.HTML.Properties
+import Ocelot.Block.Card as Card
+import Ocelot.Block.Format as Format
+import Ocelot.FilePicker as Ocelot.FilePicker
+import Ocelot.HTML.Properties as Ocelot.HTML.Properties
+import UIGuide.Block.Backdrop as Backdrop
+import UIGuide.Block.Documentation as Documentation
+
+type Component m = Halogen.Component Halogen.HTML.HTML Query Input Output m
+
+type ComponentHTML m = Halogen.ComponentHTML Action ChildSlots m
+
+type ComponentM m a = Halogen.HalogenM State Action ChildSlots Output m a
+
+type State
+  = {}
+
+data Action
+
+data Query a
+
+type Input
+  = Unit
+
+type Output
+  = Void
+
+type ChildSlots =
+  ( filePicker :: Ocelot.FilePicker.Slot Unit
+  )
+
+_filePicker = SProxy :: SProxy "filePicker"
+
+component ::
+  forall m.
+  MonadAff m =>
+  Component m
+component =
+  Halogen.mkComponent
+    { initialState
+    , render
+    , eval:
+      Halogen.mkEval
+        Halogen.defaultEval
+    }
+
+initialState :: Input -> State
+initialState _ = {}
+
+render ::
+  forall m.
+  MonadAff m =>
+  State ->
+  ComponentHTML m
+render state =
+  Halogen.HTML.div_
+  [ Documentation.customBlock_
+    { header: "File Picker"
+    , subheader: "Select File(s) from File System"
+    }
+    [ Backdrop.backdrop_
+      [ Backdrop.content_
+        [ Card.card
+          [ Ocelot.HTML.Properties.css "flex-1" ]
+          [ Halogen.HTML.h3
+              [ Halogen.HTML.Properties.classes Format.captionClasses ]
+              [ Halogen.HTML.text "Single" ]
+          , Halogen.HTML.slot _filePicker unit
+              Ocelot.FilePicker.component
+              unit
+              (const Nothing)
+          ]
+        ]
+      ]
+    ]
+  ]
+

--- a/ui-guide/Components/FilePicker.purs
+++ b/ui-guide/Components/FilePicker.purs
@@ -5,6 +5,7 @@ import Prelude
 import Data.Maybe (Maybe(..))
 import Data.Symbol (SProxy(..))
 import Effect.Aff.Class (class MonadAff)
+import Effect.Class.Console as Effect.Class.Console
 import Halogen as Halogen
 import Halogen.HTML as Halogen.HTML
 import Halogen.HTML.Properties as Halogen.HTML.Properties
@@ -14,6 +15,7 @@ import Ocelot.FilePicker as Ocelot.FilePicker
 import Ocelot.HTML.Properties as Ocelot.HTML.Properties
 import UIGuide.Block.Backdrop as Backdrop
 import UIGuide.Block.Documentation as Documentation
+import Web.File.File as Web.File.File
 
 type Component m = Halogen.Component Halogen.HTML.HTML Query Input Output m
 
@@ -25,6 +27,7 @@ type State
   = {}
 
 data Action
+  = HandleFilePicker Ocelot.FilePicker.Output
 
 data Query a
 
@@ -51,10 +54,23 @@ component =
     , eval:
       Halogen.mkEval
         Halogen.defaultEval
+          { handleAction = handleAction
+          }
     }
 
 initialState :: Input -> State
 initialState _ = {}
+
+handleAction ::
+  forall m.
+  MonadAff m =>
+  Action ->
+  ComponentM m Unit
+handleAction = case _ of
+  HandleFilePicker output -> case output of
+    Ocelot.FilePicker.Selected files -> do
+      Halogen.liftEffect <<< Effect.Class.Console.log $
+        "file selected: " <> show (map Web.File.File.name $ files)
 
 render ::
   forall m.
@@ -77,7 +93,7 @@ render state =
           , Halogen.HTML.slot _filePicker unit
               Ocelot.FilePicker.component
               unit
-              (const Nothing)
+              (Just <<< HandleFilePicker)
           ]
         ]
       ]


### PR DESCRIPTION
## What does this pull request do?

Add `Ocelot.FilePicker` component which
- allows selecting single/multiple file(s) by drag-and-drop or using browser/OS native file picker
- allows restricting acceptable files by a list of MIME types and/or file extensions
