### PR TITLE
AS-1316 Fix Typeahead border glitch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-ocelot",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "private": true,
   "scripts": {
     "build-all": "make build",

--- a/src/Blocks/Input.purs
+++ b/src/Blocks/Input.purs
@@ -38,7 +38,6 @@ inputGroupClasses = HH.ClassName <$>
   [ "flex"
   , "group"
   , "w-full"
-  , "items-center"
   ]
 
 mainItemClasses :: Array HH.ClassName
@@ -92,6 +91,8 @@ addonClasses :: Array HH.ClassName
 addonClasses = inputSharedClasses <>
   ( HH.ClassName <$>
     [ "cursor-pointer"
+    , "flex"
+    , "items-center"
     , "text-grey-70"
     ]
   )


### PR DESCRIPTION
## What does this pull request do?

The border glitch on Typeahead component happens when the search content cannot be fit into a single line like this
<img src="https://user-images.githubusercontent.com/18127498/118331235-53fca780-b4d6-11eb-820d-9935d241570e.png" width=200px />
which can be reproduced by going to [UIGuide > Typeahead](https://citizennet.github.io/purescript-ocelot/#typeaheads) and resize the width of the browser window to roughly half screen.

When the container (inputGroup) has "flex" (display: flex), all items will have the same height meaning items of less content will be assigned the same height as the one with the most content. But when the container also has "items-center" (align-items: center) or any item has "self-center" (align-self: center), items' heights are no longer regulated by the container, which cause the glitch that the boundary of search box(`addonLeft`) disconnects with the boundary of button (`addonRight`) when the content of
search box cannot be fit into a single line.

We fix it by moving the "items-center" class name from container to each item (`addon*` blocks) so that their heights are the same and their contents are centered inside.

<img src="https://user-images.githubusercontent.com/18127498/118331743-003e8e00-b4d7-11eb-83c5-433346fd11bb.png" width=200px />
