### PR TITLE
AS-1278 Centralize FilePicker label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-ocelot",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "private": true,
   "scripts": {
     "build-all": "make build",

--- a/src/FilePicker.purs
+++ b/src/FilePicker.purs
@@ -283,7 +283,7 @@ renderLabel ::
   ComponentHTML m
 renderLabel state =
   Halogen.HTML.label
-    [ Ocelot.HTMl.Properties.css "group text-center"
+    [ Ocelot.HTMl.Properties.css "group text-center w-full"
     , Halogen.HTML.Properties.for state.config.id
     ]
     [ Halogen.HTML.span


### PR DESCRIPTION
## What does this pull request do?

In Ocelot UIGuide, the label was properly centered but in combination with CN css it's not. Fix it by adding `w-full`.