### PR TITLE
AS-1317 Upgrade Halogen to v6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,10 @@ jobs:
     steps:
       - checkout
 
+      - run:
+          name: Install libtinfo (required until purescript 0.14.2)
+          command: sudo apt install libtinfo5 libncurses5-dev
+
       - restore_cache:
           keys:
             - v4-yarn-cache-{{ .Branch }}-{{ checksum "package.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ defaults: &defaults
   docker:
     - image: circleci/node:10.15-browsers
   environment:
+    GLIBC_VERSION: 2.27-r0
     RTS_ARGS: +RTS -N2 -RTS
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,8 @@ version: 2
 defaults: &defaults
   working_directory: ~/ocelot
   docker:
-    - image: circleci/node:10.15-browsers
+    - image: circleci/node:10.24-buster-browsers
   environment:
-    GLIBC_VERSION: 2.27-r0
     RTS_ARGS: +RTS -N2 -RTS
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-ocelot",
-  "version": "0.28.2",
+  "version": "0.29.0",
   "private": true,
   "scripts": {
     "build-all": "make build",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "browserify": "^16.5.1",
     "parcel": "1.12.4",
     "parcel-bundler": "1.12.3",
-    "purescript": "^0.13.8",
+    "purescript": "0.14.1",
     "spago": "^0.15.2"
   },
   "dependencies": {

--- a/packages.dhall
+++ b/packages.dhall
@@ -126,11 +126,37 @@ let halogen-renderless =
       , version = "v0.0.4"
       }
 
+let html-parser-halogen =
+      { dependencies = [ "string-parsers", "halogen" ]
+      , repo =
+          "https://github.com/rnons/purescript-html-parser-halogen.git"
+      , version = "v1.0.0-rc.2"
+      }
+
+let svg-parser =
+      { dependencies = [ "prelude", "string-parsers" ]
+      , repo =
+          "https://github.com/citizennet/purescript-svg-parser.git"
+      , version = "v2.0.0"
+      }
+
+let svg-parser-halogen =
+      { dependencies = [ "svg-parser", "halogen" ]
+      , repo =
+          "https://github.com/rnons/purescript-svg-parser-halogen.git"
+      , version = "v2.0.0-rc.1"
+      }
+
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20200724/packages.dhall sha256:bb941d30820a49345a0e88937094d2b9983d939c9fd3a46969b85ce44953d7d9
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.1-20210506/packages.dhall sha256:d199e142515f9cc15838d8e6d724a98cd0ca776ceb426b7b36e841311643e3ef
 
 let overrides = {=}
 
-let additions = { halogen-renderless }
+let additions =
+      { halogen-renderless
+      , html-parser-halogen
+      , svg-parser
+      , svg-parser-halogen
+      }
 
 in  upstream // overrides // additions

--- a/spago.dhall
+++ b/spago.dhall
@@ -31,6 +31,7 @@ Authors:
   , "halogen-svg-elems"
   , "html-parser-halogen"
   , "js-timers"
+  , "js-uri"
   , "numbers"
   , "psci-support"
   , "read"

--- a/src/Blocks/Pager.purs
+++ b/src/Blocks/Pager.purs
@@ -18,7 +18,7 @@ import Web.UIEvent.MouseEvent (MouseEvent)
 -----
 -- old CN pager (require citizennet.css)
 
-pager :: ∀ p i. Int -> Int -> (Int -> MouseEvent -> Maybe i) -> HH.HTML p i
+pager :: ∀ p i. Int -> Int -> (Int -> MouseEvent -> i) -> HH.HTML p i
 pager skip last query =
   HH.div
     [ HP.classes
@@ -102,7 +102,7 @@ pagerNew ::
   Int ->
   Int ->
   Array (HP.IProp HTMLdiv i) ->
-  (Int -> MouseEvent -> Maybe i) ->
+  (Int -> MouseEvent -> i) ->
   HH.HTML p i
 pagerNew skip last iprops query = HH.div iprops (makePagingButtonsNew skip last query)
 
@@ -110,7 +110,7 @@ makePagingButtonsNew ::
   forall p i.
   Int ->
   Int ->
-  (Int -> MouseEvent -> Maybe i) ->
+  (Int -> MouseEvent -> i) ->
   Array (HH.HTML p i)
 makePagingButtonsNew skip last query = foldlWithIndex makePagingButtons' [] makeList
   where

--- a/src/Components/MultiInput/Component.purs
+++ b/src/Components/MultiInput/Component.purs
@@ -420,7 +420,7 @@ measureTextWidth ::
   String ->
   ComponentM m (Maybe Number)
 measureTextWidth text = do
-  Halogen.query _textWidth unit <<< Halogen.request
+  Halogen.request _textWidth unit
     $ Ocelot.Components.MultiInput.TextWidth.GetWidth text
 
 preventDefault ::

--- a/src/Components/MultiInput/Component.purs
+++ b/src/Components/MultiInput/Component.purs
@@ -28,7 +28,7 @@ import Web.UIEvent.KeyboardEvent as Web.UIEvent.KeyboardEvent
 
 type Slot = Halogen.Slot Query Output
 
-type Component m = Halogen.Component Halogen.HTML.HTML Query Input Output m
+type Component m = Halogen.Component Query Input Output m
 type ComponentHTML m = Halogen.ComponentHTML Action ChildSlots m
 type ComponentM m a = Halogen.HalogenM State Action ChildSlots Output m a
 

--- a/src/Components/MultiInput/Component.purs
+++ b/src/Components/MultiInput/Component.purs
@@ -13,7 +13,6 @@ import Data.FunctorWithIndex as Data.FunctorWithIndex
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Maybe as Data.Maybe
 import Data.String as Data.String
-import Data.Symbol (SProxy(..))
 import Effect.Aff.Class (class MonadAff)
 import Halogen as Halogen
 import Halogen.HTML as Halogen.HTML
@@ -22,6 +21,7 @@ import Halogen.HTML.Properties as Halogen.HTML.Properties
 import Ocelot.Block.Icon as Ocelot.Block.Icon
 import Ocelot.Components.MultiInput.TextWidth as Ocelot.Components.MultiInput.TextWidth
 import Ocelot.HTML.Properties as Ocelot.HTML.Properties
+import Type.Proxy (Proxy(..))
 import Web.Event.Event as Web.Event.Event
 import Web.HTML.HTMLElement as Web.HTML.HTMLElement
 import Web.UIEvent.KeyboardEvent as Web.UIEvent.KeyboardEvent
@@ -86,7 +86,7 @@ type ChildSlots =
   ( textWidth :: Ocelot.Components.MultiInput.TextWidth.Slot Unit
   )
 
-_textWidth = SProxy :: SProxy "textWidth"
+_textWidth = Proxy :: Proxy "textWidth"
 
 component ::
   forall m.

--- a/src/Components/MultiInput/Component.purs
+++ b/src/Components/MultiInput/Component.purs
@@ -514,11 +514,11 @@ renderItemDisplay index text =
   Halogen.HTML.div
     [ Halogen.HTML.Properties.classes itemDisplayClasses ]
     [ Halogen.HTML.span
-        [ Halogen.HTML.Events.onClick \_ -> Just (EditItem index) ]
+        [ Halogen.HTML.Events.onClick \_ -> EditItem index ]
         [ Halogen.HTML.text text ]
     , Halogen.HTML.button
         [ Halogen.HTML.Properties.classes closeButtonClasses
-        , Halogen.HTML.Events.onClick \_ -> Just (RemoveOne index)
+        , Halogen.HTML.Events.onClick \_ -> RemoveOne index
         ]
         [ Ocelot.Block.Icon.delete_ ]
     ]
@@ -535,7 +535,7 @@ renderItemEdit placeholder index inputBox =
     [ renderAutoSizeInput placeholder index false inputBox
     , Halogen.HTML.button
         [ Halogen.HTML.Properties.classes closeButtonClasses
-        , Halogen.HTML.Events.onClick \_ -> Just (RemoveOne index)
+        , Halogen.HTML.Events.onClick \_ -> RemoveOne index
         ]
         [ Ocelot.Block.Icon.delete_ ]
     ]
@@ -553,9 +553,9 @@ renderAutoSizeInput placeholder index new inputBox =
     [ Halogen.HTML.input
         [ Halogen.HTML.Properties.attr (Halogen.HTML.AttrName "style") css
         , Halogen.HTML.Properties.classes inputClasses
-        , Halogen.HTML.Events.onBlur \_ -> Just (OnBlur index)
-        , Halogen.HTML.Events.onKeyDown (Just <<< OnKeyDown index)
-        , Halogen.HTML.Events.onValueInput (Just <<< OnInput index)
+        , Halogen.HTML.Events.onBlur \_ -> OnBlur index
+        , Halogen.HTML.Events.onKeyDown (OnKeyDown index)
+        , Halogen.HTML.Events.onValueInput (OnInput index)
         , Halogen.HTML.Properties.placeholder case new of
             false -> ""
             true

--- a/src/Components/MultiInput/TextWidth.purs
+++ b/src/Components/MultiInput/TextWidth.purs
@@ -25,7 +25,7 @@ import Web.HTML.HTMLElement as Web.HTML.HTMLElement
 
 type Slot = Halogen.Slot Query Output
 
-type Component m = Halogen.Component Halogen.HTML.HTML Query Input Output m
+type Component m = Halogen.Component Query Input Output m
 type ComponentHTML m = Halogen.ComponentHTML Action ChildSlots m
 type ComponentM m a = Halogen.HalogenM State Action ChildSlots Output m a
 

--- a/src/Components/SearchBar.purs
+++ b/src/Components/SearchBar.purs
@@ -171,7 +171,7 @@ render :: forall m.
 render st@{ query, open } =
   HH.label
     [ HP.classes $ containerClasses <> containerCondClasses
-    , HE.onClick (Just <<< const Open)
+    , HE.onClick \_ -> Open
     ]
     [ HH.div
       [ HP.classes $ iconClasses <> iconCondClasses ]
@@ -179,16 +179,16 @@ render st@{ query, open } =
     , HH.div
       [ css "flex-grow" ]
       [ HH.input
-        [ HE.onValueInput (Just <<< Search)
+        [ HE.onValueInput Search
         , HP.placeholder "Search"
         , HP.value query
         , HP.classes $ inputClasses <> inputCondClasses
-        , HE.onBlur (Just <<< const Blur)
+        , HE.onBlur \_ -> Blur
         , HP.tabIndex 0
         ]
       ]
     , HH.button
-      [ HE.onClick $ Just <<< Clear
+      [ HE.onClick Clear
       , HP.type_ HP.ButtonButton
       , HP.classes $ buttonClasses <> buttonCondClasses <> hideClearClasses
       ]

--- a/src/Components/SearchBar.purs
+++ b/src/Components/SearchBar.purs
@@ -56,7 +56,7 @@ data Message
  = Searched String
 
 -- | The standard search bar
-component :: ∀ m. MonadAff m => H.Component HH.HTML Query Input Message m
+component :: ∀ m. MonadAff m => H.Component Query Input Message m
 component =
   H.mkComponent
     { initialState
@@ -76,7 +76,7 @@ component =
 
 -- | A search bar which allows the user to specify if it should
 -- | stay open when unfocused
-component' :: ∀ m. MonadAff m => H.Component HH.HTML Query Input' Message m
+component' :: ∀ m. MonadAff m => H.Component Query Input' Message m
 component' =
   H.mkComponent
     { initialState

--- a/src/Components/Tree/Component.purs
+++ b/src/Components/Tree/Component.purs
@@ -80,14 +80,14 @@ render { items, renderItem, checkable } =
           [ css "inline-flex" ]
           [ Conditional.alt_ (checkable value)
             [ Checkbox.checkbox_
-              [ HE.onChecked $ Just <<< ToggleItem value itemPath (A.cons ix indexPath)
+              [ HE.onChecked $ ToggleItem value itemPath (A.cons ix indexPath)
               , HP.checked selected
               ]
               [ HH.fromPlainHTML $ renderItem value ]
             ]
             [ HH.span
               [ css "cursor-pointer"
-              , HE.onClick $ Just <<< const (ToggleChildren path)
+              , HE.onClick \_ -> ToggleChildren path
               ]
               [ HH.fromPlainHTML $ renderItem value ]
             ]
@@ -108,7 +108,7 @@ render { items, renderItem, checkable } =
 
     renderCarat children expanded path =
       carat
-        [ HE.onClick $ Just <<< const (ToggleChildren path)
+        [ HE.onClick \_ -> ToggleChildren path
         , css $ "mr-3 text-xl align-text-bottom cursor-pointer " <> visible
         ]
       where

--- a/src/Components/Tree/Component.purs
+++ b/src/Components/Tree/Component.purs
@@ -49,7 +49,7 @@ data Message item
 component :: ∀ m item.
   MonadAff m =>
   Eq item =>
-  H.Component HH.HTML (Query item) (Input item) (Message item) m
+  H.Component (Query item) (Input item) (Message item) m
 component =
   H.mkComponent
     { initialState

--- a/src/Data/IntervalTree.purs
+++ b/src/Data/IntervalTree.purs
@@ -17,7 +17,7 @@ import Prelude
 import Data.Array as Data.Array
 import Data.FoldableWithIndex as Data.FoldableWithIndex
 import Data.Generic.Rep as Data.Generic.Rep
-import Data.Generic.Rep.Show as Data.Generic.Rep.Show
+import Data.Show.Generic as Data.Show.Generic
 import Data.Map as Data.Map
 import Data.Maybe (Maybe(..))
 import Data.Tuple as Data.Tuple
@@ -33,7 +33,7 @@ derive instance eqIntervalPoint :: Eq IntervalPoint
 derive instance genericIntervalPoint :: Data.Generic.Rep.Generic IntervalPoint _
 
 instance showIntervalPoint :: Show IntervalPoint where
-  show = Data.Generic.Rep.Show.genericShow
+  show = Data.Show.Generic.genericShow
 
 -- | O(n log n)
 fromIntervals ::

--- a/src/Data/IntervalTree.purs
+++ b/src/Data/IntervalTree.purs
@@ -41,7 +41,7 @@ fromIntervals ::
   Ord a =>
   Array { start :: a, end :: a } ->
   IntervalTree a
-fromIntervals = Data.Array.foldl insertInterval mempty
+fromIntervals = Data.Array.foldl insertInterval Data.Map.empty
 
 -- | O(log n)
 -- |
@@ -85,7 +85,7 @@ insertInterval old { start, end }
   clearBetween :: IntervalTree a -> IntervalTree a
   clearBetween xs =
     Data.Map.submap Nothing (Just lowerBound) xs
-      <> Data.Map.submap (Just upperBound) Nothing xs
+      `Data.Map.union` Data.Map.submap (Just upperBound) Nothing xs
 
   lowerBound :: a
   lowerBound = case findGreatestLowerBound start old of

--- a/src/DatePicker.purs
+++ b/src/DatePicker.purs
@@ -249,7 +249,7 @@ calendarNav y m =
     -- in Raise.
     arrowButton q =
       Button.buttonClear
-        [ HE.onClick $ Just <<< S.Action <<< const q
+        [ HE.onClick $ S.Action <<< const q
         , css "text-grey-70 p-3"
         ]
 
@@ -496,7 +496,7 @@ padPrev Saturday  = (-6.0)
 
 render :: forall m. MonadAff m => ComponentRender m
 render st =
-  HH.slot _select unit (S.component identity spec) (embeddedInput st) (Just <<< PassingOutput)
+  HH.slot _select unit (S.component identity spec) (embeddedInput st) PassingOutput
 
 renderCalendar :: forall m. Year -> Month -> Array CalendarItem -> CompositeComponentHTML m
 renderCalendar y m calendarItems =
@@ -601,8 +601,8 @@ renderSearch :: forall m. String -> CompositeComponentHTML m
 renderSearch search =
   Input.input
   $ SS.setInputProps
-    [ HE.onBlur \_ -> Just (S.Action OnBlur)
-    , HE.onKeyDown $ Just <<< S.Action <<< Key
+    [ HE.onBlur \_ -> S.Action OnBlur
+    , HE.onKeyDown $ S.Action <<< Key
     , HP.value search
     ]
 

--- a/src/DatePicker.purs
+++ b/src/DatePicker.purs
@@ -92,7 +92,7 @@ type ChildSlots =
   ( select :: S.Slot Query EmbeddedChildSlots Output Unit
   )
 
-type Component m = H.Component HH.HTML Query Input Output m
+type Component m = H.Component Query Input Output m
 
 type ComponentHTML m = H.ComponentHTML Action ChildSlots m
 
@@ -102,7 +102,7 @@ type ComponentRender m = State -> ComponentHTML m
 
 type CompositeAction = S.Action EmbeddedAction
 
-type CompositeComponent m = H.Component HH.HTML CompositeQuery CompositeInput Output m
+type CompositeComponent m = H.Component CompositeQuery CompositeInput Output m
 
 type CompositeComponentHTML m = H.ComponentHTML CompositeAction EmbeddedChildSlots m
 

--- a/src/DatePicker.purs
+++ b/src/DatePicker.purs
@@ -437,12 +437,12 @@ handleAction = case _ of
 handleQuery :: forall m a. Query a -> ComponentM m (Maybe a)
 handleQuery = case _ of
   GetSelection reply -> do
-    response <- H.query _select unit (S.Query $ H.request GetSelection)
+    response <- H.request _select unit (S.Query <<< GetSelection)
     pure $ reply <$> response
   SetDisabled disabled a -> Just a <$ do
-    H.query _select unit (S.Query $ H.tell $ SetDisabled disabled)
+    H.tell _select unit (S.Query <<< SetDisabled disabled)
   SetSelection selection a -> Just a <$ do
-    H.query _select unit (S.Query $ H.tell $ SetSelection selection)
+    H.tell _select unit (S.Query <<< SetSelection selection)
 
 handleSearch :: forall m. MonadAff m => CompositeComponentM m Unit
 handleSearch = do

--- a/src/DatePicker.purs
+++ b/src/DatePicker.purs
@@ -59,7 +59,7 @@ import Ocelot.Data.DateTime as ODT
 import Ocelot.HTML.Properties (css)
 import Select as S
 import Select.Setters as SS
-import Type.Data.Symbol (SProxy(..))
+import Type.Proxy (Proxy(..))
 import Web.Event.Event (preventDefault)
 import Web.UIEvent.KeyboardEvent (KeyboardEvent)
 import Web.UIEvent.KeyboardEvent as KE
@@ -188,7 +188,7 @@ component = H.mkComponent
 ---------
 -- Values
 
-_select = SProxy :: SProxy "select"
+_select = Proxy :: Proxy "select"
 
 -- Summary helper function that creates a full grid calendar layout
 -- from a year and a month.

--- a/src/DateTimePicker.purs
+++ b/src/DateTimePicker.purs
@@ -37,7 +37,7 @@ type ChildSlots =
   , timepicker :: TimePicker.Slot Unit
   )
 
-type Component m = H.Component HH.HTML Query Input Output m
+type Component m = H.Component Query Input Output m
 
 type ComponentHTML m = H.ComponentHTML Action ChildSlots m
 

--- a/src/DateTimePicker.purs
+++ b/src/DateTimePicker.purs
@@ -21,8 +21,8 @@ import Effect.Aff.Class (class MonadAff)
 import Halogen as H
 import Halogen.HTML as HH
 import Ocelot.DatePicker as DatePicker
-import Ocelot.TimePicker as TimePicker
 import Ocelot.HTML.Properties (css)
+import Ocelot.TimePicker as TimePicker
 import Type.Proxy (Proxy(..))
 
 --------
@@ -113,13 +113,13 @@ handleQuery = case _ of
     pure $ reply <$> (DateTime <$> date <*> time)
   SetDisabled disabled a -> Just a <$ do
     H.modify_ _ { disabled = disabled }
-    void $ H.query _datepicker unit $ H.tell $ DatePicker.SetDisabled disabled
-    void $ H.query _timepicker unit $ H.tell $ TimePicker.SetDisabled disabled
+    void $ H.tell _datepicker unit $ DatePicker.SetDisabled disabled
+    void $ H.tell _timepicker unit $ TimePicker.SetDisabled disabled
   SetSelection dateTime a -> Just a <$ do
     let date' = date <$> dateTime
         time' = time <$> dateTime
-    void $ H.query _datepicker unit $ H.tell $ DatePicker.SetSelection date'
-    void $ H.query _timepicker unit $ H.tell $ TimePicker.SetSelection time'
+    void $ H.tell _datepicker unit $ DatePicker.SetSelection date'
+    void $ H.tell _timepicker unit $ TimePicker.SetSelection time'
     H.modify_ _ { date = date', time = time' }
   SendDateQuery q a -> Just a <$ H.query _datepicker unit q
   SendTimeQuery q a -> Just a <$ H.query _timepicker unit q

--- a/src/DateTimePicker.purs
+++ b/src/DateTimePicker.purs
@@ -143,12 +143,12 @@ render { date, time, targetDate, disabled } =
         , selection: date
         , disabled
         }
-        (Just <<< HandleDate)
+        HandleDate
       ]
     , HH.div
       [ css "flex-1" ]
       [ HH.slot _timepicker unit TimePicker.component
         { selection: time, disabled }
-        (Just <<< HandleTime)
+        HandleTime
       ]
     ]

--- a/src/DateTimePicker.purs
+++ b/src/DateTimePicker.purs
@@ -23,7 +23,7 @@ import Halogen.HTML as HH
 import Ocelot.DatePicker as DatePicker
 import Ocelot.TimePicker as TimePicker
 import Ocelot.HTML.Properties (css)
-import Type.Data.Symbol (SProxy(..))
+import Type.Proxy (Proxy(..))
 
 --------
 -- Types
@@ -88,8 +88,8 @@ component = H.mkComponent
 ---------
 -- Values
 
-_datepicker = SProxy :: SProxy "datepicker"
-_timepicker = SProxy :: SProxy "timepicker"
+_datepicker = Proxy :: Proxy "datepicker"
+_timepicker = Proxy :: Proxy "timepicker"
 
 handleAction :: forall m. Action -> ComponentM m Unit
 handleAction = case _ of

--- a/src/Dropdown.purs
+++ b/src/Dropdown.purs
@@ -258,7 +258,7 @@ renderAdapter
 renderAdapter render state =
   Halogen.HTML.slot _select unit (Select.component identity $ spec render)
     (embeddedInput state)
-    (Just <<< PassingOutput)
+    PassingOutput
 
 spec
   :: forall item m

--- a/src/Dropdown.purs
+++ b/src/Dropdown.purs
@@ -46,7 +46,7 @@ import Ocelot.HTML.Properties as Ocelot.HTML.Properties
 import Renderless.State as Renderless.State
 import Select as Select
 import Select.Setters as Select.Setters
-import Type.Data.Symbol (SProxy(..))
+import Type.Proxy (Proxy(..))
 
 --------
 -- Types
@@ -154,7 +154,7 @@ component = Halogen.mkComponent
 ---------
 -- Values
 
-_select = SProxy :: SProxy "select"
+_select = Proxy :: Proxy "select"
 
 defDropdown
   :: ∀ item m

--- a/src/Dropdown.purs
+++ b/src/Dropdown.purs
@@ -65,7 +65,7 @@ type ChildSlots item
     )
 
 type Component item m 
-  = Halogen.Component Halogen.HTML.HTML (Query item) (Input item m) (Output item) m
+  = Halogen.Component (Query item) (Input item m) (Output item) m
 
 type ComponentHTML item m 
   = Halogen.ComponentHTML (Action item m) (ChildSlots item) m
@@ -80,7 +80,7 @@ type CompositeAction
   = Select.Action EmbeddedAction
 
 type CompositeComponent item m 
-  = Halogen.Component Halogen.HTML.HTML (CompositeQuery item) (CompositeInput item) (Output item) m
+  = Halogen.Component (CompositeQuery item) (CompositeInput item) (Output item) m
 
 type CompositeComponentHTML m 
   = Halogen.ComponentHTML CompositeAction EmbeddedChildSlots m

--- a/src/Dropdown.purs
+++ b/src/Dropdown.purs
@@ -31,11 +31,11 @@ module Ocelot.Dropdown
 import Prelude
 import Control.Comonad as Control.Comonad
 import Control.Comonad.Store as Control.Comonad.Store
+import DOM.HTML.Indexed as DOM.HTML.Indexed
 import Data.Array ((!!))
 import Data.Array as Data.Array
 import Data.Maybe (Maybe(..))
 import Data.Maybe as Data.Maybe
-import DOM.HTML.Indexed as DOM.HTML.Indexed
 import Effect.Aff.Class as Effect.Aff.Class
 import Halogen as Halogen
 import Halogen.HTML as Halogen.HTML
@@ -240,11 +240,11 @@ handleAction = case _ of
 handleQuery :: forall item m a. Query item a -> ComponentM item m (Maybe a)
 handleQuery = case _ of
   SetDisabled disabled a -> Just a <$ do
-    Halogen.query _select unit (Select.Query $ Halogen.tell $ SetDisabled disabled)
+    Halogen.tell _select unit (Select.Query <<< SetDisabled disabled)
   SetItems items a -> Just a <$ do
-    Halogen.query _select unit (Select.Query $ Halogen.tell $ SetItems items)
+    Halogen.tell _select unit (Select.Query <<< SetItems items)
   SetSelection item a -> Just a <$ do
-    Halogen.query _select unit (Select.Query $ Halogen.tell $ SetSelection item)
+    Halogen.tell _select unit (Select.Query <<< SetSelection item)
 
 initialState :: forall item m. Effect.Aff.Class.MonadAff m => Input item m -> StateStore item m
 initialState { disabled, items, render, selectedItem } =

--- a/src/FilePicker.purs
+++ b/src/FilePicker.purs
@@ -38,7 +38,7 @@ type Config
 
 type Slot = Halogen.Slot Query Output
 
-type Component m = Halogen.Component Halogen.HTML.HTML Query Input Output m
+type Component m = Halogen.Component Query Input Output m
 type ComponentHTML m = Halogen.ComponentHTML Action ChildSlots m
 type ComponentM m a = Halogen.HalogenM State Action ChildSlots Output m a
 

--- a/src/FilePicker.purs
+++ b/src/FilePicker.purs
@@ -202,10 +202,10 @@ ipropIdle :: Array (Halogen.HTML.Properties.IProp HTMLdiv Action)
 ipropIdle =
   [ Ocelot.HTMl.Properties.css cssIdle
   , Ocelot.HTMl.Properties.style styleIdle
-  , Ocelot.HTML.Events.onDrag (Just <<< PreventDefault <<< Web.HTML.Event.DragEvent.toEvent)
-  , Ocelot.HTML.Events.onDragEnter (Just <<< DragEnter)
-  , Ocelot.HTML.Events.onDragOver (Just <<< PreventDefault <<< Web.HTML.Event.DragEvent.toEvent)
-  , Ocelot.HTML.Events.onDragStart (Just <<< PreventDefault <<< Web.HTML.Event.DragEvent.toEvent)
+  , Ocelot.HTML.Events.onDrag (PreventDefault <<< Web.HTML.Event.DragEvent.toEvent)
+  , Ocelot.HTML.Events.onDragEnter DragEnter
+  , Ocelot.HTML.Events.onDragOver (PreventDefault <<< Web.HTML.Event.DragEvent.toEvent)
+  , Ocelot.HTML.Events.onDragStart (PreventDefault <<< Web.HTML.Event.DragEvent.toEvent)
   ]
   where
   cssIdle :: String
@@ -223,10 +223,10 @@ ipropDragOver :: Array (Halogen.HTML.Properties.IProp HTMLdiv Action)
 ipropDragOver =
   [ Ocelot.HTMl.Properties.css cssDragOver
   , Ocelot.HTMl.Properties.style styleDragOver
-  , Ocelot.HTML.Events.onDragEnd (Just <<< PreventDefault <<< Web.HTML.Event.DragEvent.toEvent)
-  , Ocelot.HTML.Events.onDragLeave (Just <<< DragLeave)
-  , Ocelot.HTML.Events.onDragOver (Just <<< PreventDefault <<< Web.HTML.Event.DragEvent.toEvent)
-  , Ocelot.HTML.Events.onDrop (Just <<< DropFile)
+  , Ocelot.HTML.Events.onDragEnd (PreventDefault <<< Web.HTML.Event.DragEvent.toEvent)
+  , Ocelot.HTML.Events.onDragLeave DragLeave
+  , Ocelot.HTML.Events.onDragOver (PreventDefault <<< Web.HTML.Event.DragEvent.toEvent)
+  , Ocelot.HTML.Events.onDrop DropFile
   ]
   where
   cssDragOver :: String
@@ -269,7 +269,7 @@ renderInput state =
     ( [ Ocelot.HTMl.Properties.css "hidden"
       , Halogen.HTML.Properties.id_ state.config.id
       , Halogen.HTML.Properties.type_ Halogen.HTML.Properties.InputFile
-      , Ocelot.HTML.Events.onFileUpload (Just <<< ChooseFile)
+      , Ocelot.HTML.Events.onFileUpload ChooseFile
       , Halogen.HTML.Properties.multiple state.config.multiple
       ]
         <> case state.config.accept of

--- a/src/Interfaces/Utilities.purs
+++ b/src/Interfaces/Utilities.purs
@@ -2,7 +2,6 @@ module Ocelot.Interface.Utilities where
 
 import Prelude
 
-import Control.Coroutine (consumer)
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Aff (Aff, error, killFiber, launchAff, launchAff_)
@@ -10,6 +9,7 @@ import Effect.Aff.AVar (AVar, read) as AffAVar
 import Effect.Aff.Compat (EffectFn1, mkEffectFn1, runEffectFn1)
 import Effect.Class (liftEffect)
 import Halogen (HalogenIO)
+import Halogen.Subscription as Halogen.Subscription
 
 -- | A row containing the 'subscribe' function from Halogen so it
 -- | may be used to subscribe to the message variant in JS.
@@ -33,7 +33,7 @@ mkSubscription
 mkSubscription ioVar convertMessage = mkEffectFn1 \cb -> do
   fiber <- launchAff do
     io <- AffAVar.read ioVar
-    io.subscribe $ consumer \msg -> do
+    void $ liftEffect $ Halogen.Subscription.subscribe io.messages \msg -> do
       let msgVariant = convertMessage msg
       liftEffect $ runEffectFn1 cb msgVariant
       pure Nothing

--- a/src/Parts/Modal.purs
+++ b/src/Parts/Modal.purs
@@ -11,7 +11,7 @@ import Effect.Aff.Class (class MonadAff)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
-import Halogen.Query.EventSource as ES
+import Halogen.Query.Event as ES
 import Ocelot.Block.Format as Format
 import Ocelot.HTML.Properties (css, (<&>))
 import Web.HTML (window)
@@ -32,7 +32,7 @@ initializeWith
 initializeWith toAction = do
   document <- H.liftEffect $ document =<< window
   H.subscribe
-    $ ES.eventListenerEventSource
+    $ ES.eventListener
       KET.keydown
       (HTMLDocument.toEventTarget document)
       (toAction <=< KE.fromEvent)

--- a/src/Parts/Panel.purs
+++ b/src/Parts/Panel.purs
@@ -12,7 +12,7 @@ import Foreign.Object as Foreign.Object
 import Halogen as Halogen
 import Halogen.HTML as Halogen.HTML
 import Halogen.HTML.Properties as Halogen.HTML.Properties
-import Halogen.Query.EventSource as Halogen.Query.EventSource
+import Halogen.Query.Event as Halogen.Query.Event
 import Ocelot.Block.Format as Ocelot.Block.Format
 import Ocelot.HTML.Properties ((<&>))
 import Ocelot.HTML.Properties as Ocelot.HTML.Properties
@@ -34,7 +34,7 @@ initializeWith ::
 initializeWith toAction = do
   document <- Halogen.liftEffect $ Web.HTML.Window.document =<< Web.HTML.window
   Halogen.subscribe
-    $ Halogen.Query.EventSource.eventListenerEventSource
+    $ Halogen.Query.Event.eventListener
       Web.UIEvent.KeyboardEvent.EventTypes.keydown
       (Web.HTML.HTMLDocument.toEventTarget document)
       (toAction <=< Web.UIEvent.KeyboardEvent.fromEvent)

--- a/src/Slider.purs
+++ b/src/Slider.purs
@@ -24,7 +24,7 @@ import Effect.Aff.Class (class MonadAff)
 import Halogen as Halogen
 import Halogen.HTML as Halogen.HTML
 import Halogen.HTML.Events as Halogen.HTML.Events
-import Halogen.Query.EventSource as Halogen.Query.EventSource
+import Halogen.Query.Event as Halogen.Query.Event
 import Halogen.Svg.Attributes as Halogen.Svg.Attributes
 import Ocelot.Data.IntervalTree as Ocelot.Data.IntervalTree
 import Ocelot.Slider.Render as Ocelot.Slider.Render
@@ -559,7 +559,7 @@ listenOnMouseMove ::
   ComponentM m Halogen.SubscriptionId
 listenOnMouseMove window = do
   Halogen.subscribe
-    $ Halogen.Query.EventSource.eventListenerEventSource
+    $ Halogen.Query.Event.eventListener
         Web.UIEvent.MouseEvent.EventTypes.mousemove
         (Web.HTML.Window.toEventTarget window)
         toAction
@@ -574,7 +574,7 @@ listenOnMouseUp ::
   ComponentM m Halogen.SubscriptionId
 listenOnMouseUp window = do
   Halogen.subscribe
-    $ Halogen.Query.EventSource.eventListenerEventSource
+    $ Halogen.Query.Event.eventListener
         Web.UIEvent.MouseEvent.EventTypes.mouseup
         (Web.HTML.Window.toEventTarget window)
         toAction

--- a/src/Slider.purs
+++ b/src/Slider.purs
@@ -523,13 +523,15 @@ sortByDistance ::
   Array { percent :: Number } ->
   Data.Map.Map { percent :: Number } {- distance -}
     { percent :: Number } {- mark -}
-sortByDistance x = Data.Array.foldMap reducer
+sortByDistance x = Data.Array.foldl reducer Data.Map.empty
   where
   reducer ::
+    Data.Map.Map { percent :: Number }
+      { percent :: Number } ->
     { percent :: Number } ->
     Data.Map.Map { percent :: Number }
       { percent :: Number }
-  reducer mark = Data.Map.singleton (absDistance mark x) mark
+  reducer old mark = Data.Map.insert (absDistance mark x) mark old
 
 absDistance :: { percent :: Number } -> { percent :: Number } -> { percent :: Number }
 absDistance x y = Data.Ord.abs (x - y)

--- a/src/Slider.purs
+++ b/src/Slider.purs
@@ -643,11 +643,11 @@ renderThumbs state =
 renderThumb :: forall m. State -> Int -> { percent :: Number } -> ComponentHTML m
 renderThumb state index percent =
   Ocelot.Slider.Render.thumb state.input.layout percent
-    [ Halogen.HTML.Events.onMouseDown
-        if state.input.disabled
-        then const Nothing
-        else (Just <<< MouseDownOnThumb index)
-    ]
+    ( Data.Monoid.guard (not state.input.disabled)
+        [ Halogen.HTML.Events.onMouseDown
+            (MouseDownOnThumb index)
+        ]
+    )
 
 renderTrack :: forall m. State -> ComponentHTML m
 renderTrack state =

--- a/src/Slider.purs
+++ b/src/Slider.purs
@@ -36,7 +36,7 @@ import Web.UIEvent.MouseEvent.EventTypes as Web.UIEvent.MouseEvent.EventTypes
 
 type Slot = Halogen.Slot Query Output
 
-type Component m = Halogen.Component Halogen.HTML.HTML Query Input Output m
+type Component m = Halogen.Component Query Input Output m
 type ComponentHTML m = Halogen.ComponentHTML Action ChildSlots m
 type ComponentM m a = Halogen.HalogenM State Action ChildSlots Output m a
 

--- a/src/TimePicker.purs
+++ b/src/TimePicker.purs
@@ -340,7 +340,7 @@ meridiemToString = case _ of
 
 render :: forall m. MonadAff m => ComponentRender m
 render st =
-    HH.slot _select unit (S.component identity spec) (embeddedInput st) (Just <<< PassingOutput)
+    HH.slot _select unit (S.component identity spec) (embeddedInput st) PassingOutput
 
 renderItem :: forall m. Int -> TimeUnit -> CompositeComponentHTML m
 renderItem index item =
@@ -394,8 +394,8 @@ renderSearch :: forall m. String -> CompositeComponentHTML m
 renderSearch search =
   Input.input
     ( Setters.setInputProps
-      [ HE.onBlur \_ -> Just (S.Action OnBlur)
-      , HE.onKeyDown $ Just <<< S.Action <<< Key
+      [ HE.onBlur \_ -> S.Action OnBlur
+      , HE.onKeyDown $ S.Action <<< Key
       , HP.value search
       ]
     )

--- a/src/TimePicker.purs
+++ b/src/TimePicker.purs
@@ -38,7 +38,6 @@ import Data.FunctorWithIndex (mapWithIndex)
 import Data.Maybe (Maybe(..), fromMaybe, isNothing, maybe)
 import Data.String (joinWith, toLower, trim)
 import Data.String.Regex (match, parseFlags, regex)
-import Data.Symbol (SProxy(..))
 import Data.Time (Time)
 import Effect.Aff.Class (class MonadAff)
 import Halogen as H
@@ -51,6 +50,7 @@ import Ocelot.Data.DateTime as ODT
 import Ocelot.HTML.Properties (css)
 import Select as S
 import Select.Setters as Setters
+import Type.Proxy (Proxy(..))
 import Web.Event.Event (preventDefault)
 import Web.UIEvent.KeyboardEvent (KeyboardEvent)
 import Web.UIEvent.KeyboardEvent as KE
@@ -154,7 +154,7 @@ component = H.mkComponent
 ---------
 -- Values
 
-_select = SProxy :: SProxy "select"
+_select = Proxy :: Proxy "select"
 
 dropdownClasses :: Array HH.ClassName
 dropdownClasses = HH.ClassName <$>

--- a/src/TimePicker.purs
+++ b/src/TimePicker.purs
@@ -65,7 +65,7 @@ type ChildSlots =
   ( select :: S.Slot Query EmbeddedChildSlots Output Unit
   )
 
-type Component m = H.Component HH.HTML Query Input Output m
+type Component m = H.Component Query Input Output m
 
 type ComponentHTML m = H.ComponentHTML Action ChildSlots m
 
@@ -75,7 +75,7 @@ type ComponentRender m = State -> ComponentHTML m
 
 type CompositeAction = S.Action EmbeddedAction
 
-type CompositeComponent m = H.Component HH.HTML CompositeQuery CompositeInput Output m
+type CompositeComponent m = H.Component CompositeQuery CompositeInput Output m
 
 type CompositeComponentHTML m = H.ComponentHTML CompositeAction EmbeddedChildSlots m
 

--- a/src/TimePicker.purs
+++ b/src/TimePicker.purs
@@ -307,12 +307,12 @@ handleAction = case _ of
 handleQuery :: forall m a. Query a -> ComponentM m (Maybe a)
 handleQuery = case _ of
   GetSelection reply -> do
-    response <- H.query _select unit (S.Query $ H.request GetSelection)
+    response <- H.request _select unit (S.Query <<< GetSelection)
     pure $ reply <$> response
   SetDisabled disabled a -> Just a <$ do
-    void $ H.query _select unit (S.Query $ H.tell $ SetDisabled disabled)
+    void $ H.tell _select unit (S.Query <<<  SetDisabled disabled)
   SetSelection selection a -> Just a <$ do
-    H.query _select unit (S.Query $ H.tell $ SetSelection selection)
+    H.tell _select unit (S.Query <<< SetSelection selection)
 
 handleSearch :: forall m. MonadAff m => CompositeComponentM m Unit
 handleSearch = do

--- a/src/Typeahead.purs
+++ b/src/Typeahead.purs
@@ -102,7 +102,7 @@ type ChildSlots action f item =
   )
 
 type Component action f item m 
-  = Halogen.Component Halogen.HTML.HTML (Query f item) (Input action f item m) (Output action f item) m
+  = Halogen.Component (Query f item) (Input action f item m) (Output action f item) m
 
 type ComponentHTML action f item m 
   = Halogen.ComponentHTML (Action action f item m) (ChildSlots action f item) m
@@ -117,7 +117,7 @@ type CompositeAction action f item m
   = Select.Action (EmbeddedAction action f item m)
 
 type CompositeComponent action f item m 
-  = Halogen.Component Halogen.HTML.HTML (CompositeQuery f item) (CompositeInput f item m) (Output action f item) m
+  = Halogen.Component (CompositeQuery f item) (CompositeInput f item m) (Output action f item) m
 
 type CompositeComponentHTML action f item m 
   = Halogen.ComponentHTML (CompositeAction action f item m) EmbeddedChildSlots m

--- a/src/Typeahead.purs
+++ b/src/Typeahead.purs
@@ -688,7 +688,7 @@ renderAdapter
 renderAdapter render state =
   Halogen.HTML.slot _select unit (Select.component identity $ spec render)
     (embeddedInput state)
-    (Just <<< PassingOutput)
+    PassingOutput
 
 renderError :: ∀ p i. Boolean -> Halogen.HTML.HTML p i
 renderError error =
@@ -731,7 +731,7 @@ renderMulti iprops renderItem renderContainer st =
         then
           Halogen.HTML.a
             [ Ocelot.HTML.Properties.css "absolute -mt-7 pin-r underline text-grey-70 cursor-pointer"
-            , Halogen.HTML.Events.onClick $ const <<< Just <<< Select.Action $ RemoveAll
+            , Halogen.HTML.Events.onClick \_ -> Select.Action $ RemoveAll
             ]
             [ Halogen.HTML.text "Remove All" ]
         else
@@ -745,7 +745,7 @@ renderMulti iprops renderItem renderContainer st =
               Ocelot.Block.ItemContainer.selectionGroup
                 renderItem
                 []
-                [ Halogen.HTML.Events.onClick $ const <<< Just <<< Select.Action $ Remove selected ]
+                [ Halogen.HTML.Events.onClick \_ -> Select.Action $ Remove selected ]
                 selected
     , Ocelot.Block.Input.inputGroup_
       [ Ocelot.Block.Input.inputCenter $ inputProps disabled iprops
@@ -804,7 +804,7 @@ renderSearchDropdown resetLabel label renderFuzzy st =
   renderReset =
     Ocelot.Block.ItemContainer.dropdownItem
       Halogen.HTML.div
-      [ Halogen.HTML.Events.onClick $ const <<< Just <<< Select.Action $ RemoveAll
+      [ Halogen.HTML.Events.onClick \_ -> Select.Action $ RemoveAll
       ]
       [ Halogen.HTML.text resetLabel ]
       ( Data.Maybe.isNothing st.selected )
@@ -833,14 +833,14 @@ renderSingle iprops renderItem renderContainer st =
             ( \selected -> Halogen.HTML.div
               [ Halogen.HTML.Properties.classes Ocelot.Block.Input.mainLeftClasses ]
               [ Ocelot.Block.ItemContainer.selectionGroup renderItem
-                [ Halogen.HTML.Events.onClick $ Just <<< Select.ToggleClick ]
-                [ Halogen.HTML.Events.onClick $ const <<< Just <<< Select.Action $ Remove selected ]
+                [ Halogen.HTML.Events.onClick Select.ToggleClick ]
+                [ Halogen.HTML.Events.onClick \_ -> Select.Action $ Remove selected ]
                 selected
               ])
             st.selected
       , Ocelot.Block.Input.borderRight
         [ Halogen.HTML.Properties.classes $ linkClasses disabled
-        , Halogen.HTML.Events.onClick $ Just <<< Select.ToggleClick
+        , Halogen.HTML.Events.onClick Select.ToggleClick
         ]
         [ Halogen.HTML.text "Change" ]
       ]

--- a/src/Typeahead.purs
+++ b/src/Typeahead.purs
@@ -611,18 +611,18 @@ handleAction = case _ of
 handleQuery :: forall action f item m a. Query f item a -> ComponentM action f item m (Maybe a)
 handleQuery = case _ of
   GetSelected reply -> do
-    response <- Halogen.query _select unit (Select.Query $ Halogen.request GetSelected)
+    response <- Halogen.request _select unit (Select.Query <<< GetSelected)
     pure $ reply <$> response
   ReplaceSelected selected a -> Just a <$ do
-    Halogen.query _select unit (Select.Query $ Halogen.tell $ ReplaceSelected selected)
+    Halogen.tell _select unit (Select.Query <<< ReplaceSelected selected)
   ReplaceSelectedBy f a -> Just a <$ do
-    Halogen.query _select unit (Select.Query $ Halogen.tell $ ReplaceSelectedBy f)
+    Halogen.tell _select unit (Select.Query <<< ReplaceSelectedBy f)
   ReplaceItems items a -> Just a <$ do
-    Halogen.query _select unit (Select.Query $ Halogen.tell $ ReplaceItems items)
+    Halogen.tell _select unit (Select.Query <<< ReplaceItems items)
   Reset a -> Just a <$ do
-    Halogen.query _select unit (Select.Query $ Halogen.tell $ Reset)
+    Halogen.tell _select unit (Select.Query <<< Reset)
   SetDisabled disabled a -> Just a <$ do
-    Halogen.query _select unit (Select.Query $ Halogen.tell $ SetDisabled disabled)
+    Halogen.tell _select unit (Select.Query <<< SetDisabled disabled)
 
 initialState
   :: forall action f item m

--- a/src/Typeahead.purs
+++ b/src/Typeahead.purs
@@ -87,7 +87,7 @@ import Ocelot.HTML.Properties as Ocelot.HTML.Properties
 import Renderless.State as Renderless.State
 import Select as Select
 import Select.Setters as Select.Setters
-import Type.Data.Symbol (SProxy(..))
+import Type.Proxy (Proxy(..))
 import Unsafe.Coerce as Unsafe.Coerce
 
 --------
@@ -387,7 +387,7 @@ syncMulti { itemToObject, renderFuzzy } props =
 ---------
 -- Values
 
-_select = SProxy :: SProxy "select"
+_select = Proxy :: Proxy "select"
 
 applyInsertable
   :: forall item

--- a/test/Test/Data/IntervalTree.purs
+++ b/test/Test/Data/IntervalTree.purs
@@ -235,7 +235,7 @@ lookupIntervalTests =
     Test.Unit.test "empty tree" do
       let
         emptyTree :: Ocelot.Data.IntervalTree.IntervalTree Int
-        emptyTree = mempty
+        emptyTree = Data.Map.empty
 
         expected ::
           { left :: Maybe { key :: Int, value :: Ocelot.Data.IntervalTree.IntervalPoint }

--- a/ui-guide/App/App.purs
+++ b/ui-guide/App/App.purs
@@ -18,16 +18,18 @@ import Data.Const (Const)
 import Data.Functor (mapFlipped)
 import Data.Map as M
 import Data.Maybe (Maybe(..))
+import Data.Maybe as Data.Maybe
 import Data.Symbol (SProxy(..))
 import Data.Tuple (Tuple(..))
 import Effect.Aff (Aff, launchAff_)
-import Global.Unsafe (unsafeDecodeURI, unsafeEncodeURI)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
 import Halogen.Storybook.Proxy (proxy)
 import Halogen.VDom.Driver (runUI)
+import JSURI as JSURI
 import Ocelot.Block.Format as Format
+import Partial.Unsafe as Partial.Unsafe
 import Routing.Hash (hashes)
 import UIGuide.Block.Backdrop as Backdrop
 import Web.HTML.HTMLElement (HTMLElement)
@@ -212,3 +214,9 @@ app =
 
 partitionByGroup :: ∀ m. Group -> Stories m -> Tuple Group (Stories m)
 partitionByGroup g = Tuple g <<< M.filter (\{ group } -> group == g)
+
+unsafeEncodeURI :: String -> String
+unsafeEncodeURI x = Partial.Unsafe.unsafePartial (Data.Maybe.fromJust (JSURI.encodeURIComponent x))
+
+unsafeDecodeURI :: String -> String
+unsafeDecodeURI x = Partial.Unsafe.unsafePartial (Data.Maybe.fromJust (JSURI.decodeURIComponent x))

--- a/ui-guide/App/App.purs
+++ b/ui-guide/App/App.purs
@@ -19,7 +19,6 @@ import Data.Functor (mapFlipped)
 import Data.Map as M
 import Data.Maybe (Maybe(..))
 import Data.Maybe as Data.Maybe
-import Data.Symbol (SProxy(..))
 import Data.Tuple (Tuple(..))
 import Effect.Aff (Aff, launchAff_)
 import Halogen as H
@@ -31,6 +30,7 @@ import JSURI as JSURI
 import Ocelot.Block.Format as Format
 import Partial.Unsafe as Partial.Unsafe
 import Routing.Hash (hashes)
+import Type.Proxy (Proxy(..))
 import UIGuide.Block.Backdrop as Backdrop
 import Web.HTML.HTMLElement (HTMLElement)
 
@@ -69,7 +69,7 @@ type HTML m = H.ComponentHTML Action Slots m
 
 type Slots =
   ( child :: H.Slot StoryQuery Void String )
-_child = SProxy :: SProxy "child"
+_child = Proxy :: Proxy "child"
 
 -- | Takes stories config and mount element, and renders the storybook.
 runStorybook

--- a/ui-guide/App/App.purs
+++ b/ui-guide/App/App.purs
@@ -49,7 +49,7 @@ type Stories m = M.Map String (Page m)
 
 type Page m =
   { anchor :: String
-  , component :: H.Component HH.HTML StoryQuery Unit Void m
+  , component :: H.Component StoryQuery Unit Void m
   , group :: Group
   }
 
@@ -87,7 +87,7 @@ type Input m =
   , groups :: Array Group
   }
 
-app :: ∀ m. H.Component HH.HTML Query (Input m) Void m
+app :: ∀ m. H.Component Query (Input m) Void m
 app =
   H.mkComponent
     { initialState

--- a/ui-guide/App/App.purs
+++ b/ui-guide/App/App.purs
@@ -80,7 +80,7 @@ runStorybook
 runStorybook stories groups body = do
   app' <- runUI app { stories, groups } body
   void $ H.liftEffect $ hashes $ \_ next ->
-    launchAff_ $ app'.query (H.tell $ RouteChange $ unsafeDecodeURI next)
+    launchAff_ $ app'.query (H.mkTell $ RouteChange $ unsafeDecodeURI next)
 
 type Input m =
   { stories :: Stories m

--- a/ui-guide/App/Routes.purs
+++ b/ui-guide/App/Routes.purs
@@ -8,7 +8,6 @@ import Data.Map (Map, fromFoldable)
 import Data.Tuple (Tuple(..))
 import Effect.Aff (Aff)
 import Halogen as H
-import Halogen.HTML as HH
 import UIGuide.App (Group(..), proxy)
 import UIGuide.Component.Badge as Badge
 import UIGuide.Component.Button as Button
@@ -39,7 +38,7 @@ groups =
 
 type RouteConfig =
   { anchor :: String
-  , component :: H.Component HH.HTML (Const Void) Unit Void Aff
+  , component :: H.Component (Const Void) Unit Void Aff
   , group :: Group
   }
 

--- a/ui-guide/Components/Badge.purs
+++ b/ui-guide/Components/Badge.purs
@@ -24,7 +24,7 @@ type Message = Void
 -- HTML
 
 component
-  :: ∀ m. H.Component HH.HTML Query Input Message m
+  :: ∀ m. H.Component Query Input Message m
 component
   = H.mkComponent
     { initialState: const unit

--- a/ui-guide/Components/Button.purs
+++ b/ui-guide/Components/Button.purs
@@ -24,7 +24,7 @@ type Message = Void
 ----------
 -- HTML
 
-component :: ∀ m. H.Component HH.HTML Query Input Message m
+component :: ∀ m. H.Component Query Input Message m
 component =
   H.mkComponent
     { initialState: const unit

--- a/ui-guide/Components/Card.purs
+++ b/ui-guide/Components/Card.purs
@@ -21,7 +21,7 @@ type Message = Void
 
 card
   :: ∀ m
-  . H.Component HH.HTML Query Input Message m
+  . H.Component Query Input Message m
 card =
   H.mkComponent
     { initialState: const unit

--- a/ui-guide/Components/DatePickers.purs
+++ b/ui-guide/Components/DatePickers.purs
@@ -50,7 +50,7 @@ _dtp = SProxy :: SProxy "dtp"
 
 component :: ∀ m
   . MonadAff m
- => H.Component HH.HTML Query Unit Void m
+ => H.Component Query Unit Void m
 component =
   H.mkComponent
   { initialState

--- a/ui-guide/Components/DatePickers.purs
+++ b/ui-guide/Components/DatePickers.purs
@@ -101,7 +101,7 @@ cnDocumentationBlocks =
         [ css "inline mr-4" ]
         [ HH.text "You can toggle between enabled/disabled states" ]
       , Button.button
-        [ HE.onClick $ const $ Just ToggleDisabled ]
+        [ HE.onClick \_ -> ToggleDisabled ]
         [ HH.text "Toggle" ]
       ]
     , HH.div_
@@ -116,12 +116,11 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "start-date"
               }
-              [ HH.slot _datePicker 0 DatePicker.component
+              [ HH.slot_ _datePicker 0 DatePicker.component
                 { targetDate: Nothing
                 , selection: Nothing
                 , disabled: false
                 }
-                (const Nothing)
               ]
             , Format.caption_ [ HH.text "Standard Disabled" ]
             , FormField.fieldMid_
@@ -130,12 +129,11 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "start-date-disabled"
               }
-              [ HH.slot _datePicker 2 DatePicker.component
+              [ HH.slot_ _datePicker 2 DatePicker.component
                 { targetDate: Nothing
                 , selection: Nothing
                 , disabled: true
                 }
-                (const Nothing)
               ]
             ]
           ]
@@ -149,12 +147,11 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "end-date"
               }
-              [ HH.slot _datePicker 1 DatePicker.component
+              [ HH.slot_ _datePicker 1 DatePicker.component
                 { targetDate: Nothing
                 , selection: Just $ unsafeMkDate 2019 1 1
                 , disabled: false
                 }
-                (const Nothing)
               ]
             , Format.caption_ [ HH.text "Hydrated Disabled" ]
             , FormField.fieldMid_
@@ -163,12 +160,11 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "end-date-disabled"
               }
-              [ HH.slot _datePicker 3 DatePicker.component
+              [ HH.slot_ _datePicker 3 DatePicker.component
                 { targetDate: Nothing
                 , selection: Just $ unsafeMkDate 2019 1 1
                 , disabled: true
                 }
-                (const Nothing)
               ]
             ]
           ]
@@ -189,11 +185,10 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "start-time"
               }
-              [ HH.slot _timePicker 0 TimePicker.component
+              [ HH.slot_ _timePicker 0 TimePicker.component
                 { selection: Nothing
                 , disabled: false
                 }
-                (const Nothing)
               ]
             , Format.caption_ [ HH.text "Standard Disabled" ]
             , FormField.fieldMid_
@@ -202,11 +197,10 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "start-time-disabled"
               }
-              [ HH.slot _timePicker 2 TimePicker.component
+              [ HH.slot_ _timePicker 2 TimePicker.component
                 { selection: Nothing
                 , disabled: true
                 }
-                (const Nothing)
               ]
             ]
           ]
@@ -220,11 +214,10 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "end-time"
               }
-              [ HH.slot _timePicker 1 TimePicker.component
+              [ HH.slot_ _timePicker 1 TimePicker.component
                 { selection: Just $ unsafeMkTime 12 0 0 0
                 , disabled: false
                 }
-                (const Nothing)
               ]
             , Format.caption_ [ HH.text "Hydrated Disabled" ]
             , FormField.fieldMid_
@@ -233,11 +226,10 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "end-time-disabled"
               }
-              [ HH.slot _timePicker 3 TimePicker.component
+              [ HH.slot_ _timePicker 3 TimePicker.component
                 { selection: Just $ unsafeMkTime 12 0 0 0
                 , disabled: true
                 }
-                (const Nothing)
               ]
             ]
           ]
@@ -258,12 +250,11 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "start"
               }
-              [ HH.slot _dtp 0 DateTimePicker.component
+              [ HH.slot_ _dtp 0 DateTimePicker.component
                 { targetDate: Nothing
                 , selection: Nothing
                 , disabled: false
                 }
-                (const Nothing)
               ]
             , Format.caption_ [ HH.text "Standard Disabled" ]
             , FormField.field_
@@ -272,12 +263,11 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "start-disabled"
               }
-              [ HH.slot _dtp 2 DateTimePicker.component
+              [ HH.slot_ _dtp 2 DateTimePicker.component
                 { targetDate: Nothing
                 , selection: Nothing
                 , disabled: true
                 }
-                (const Nothing)
               ]
             ]
           ]
@@ -291,12 +281,11 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "end"
               }
-              [ HH.slot _dtp 1 DateTimePicker.component
+              [ HH.slot_ _dtp 1 DateTimePicker.component
                 { targetDate: Nothing
                 , selection: Just $ DateTime (unsafeMkDate 2019 1 1) (unsafeMkTime 0 0 0 0)
                 , disabled: false
                 }
-                (const Nothing)
               ]
             , Format.caption_ [ HH.text "Hydrated Disabled" ]
             , FormField.field_
@@ -305,12 +294,11 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "end-disabled"
               }
-              [ HH.slot _dtp 3 DateTimePicker.component
+              [ HH.slot_ _dtp 3 DateTimePicker.component
                 { targetDate: Nothing
                 , selection: Just $ DateTime (unsafeMkDate 2019 1 1) (unsafeMkTime 0 0 0 0)
                 , disabled: true
                 }
-                (const Nothing)
               ]
             ]
           ]

--- a/ui-guide/Components/DatePickers.purs
+++ b/ui-guide/Components/DatePickers.purs
@@ -11,11 +11,11 @@ import Ocelot.Block.Button as Button
 import Ocelot.Block.Card as Card
 import Ocelot.Block.FormField as FormField
 import Ocelot.Block.Format as Format
+import Ocelot.Data.DateTime (unsafeMkDate, unsafeMkTime)
 import Ocelot.DatePicker as DatePicker
 import Ocelot.DateTimePicker as DateTimePicker
-import Ocelot.TimePicker as TimePicker
-import Ocelot.Data.DateTime (unsafeMkDate, unsafeMkTime)
 import Ocelot.HTML.Properties (css)
+import Ocelot.TimePicker as TimePicker
 import Type.Proxy (Proxy(..))
 import UIGuide.Block.Backdrop as Backdrop
 import UIGuide.Block.Documentation as Documentation
@@ -63,12 +63,12 @@ component =
     handleAction = case _ of  
       ToggleDisabled -> do
         st <- H.modify \s -> s { disabled = not s.disabled }
-        void $ H.query _datePicker 0 $ H.tell $ DatePicker.SetDisabled st.disabled
-        void $ H.query _datePicker 1 $ H.tell $ DatePicker.SetDisabled st.disabled
-        void $ H.query _timePicker 0 $ H.tell $ TimePicker.SetDisabled st.disabled
-        void $ H.query _timePicker 1 $ H.tell $ TimePicker.SetDisabled st.disabled
-        void $ H.query _dtp 0 $ H.tell $ DateTimePicker.SetDisabled st.disabled
-        void $ H.query _dtp 1 $ H.tell $ DateTimePicker.SetDisabled st.disabled
+        void $ H.tell _datePicker 0 $ DatePicker.SetDisabled st.disabled
+        void $ H.tell _datePicker 1 $ DatePicker.SetDisabled st.disabled
+        void $ H.tell _timePicker 0 $ TimePicker.SetDisabled st.disabled
+        void $ H.tell _timePicker 1 $ TimePicker.SetDisabled st.disabled
+        void $ H.tell _dtp 0 $ DateTimePicker.SetDisabled st.disabled
+        void $ H.tell _dtp 1 $ DateTimePicker.SetDisabled st.disabled
         
     initialState :: Unit -> State
     initialState _ = { disabled: false }

--- a/ui-guide/Components/DatePickers.purs
+++ b/ui-guide/Components/DatePickers.purs
@@ -3,7 +3,6 @@ module UIGuide.Component.DatePickers where
 import Prelude
 import Data.DateTime (DateTime(..))
 import Data.Maybe (Maybe(..))
-import Data.Symbol (SProxy(..))
 import Effect.Aff.Class (class MonadAff)
 import Halogen as H
 import Halogen.HTML as HH
@@ -17,6 +16,7 @@ import Ocelot.DateTimePicker as DateTimePicker
 import Ocelot.TimePicker as TimePicker
 import Ocelot.Data.DateTime (unsafeMkDate, unsafeMkTime)
 import Ocelot.HTML.Properties (css)
+import Type.Proxy (Proxy(..))
 import UIGuide.Block.Backdrop as Backdrop
 import UIGuide.Block.Documentation as Documentation
 
@@ -41,9 +41,9 @@ type ChildSlot =
   , dtp :: DateTimePicker.Slot Int
   )
 
-_datePicker = SProxy :: SProxy "datePicker"
-_timePicker = SProxy :: SProxy "timePicker"
-_dtp = SProxy :: SProxy "dtp"
+_datePicker = Proxy :: Proxy "datePicker"
+_timePicker = Proxy :: Proxy "timePicker"
+_dtp = Proxy :: Proxy "dtp"
 
 ----------
 -- Component definition

--- a/ui-guide/Components/Diagram.purs
+++ b/ui-guide/Components/Diagram.purs
@@ -14,7 +14,7 @@ import Ocelot.HTML.Properties as Ocelot.HTML.Properties
 import UIGuide.Block.Backdrop as Backdrop
 import UIGuide.Block.Documentation as Documentation
 
-type Component m = Halogen.Component Halogen.HTML.HTML Query Input Output m
+type Component m = Halogen.Component Query Input Output m
 
 type ComponentHTML m = Halogen.ComponentHTML Action ChildSlots m
 

--- a/ui-guide/Components/Dialogs.purs
+++ b/ui-guide/Components/Dialogs.purs
@@ -45,7 +45,7 @@ type Message = Void
 component
   :: ∀ m
    . MonadAff m
-  => H.Component HH.HTML Query Input Message m
+  => H.Component Query Input Message m
 component =
   H.mkComponent
     { initialState: const { toast: Nothing }

--- a/ui-guide/Components/Dialogs.purs
+++ b/ui-guide/Components/Dialogs.purs
@@ -3,7 +3,7 @@ module UIGuide.Component.Dialogs where
 import Prelude
 
 import Data.Generic.Rep (class Generic)
-import Data.Generic.Rep.Show (genericShow)
+import Data.Show.Generic (genericShow)
 import Data.Maybe (Maybe(..))
 import Data.Time.Duration (Milliseconds(..))
 import Effect.Aff (delay)

--- a/ui-guide/Components/Dialogs.purs
+++ b/ui-guide/Components/Dialogs.purs
@@ -101,7 +101,7 @@ component =
                 [ Format.caption_
                   [ HH.text "Success" ]
                 , Button.button
-                  [ HE.onClick $ const $ Just $ Toggle Success ]
+                  [ HE.onClick \_ -> Toggle Success ]
                   [ HH.text "Success" ]
                 , Toast.toast
                   [ Toast.visible $ state.toast == Just Success ]
@@ -120,7 +120,7 @@ component =
                 [ Format.caption_
                   [ HH.text "Error" ]
                 , Button.button
-                  [ HE.onClick $ const $ Just $ Toggle Error ]
+                  [ HE.onClick \_ -> Toggle Error ]
                   [ HH.text "Error" ]
                 , Toast.toast
                   [ Toast.visible $ state.toast == Just Error ]

--- a/ui-guide/Components/Dropdown.purs
+++ b/ui-guide/Components/Dropdown.purs
@@ -5,7 +5,6 @@ import Data.Array (mapWithIndex)
 import Data.Array as Array
 import Data.Const (Const)
 import Data.Maybe (Maybe(..))
-import Data.Symbol (SProxy(..))
 import Effect.Aff.Class (class MonadAff)
 import Effect.Class.Console (log)
 import Halogen as H
@@ -20,6 +19,7 @@ import Ocelot.Dropdown as Ocelot.Dropdown
 import Ocelot.HTML.Properties (css)
 import Select as Select
 import Select.Setters as SelectSetters
+import Type.Proxy (Proxy(..))
 import UIGuide.Block.Backdrop as Backdrop
 import UIGuide.Block.Documentation as Documentation
 
@@ -55,8 +55,8 @@ type ChildSlot =
   , select :: Select.Slot (Const Query) () Select.Event Unit
   )
 
-_dropdown = SProxy :: SProxy "dropdown"
-_select = SProxy :: SProxy "select"
+_dropdown = Proxy :: Proxy "dropdown"
+_select = Proxy :: Proxy "select"
 
 data Platform
   = Facebook

--- a/ui-guide/Components/Dropdown.purs
+++ b/ui-guide/Components/Dropdown.purs
@@ -90,9 +90,9 @@ component =
         _ -> pure unit
       ToggleDisabled old -> do
         let disabled = not old
-        void $ H.query _dropdown StandardDynamic (H.tell (Ocelot.Dropdown.SetDisabled disabled))
-        void $ H.query _dropdown PrimaryDynamic (H.tell (Ocelot.Dropdown.SetDisabled disabled))
-        void $ H.query _dropdown DarkDynamic (H.tell (Ocelot.Dropdown.SetDisabled disabled))
+        void $ H.tell _dropdown StandardDynamic (Ocelot.Dropdown.SetDisabled disabled)
+        void $ H.tell _dropdown PrimaryDynamic (Ocelot.Dropdown.SetDisabled disabled)
+        void $ H.tell _dropdown DarkDynamic (Ocelot.Dropdown.SetDisabled disabled)
         H.modify_ \state -> state { disabled = disabled }
 
     initialState :: Input -> State

--- a/ui-guide/Components/Dropdown.purs
+++ b/ui-guide/Components/Dropdown.purs
@@ -122,7 +122,7 @@ component =
                     , items
                     , render: renderDropdown Button.button
                     }
-                    ( Just <<< HandleDropdown )
+                    HandleDropdown
                 ]
               , HH.div
                 [ css "mb-6" ]
@@ -139,9 +139,9 @@ component =
                         , items
                         , render: renderDropdown Button.button
                         }
-                        ( Just <<< HandleDropdown )
+                        HandleDropdown
                     , Button.button
-                        [ Halogen.HTML.Events.onClick (const (Just (ToggleDisabled state.disabled)))
+                        [ Halogen.HTML.Events.onClick \_ -> ToggleDisabled state.disabled
                         , css "ml-2"
                         ]
                         [ HH.text "Toggle" ]
@@ -164,7 +164,7 @@ component =
                   , items
                   , render: renderDropdown Button.buttonPrimary
                   }
-                  ( Just <<< HandleDropdown )
+                  HandleDropdown
                 ]
               , HH.div
                 [ css "mb-6" ]
@@ -181,9 +181,9 @@ component =
                         , items
                         , render: renderDropdown Button.buttonPrimary
                         }
-                        ( Just <<< HandleDropdown )
+                        HandleDropdown
                     , Button.buttonPrimary
-                        [ Halogen.HTML.Events.onClick (const (Just (ToggleDisabled state.disabled)))
+                        [ Halogen.HTML.Events.onClick \_ -> ToggleDisabled state.disabled
                         , css "ml-2"
                         ]
                         [ HH.text "Toggle" ]
@@ -206,7 +206,7 @@ component =
                   , items
                   , render: renderDropdown Button.buttonDark
                   }
-                  ( Just <<< HandleDropdown )
+                  HandleDropdown
                 ]
               , HH.div
                 [ css "mb-6" ]
@@ -223,9 +223,9 @@ component =
                         , items
                         , render: renderDropdown Button.buttonDark
                         }
-                        ( Just <<< HandleDropdown )
+                        HandleDropdown
                     , Button.buttonDark
-                        [ Halogen.HTML.Events.onClick (const (Just (ToggleDisabled state.disabled)))
+                        [ Halogen.HTML.Events.onClick \_ -> ToggleDisabled state.disabled
                         , css "ml-2"
                         ]
                         [ HH.text "Toggle" ]
@@ -245,7 +245,7 @@ component =
                 unit
                 (Select.component identity choiceSpec )
                 selectInput
-                ( Just <<< HandleChoice )
+                HandleChoice
             ]
           ]
         ]

--- a/ui-guide/Components/Dropdown.purs
+++ b/ui-guide/Components/Dropdown.purs
@@ -65,7 +65,7 @@ data Platform
 component
   :: ∀ m
    . MonadAff m
-  => H.Component HH.HTML (Const Query) Input Message m
+  => H.Component (Const Query) Input Message m
 component =
   H.mkComponent
     { initialState

--- a/ui-guide/Components/ExpansionCards.purs
+++ b/ui-guide/Components/ExpansionCards.purs
@@ -19,8 +19,8 @@ import Ocelot.Block.Format as Format
 import Ocelot.Block.Icon as Icon
 import Ocelot.Block.ItemContainer (boldMatches) as IC
 import Ocelot.Block.Toggle as Toggle
-import Ocelot.Typeahead as TA
 import Ocelot.HTML.Properties (css)
+import Ocelot.Typeahead as TA
 import Type.Proxy (Proxy(..))
 import UIGuide.Block.Backdrop as Backdrop
 import UIGuide.Block.Documentation as Documentation
@@ -93,40 +93,40 @@ component =
         H.put (over lens not st)
 
       Initialize -> do
-        _ <- H.queryAll _cp1 $ H.tell $ TA.ReplaceItems Loading
-        _ <- H.queryAll _cp2 $ H.tell $ TA.ReplaceItems Loading
-        _ <- H.queryAll _cp3 $ H.tell $ TA.ReplaceItems Loading
-        _ <- H.queryAll _cp4 $ H.tell $ TA.ReplaceItems Loading
+        _ <- H.queryAll _cp1 $ H.mkTell $ TA.ReplaceItems Loading
+        _ <- H.queryAll _cp2 $ H.mkTell $ TA.ReplaceItems Loading
+        _ <- H.queryAll _cp3 $ H.mkTell $ TA.ReplaceItems Loading
+        _ <- H.queryAll _cp4 $ H.mkTell $ TA.ReplaceItems Loading
 
         remoteLocations <- H.liftAff $ Async.loadFromSource Async.locations ""
         _ <- case remoteLocations of
           items@(Success _) -> do
-            _ <- H.queryAll _cp3 $ H.tell $ TA.ReplaceItems items
-            _ <- H.queryAll _cp4 $ H.tell $ TA.ReplaceItems items
+            _ <- H.queryAll _cp3 $ H.mkTell $ TA.ReplaceItems items
+            _ <- H.queryAll _cp4 $ H.mkTell $ TA.ReplaceItems items
             pure unit
           otherwise -> pure unit
 
         remoteUsers <- H.liftAff $ Async.loadFromSource Async.users ""
         _ <- case remoteUsers of
           items@(Success _) -> do
-            _ <- H.queryAll _cp1 $ H.tell $ TA.ReplaceItems items
-            _ <- H.queryAll _cp2 $ H.tell $ TA.ReplaceItems items
+            _ <- H.queryAll _cp1 $ H.mkTell $ TA.ReplaceItems items
+            _ <- H.queryAll _cp2 $ H.mkTell $ TA.ReplaceItems items
             pure unit
           otherwise -> pure unit
 
         selectedLocations <- H.liftAff $ Async.loadFromSource Async.locations "an"
         _ <- case selectedLocations of
           Success xs -> do
-            _ <- H.query _cp3 1 $ H.tell $ TA.ReplaceSelected (head xs)
-            _ <- H.query _cp4 3 $ H.tell $ TA.ReplaceSelected (take 4 xs)
+            _ <- H.tell _cp3 1 $ TA.ReplaceSelected (head xs)
+            _ <- H.tell _cp4 3 $ TA.ReplaceSelected (take 4 xs)
             pure unit
           otherwise -> pure unit
 
         selectedUsers <- H.liftAff $ Async.loadFromSource Async.users "an"
         case selectedUsers of
           Success xs -> do
-            _ <- H.query _cp1 1 $ H.tell $ TA.ReplaceSelected (head xs)
-            _ <- H.query _cp2 3 $ H.tell $ TA.ReplaceSelected (take 4 xs)
+            _ <- H.tell _cp1 1 $ TA.ReplaceSelected (head xs)
+            _ <- H.tell _cp2 3 $ TA.ReplaceSelected (take 4 xs)
             pure unit
           otherwise -> pure unit
 

--- a/ui-guide/Components/ExpansionCards.purs
+++ b/ui-guide/Components/ExpansionCards.purs
@@ -175,7 +175,7 @@ cnDocumentationBlocks st =
           [ Backdrop.content_
             [ Card.card_
               [ Expandable.heading
-                [ HE.onClick $ const $ Just $ ToggleCard _singleLocation
+                [ HE.onClick \_ -> ToggleCard _singleLocation
                 , Expandable.status st.singleLocation
                 ]
                 [ Format.subHeading_ [ HH.text "Locations" ]
@@ -189,7 +189,7 @@ cnDocumentationBlocks st =
                   , error: []
                   , inputId: "location"
                   }
-                  [ HH.slot _cp3 0 TA.single
+                  [ HH.slot_ _cp3 0 TA.single
                     ( TA.asyncSingle
                       { renderFuzzy: HH.span_ <<< IC.boldMatches "name"
                       , itemToObject: Async.locationToObject
@@ -199,7 +199,6 @@ cnDocumentationBlocks st =
                       , HP.id_ "location"
                       ]
                     )
-                    ( const Nothing )
                   ]
                 , FormField.field_
                   { label: HH.text "Secondary Location"
@@ -207,7 +206,7 @@ cnDocumentationBlocks st =
                   , error: []
                   , inputId: "location-hydrated"
                   }
-                  [ HH.slot _cp3 1 TA.single
+                  [ HH.slot_ _cp3 1 TA.single
                     ( TA.asyncSingle
                       { renderFuzzy: HH.span_ <<< IC.boldMatches "name"
                       , itemToObject: Async.locationToObject
@@ -217,7 +216,6 @@ cnDocumentationBlocks st =
                       , HP.id_ "location-hydrated"
                       ]
                     )
-                    ( const Nothing )
                   ]
                 ]
               ]
@@ -225,7 +223,7 @@ cnDocumentationBlocks st =
           , Backdrop.content_
             [ Card.card_
               [ Expandable.heading
-                [ HE.onClick $ const $ Just $ ToggleCard _singleUser
+                [ HE.onClick \_ -> ToggleCard _singleUser
                 , Expandable.status st.singleUser
                 ]
                 [ Format.subHeading_ [ HH.text "Users" ] ]
@@ -237,7 +235,7 @@ cnDocumentationBlocks st =
                   , error: []
                   , inputId: "user"
                   }
-                  [ HH.slot _cp1 0 TA.single
+                  [ HH.slot_ _cp1 0 TA.single
                     ( TA.asyncSingle
                       { renderFuzzy: Async.renderFuzzyUser
                       , itemToObject: Async.userToObject
@@ -247,7 +245,6 @@ cnDocumentationBlocks st =
                       , HP.id_ "user"
                       ]
                     )
-                    ( const Nothing )
                   ]
                 , FormField.field_
                   { label: HH.text "Secondary User"
@@ -255,7 +252,7 @@ cnDocumentationBlocks st =
                   , error: []
                   , inputId: "user-hydrated"
                   }
-                  [ HH.slot _cp1 1 TA.single
+                  [ HH.slot_ _cp1 1 TA.single
                     ( TA.asyncSingle
                       { renderFuzzy: Async.renderFuzzyUser
                       , itemToObject: Async.userToObject
@@ -265,7 +262,6 @@ cnDocumentationBlocks st =
                       , HP.id_ "user-hydrated"
                       ]
                     )
-                    ( const Nothing )
                   ]
                 ]
               ]
@@ -294,7 +290,7 @@ cnDocumentationBlocks st =
                 [ HP.id_ "enable-locations"
                 , HP.checked
                   $ Expandable.toBoolean st.multiLocation
-                , HE.onChange $ const $ Just $ ToggleCard _multiLocation
+                , HE.onChange \_ -> ToggleCard _multiLocation
                 ]
               ]
             , Expandable.content_
@@ -305,7 +301,7 @@ cnDocumentationBlocks st =
                 , error: []
                 , inputId: "locations"
                 }
-                [ HH.slot _cp4 0 TA.multi
+                [ HH.slot_ _cp4 0 TA.multi
                   ( TA.asyncMulti
                     { renderFuzzy: HH.span_ <<< IC.boldMatches "name"
                     , itemToObject: Async.locationToObject
@@ -315,7 +311,6 @@ cnDocumentationBlocks st =
                     , HP.id_ "locations"
                     ]
                   )
-                  ( const Nothing )
                 ]
               , FormField.field_
                 { label: HH.text "Excluded Locations"
@@ -323,7 +318,7 @@ cnDocumentationBlocks st =
                 , error: []
                 , inputId: "locations"
                 }
-                [ HH.slot _cp4 1 TA.multi
+                [ HH.slot_ _cp4 1 TA.multi
                   ( TA.asyncMulti
                     { renderFuzzy: HH.span_ <<< IC.boldMatches "name"
                     , itemToObject: Async.locationToObject
@@ -333,7 +328,6 @@ cnDocumentationBlocks st =
                     , HP.id_ "locations"
                     ]
                   )
-                  ( const Nothing )
                 ]
               ]
             ]
@@ -354,7 +348,7 @@ cnDocumentationBlocks st =
                 [ HP.id_ "enable-users"
                 , HP.checked
                   $ Expandable.toBoolean st.multiUser
-                , HE.onChange $ const $ Just $ ToggleCard _multiUser
+                , HE.onChange \_ -> ToggleCard _multiUser
                 ]
               ]
             , Expandable.content_
@@ -365,7 +359,7 @@ cnDocumentationBlocks st =
                 , error: []
                 , inputId: "users"
                 }
-                [ HH.slot _cp2 0 TA.multi
+                [ HH.slot_ _cp2 0 TA.multi
                   ( TA.asyncMulti
                     { renderFuzzy: Async.renderFuzzyUser
                     , itemToObject: Async.userToObject
@@ -375,7 +369,6 @@ cnDocumentationBlocks st =
                     , HP.id_ "users"
                     ]
                   )
-                  ( const Nothing )
                 ]
               , FormField.field_
                 { label: HH.text "Excluded Users"
@@ -383,7 +376,7 @@ cnDocumentationBlocks st =
                 , error: []
                 , inputId: "users-hydrated"
                 }
-                [ HH.slot _cp2 1 TA.multi
+                [ HH.slot_ _cp2 1 TA.multi
                   ( TA.asyncMulti
                     { renderFuzzy: Async.renderFuzzyUser
                     , itemToObject: Async.userToObject
@@ -393,7 +386,6 @@ cnDocumentationBlocks st =
                     , HP.id_ "users-hydrated"
                     ]
                   )
-                  ( const Nothing )
                 ]
               ]
             ]

--- a/ui-guide/Components/ExpansionCards.purs
+++ b/ui-guide/Components/ExpansionCards.purs
@@ -6,7 +6,6 @@ import Data.Array (head, take)
 import Data.Lens (Lens', over)
 import Data.Lens.Record (prop)
 import Data.Maybe (Maybe(..))
-import Data.Symbol (SProxy(..))
 import Effect.Aff.Class (class MonadAff)
 import Halogen as H
 import Halogen.HTML as HH
@@ -22,6 +21,7 @@ import Ocelot.Block.ItemContainer (boldMatches) as IC
 import Ocelot.Block.Toggle as Toggle
 import Ocelot.Typeahead as TA
 import Ocelot.HTML.Properties (css)
+import Type.Proxy (Proxy(..))
 import UIGuide.Block.Backdrop as Backdrop
 import UIGuide.Block.Documentation as Documentation
 import UIGuide.Utility.Async as Async
@@ -52,10 +52,10 @@ type ChildSlot =
   , cp4 :: TA.Slot Action Array Async.Location Int
   )
 
-_cp1 = SProxy :: SProxy "cp1"
-_cp2 = SProxy :: SProxy "cp2"
-_cp3 = SProxy :: SProxy "cp3"
-_cp4 = SProxy :: SProxy "cp4"
+_cp1 = Proxy :: Proxy "cp1"
+_cp2 = Proxy :: Proxy "cp2"
+_cp3 = Proxy :: Proxy "cp3"
+_cp4 = Proxy :: Proxy "cp4"
 
 ----------
 -- Component definition
@@ -135,16 +135,16 @@ component =
 -- HTML
 
 _singleLocation :: Lens' State Expandable.Status
-_singleLocation = prop (SProxy :: SProxy "singleLocation")
+_singleLocation = prop (Proxy :: Proxy "singleLocation")
 
 _singleUser :: Lens' State Expandable.Status
-_singleUser = prop (SProxy :: SProxy "singleUser")
+_singleUser = prop (Proxy :: Proxy "singleUser")
 
 _multiLocation :: Lens' State Expandable.Status
-_multiLocation = prop (SProxy :: SProxy "multiLocation")
+_multiLocation = prop (Proxy :: Proxy "multiLocation")
 
 _multiUser :: Lens' State Expandable.Status
-_multiUser = prop (SProxy :: SProxy "multiUser")
+_multiUser = prop (Proxy :: Proxy "multiUser")
 
 cnDocumentationBlocks :: ∀ m
   . MonadAff m

--- a/ui-guide/Components/ExpansionCards.purs
+++ b/ui-guide/Components/ExpansionCards.purs
@@ -1,6 +1,7 @@
 module UIGuide.Component.ExpansionCards where
 
 import Prelude
+
 import Data.Array (head, take)
 import Data.Lens (Lens', over)
 import Data.Lens.Record (prop)
@@ -61,7 +62,7 @@ _cp4 = SProxy :: SProxy "cp4"
 
 component :: ∀ m
   . MonadAff m
- => H.Component HH.HTML Query Unit Void m
+ => H.Component Query Unit Void m
 component =
   H.mkComponent
   { initialState

--- a/ui-guide/Components/FilePicker.purs
+++ b/ui-guide/Components/FilePicker.purs
@@ -5,7 +5,6 @@ import Prelude
 import DOM.HTML.Indexed.InputAcceptType as DOM.HTML.Indexed.InputAcceptType
 import Data.Maybe (Maybe(..))
 import Data.MediaType.Common as Data.MediaType.Common
-import Data.Symbol (SProxy(..))
 import Effect.Aff.Class (class MonadAff)
 import Effect.Class.Console as Effect.Class.Console
 import Halogen as Halogen
@@ -16,6 +15,7 @@ import Ocelot.Block.Format as Format
 import Ocelot.Data.InputAcceptType as Ocelot.Data.InputAcceptType
 import Ocelot.FilePicker as Ocelot.FilePicker
 import Ocelot.HTML.Properties as Ocelot.HTML.Properties
+import Type.Proxy (Proxy(..))
 import UIGuide.Block.Backdrop as Backdrop
 import UIGuide.Block.Documentation as Documentation
 import Web.File.File as Web.File.File
@@ -44,7 +44,7 @@ type ChildSlots =
   ( filePicker :: Ocelot.FilePicker.Slot String
   )
 
-_filePicker = SProxy :: SProxy "filePicker"
+_filePicker = Proxy :: Proxy "filePicker"
 
 component ::
   forall m.

--- a/ui-guide/Components/FilePicker.purs
+++ b/ui-guide/Components/FilePicker.purs
@@ -20,7 +20,7 @@ import UIGuide.Block.Backdrop as Backdrop
 import UIGuide.Block.Documentation as Documentation
 import Web.File.File as Web.File.File
 
-type Component m = Halogen.Component Halogen.HTML.HTML Query Input Output m
+type Component m = Halogen.Component Query Input Output m
 
 type ComponentHTML m = Halogen.ComponentHTML Action ChildSlots m
 

--- a/ui-guide/Components/FilePicker.purs
+++ b/ui-guide/Components/FilePicker.purs
@@ -101,7 +101,7 @@ render state =
                 }
             )
             unit
-            (Just <<< HandleFilePicker)
+            HandleFilePicker
           ]
         , Card.card
           [ Ocelot.HTML.Properties.css "flex-1" ]
@@ -116,7 +116,7 @@ render state =
                 }
             )
             unit
-            (Just <<< HandleFilePicker)
+            HandleFilePicker
           ]
         , Card.card
           [ Ocelot.HTML.Properties.css "flex-1" ]
@@ -134,7 +134,7 @@ render state =
               }
             )
             unit
-            (Just <<< HandleFilePicker)
+            HandleFilePicker
           ]
         , Card.card
           [ Ocelot.HTML.Properties.css "flex-1" ]
@@ -149,7 +149,7 @@ render state =
               }
             )
             unit
-            (Just <<< HandleFilePicker)
+            HandleFilePicker
           ]
         ]
       ]

--- a/ui-guide/Components/FormControl.purs
+++ b/ui-guide/Components/FormControl.purs
@@ -5,7 +5,6 @@ import Prelude
 import Data.Array as Data.Array
 import Data.Int as Data.Int
 import Data.Maybe (Maybe(..))
-import Data.Symbol (SProxy(..))
 import Effect.Aff.Class (class MonadAff)
 import Effect.Console (log)
 import Halogen as Halogen
@@ -23,6 +22,7 @@ import Ocelot.Block.Radio as Radio
 import Ocelot.HTML.Properties (css)
 import Ocelot.Slider as Ocelot.Slider
 import Ocelot.Slider.Render as Ocelot.Slider.Render
+import Type.Proxy (Proxy(..))
 import UIGuide.Block.Backdrop as Backdrop
 import UIGuide.Block.Documentation as Documentation
 import Web.UIEvent.MouseEvent (MouseEvent)
@@ -52,7 +52,7 @@ type Output = Void
 type ChildSlots =
   ( slider :: Ocelot.Slider.Slot String )
 
-_slider = SProxy :: SProxy "slider"
+_slider = Proxy :: Proxy "slider"
 
 component ::
   forall m.

--- a/ui-guide/Components/FormControl.purs
+++ b/ui-guide/Components/FormControl.purs
@@ -138,37 +138,37 @@ render state =
                 [ css "pr-6" ]
                 [ Halogen.HTML.Propreties.name "slider-discrete"
                 , Halogen.HTML.Propreties.checked true
-                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 1 "discrete")
+                , Halogen.HTML.Events.onClick \_ -> HandleThumbCount 1 "discrete"
                 ]
                 [ Halogen.HTML.text "1" ]
               , Radio.radio
                 [ css "pr-6" ]
                 [ Halogen.HTML.Propreties.name "slider-discrete"
-                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 2 "discrete")
+                , Halogen.HTML.Events.onClick \_ -> HandleThumbCount 2 "discrete"
                 ]
                 [ Halogen.HTML.text "2" ]
               , Radio.radio
                 [ css "pr-6" ]
                 [ Halogen.HTML.Propreties.name "slider-discrete"
-                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 3 "discrete")
+                , Halogen.HTML.Events.onClick \_ -> HandleThumbCount 3 "discrete"
                 ]
                 [ Halogen.HTML.text "3" ]
               , Radio.radio
                 [ css "pr-6" ]
                 [ Halogen.HTML.Propreties.name "slider-discrete"
-                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 4 "discrete")
+                , Halogen.HTML.Events.onClick \_ -> HandleThumbCount 4 "discrete"
                 ]
                 [ Halogen.HTML.text "4" ]
               , Radio.radio
                 [ css "pr-6" ]
                 [ Halogen.HTML.Propreties.name "slider-discrete"
-                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 5 "discrete")
+                , Halogen.HTML.Events.onClick \_ -> HandleThumbCount 5 "discrete"
                 ]
                 [ Halogen.HTML.text "5" ]
               , Radio.radio
                 [ css "pr-6" ]
                 [ Halogen.HTML.Propreties.name "slider-discrete"
-                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 6 "discrete")
+                , Halogen.HTML.Events.onClick \_ -> HandleThumbCount 6 "discrete"
                 ]
                 [ Halogen.HTML.text "6" ]
               ]
@@ -181,7 +181,7 @@ render state =
               , minDistance: Just { percent: 9.9 }
               , renderIntervals: Data.Array.foldMap renderInterval
               }
-              (Just <<< HandleSlider)
+              HandleSlider
             ]
           , Card.card
             [ css "flex-1" ]
@@ -194,37 +194,37 @@ render state =
                 [ css "pr-6" ]
                 [ Halogen.HTML.Propreties.name "slider-continuous"
                 , Halogen.HTML.Propreties.checked true
-                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 1 "continuous")
+                , Halogen.HTML.Events.onClick \_ -> HandleThumbCount 1 "continuous"
                 ]
                 [ Halogen.HTML.text "1" ]
               , Radio.radio
                 [ css "pr-6" ]
                 [ Halogen.HTML.Propreties.name "slider-continuous"
-                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 2 "continuous")
+                , Halogen.HTML.Events.onClick \_ -> HandleThumbCount 2 "continuous"
                 ]
                 [ Halogen.HTML.text "2" ]
               , Radio.radio
                 [ css "pr-6" ]
                 [ Halogen.HTML.Propreties.name "slider-continuous"
-                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 3 "continuous")
+                , Halogen.HTML.Events.onClick \_ -> HandleThumbCount 3 "continuous"
                 ]
                 [ Halogen.HTML.text "3" ]
               , Radio.radio
                 [ css "pr-6" ]
                 [ Halogen.HTML.Propreties.name "slider-continuous"
-                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 4 "continuous")
+                , Halogen.HTML.Events.onClick \_ -> HandleThumbCount 4 "continuous"
                 ]
                 [ Halogen.HTML.text "4" ]
               , Radio.radio
                 [ css "pr-6" ]
                 [ Halogen.HTML.Propreties.name "slider-continuous"
-                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 5 "continuous")
+                , Halogen.HTML.Events.onClick \_ -> HandleThumbCount 5 "continuous"
                 ]
                 [ Halogen.HTML.text "5" ]
               , Radio.radio
                 [ css "pr-6" ]
                 [ Halogen.HTML.Propreties.name "slider-continuous"
-                , Halogen.HTML.Events.onClick \_ -> Just (HandleThumbCount 6 "continuous")
+                , Halogen.HTML.Events.onClick \_ -> HandleThumbCount 6 "continuous"
                 ]
                 [ Halogen.HTML.text "6" ]
               ]
@@ -237,7 +237,7 @@ render state =
               , minDistance: Just { percent: 10.0 }
               , renderIntervals: Data.Array.foldMap renderInterval
               }
-              (Just <<< HandleSlider)
+              HandleSlider
             ]
           , Card.card
             [ css "flex-1" ]
@@ -253,7 +253,7 @@ render state =
               , minDistance: Just { percent: 10.0 }
               , renderIntervals: Data.Array.foldMap renderInterval
               }
-              (Just <<< HandleSlider)
+              HandleSlider
             ]
           ]
         ]

--- a/ui-guide/Components/FormControl.purs
+++ b/ui-guide/Components/FormControl.purs
@@ -27,7 +27,7 @@ import UIGuide.Block.Backdrop as Backdrop
 import UIGuide.Block.Documentation as Documentation
 import Web.UIEvent.MouseEvent (MouseEvent)
 
-type Component m = Halogen.Component Halogen.HTML.HTML Query Input Output m
+type Component m = Halogen.Component Query Input Output m
 
 type ComponentHTML m = Halogen.ComponentHTML Action ChildSlots m
 

--- a/ui-guide/Components/FormControl.purs
+++ b/ui-guide/Components/FormControl.purs
@@ -84,11 +84,11 @@ handleAction = case _ of
       Halogen.liftEffect (log ("slider: " <> show xs))
 
   HandleThumbCount n slotKey -> do
-    void $ Halogen.query _slider slotKey <<< Halogen.tell
+    void $ Halogen.tell _slider slotKey
       $ Ocelot.Slider.SetThumbCount n
 
   Initialize -> do
-    void <<< Halogen.query _slider "disabled" <<< Halogen.tell
+    void <<< Halogen.tell _slider "disabled"
       $ Ocelot.Slider.ReplaceThumbs [ { percent: 30.0 }, { percent: 70.0 } ]
 
   ToggleFormPanel _ -> do

--- a/ui-guide/Components/Icons.purs
+++ b/ui-guide/Components/Icons.purs
@@ -21,7 +21,7 @@ type Input = Unit
 
 type Message = Void
 
-component :: ∀ m . H.Component HH.HTML Query Input Message m
+component :: ∀ m . H.Component Query Input Message m
 component =
   H.mkComponent
     { initialState: const unit

--- a/ui-guide/Components/Modals.purs
+++ b/ui-guide/Components/Modals.purs
@@ -26,7 +26,7 @@ import UIGuide.Block.Documentation as Documentation
 import UIGuide.Utility.Async as Async
 import Web.UIEvent.KeyboardEvent as KE
 
-type Component m = H.Component HH.HTML Query Input Message m
+type Component m = H.Component Query Input Message m
 
 type ComponentHTML m = H.ComponentHTML Action ChildSlot m
 

--- a/ui-guide/Components/Modals.purs
+++ b/ui-guide/Components/Modals.purs
@@ -16,10 +16,10 @@ import Ocelot.Block.Format as Format
 import Ocelot.Block.Icon as Icon
 import Ocelot.Block.ItemContainer (boldMatches) as IC
 import Ocelot.Block.Toast as Ocelot.Block.Toast
-import Ocelot.Typeahead as TA
 import Ocelot.HTML.Properties (css)
 import Ocelot.Part.Modal as Modal
 import Ocelot.Part.Panel as Panel
+import Ocelot.Typeahead as TA
 import Type.Proxy (Proxy(..))
 import UIGuide.Block.Backdrop as Backdrop
 import UIGuide.Block.Documentation as Documentation
@@ -145,7 +145,7 @@ render st =
       [ Backdrop.content
         [ css "mt-0 text-center" ]
         [ Button.button
-          [ HE.onClick $ const $ Just (Open PanelLeft) ]
+          [ HE.onClick \_ -> Open PanelLeft ]
           [ HH.text "Open Left Panel" ]
         ]
       ]
@@ -154,7 +154,7 @@ render st =
       [ Backdrop.content
         [ css "mt-0 text-center" ]
         [ Button.buttonPrimary
-          [ HE.onClick $ const $ Just (Open Modal) ]
+          [ HE.onClick \_ -> Open Modal ]
           [ HH.text "Open Modal" ]
         ]
       ]
@@ -163,7 +163,7 @@ render st =
       [ Backdrop.content
         [ css "mt-0 text-center" ]
         [ Button.button
-          [ HE.onClick $ const $ Just (Open PanelRight) ]
+          [ HE.onClick \_ -> Open PanelRight ]
           [ HH.text "Open Right Panel" ]
         ]
       ]
@@ -189,10 +189,10 @@ renderModal =
     { buttons:
       [ HH.a
         [ HP.classes ( Format.linkDarkClasses <> [ HH.ClassName "mr-4" ] )
-        , HE.onClick $ const $ Just (Close Modal) ]
+        , HE.onClick \_ -> Close Modal ]
         [ HH.text "Cancel" ]
       , Button.buttonPrimary
-        [ HE.onClick $ const $ Just Toast ]
+        [ HE.onClick \_ -> Toast ]
         [ HH.text "Submit" ]
       ]
     , title: [ HH.text "Editing" ]
@@ -213,7 +213,7 @@ renderPanelLeft visible =
   [ Panel.header
     { buttons:
       [ Button.buttonClear
-        [ HE.onClick $ const $ Just (Close PanelLeft) ]
+        [ HE.onClick \_ -> Close PanelLeft ]
         [ Icon.close_ ]
       ]
     , title: [ HH.text "Editing" ]
@@ -237,7 +237,7 @@ renderPanelRight visible =
   [ Panel.header
     { buttons:
       [ Button.buttonClear
-        [ HE.onClick $ const $ Just (Close PanelRight) ]
+        [ HE.onClick \_ -> Close PanelRight ]
         [ Icon.close_ ]
       ]
     , title: [ HH.text "Editing" ]
@@ -266,7 +266,7 @@ renderContent label =
     , error: []
     , inputId: "locations"
     }
-    [ HH.slot _cp1 label TA.multi
+    [ HH.slot_ _cp1 label TA.multi
       ( TA.asyncMulti
         { renderFuzzy: HH.span_ <<< IC.boldMatches "name"
         , itemToObject: Async.locationToObject
@@ -276,7 +276,6 @@ renderContent label =
         , HP.id_ "locations"
         ]
       )
-      ( const Nothing )
     ]
   , HH.h3
     [ HP.classes Format.captionClasses ]
@@ -287,7 +286,7 @@ renderContent label =
     , error: []
     , inputId: "users"
     }
-    [ HH.slot _cp2 label TA.multi
+    [ HH.slot_ _cp2 label TA.multi
       ( TA.asyncMulti
         { renderFuzzy: Async.renderFuzzyUser
         , itemToObject: Async.userToObject
@@ -297,6 +296,5 @@ renderContent label =
         , HP.id_ "users"
         ]
       )
-      ( const Nothing )
     ]
   ]

--- a/ui-guide/Components/Modals.purs
+++ b/ui-guide/Components/Modals.purs
@@ -4,7 +4,6 @@ import Prelude
 import Data.Foldable (traverse_)
 import Data.Map as Data.Map
 import Data.Maybe (Maybe(..), isJust)
-import Data.Symbol (SProxy(..))
 import Effect.Aff.Class (class MonadAff)
 import Halogen as H
 import Halogen.HTML as HH
@@ -21,6 +20,7 @@ import Ocelot.Typeahead as TA
 import Ocelot.HTML.Properties (css)
 import Ocelot.Part.Modal as Modal
 import Ocelot.Part.Panel as Panel
+import Type.Proxy (Proxy(..))
 import UIGuide.Block.Backdrop as Backdrop
 import UIGuide.Block.Documentation as Documentation
 import UIGuide.Utility.Async as Async
@@ -62,8 +62,8 @@ type ChildSlot =
   , cp2 :: TA.Slot Action Array Async.User String
   )
 
-_cp1 = SProxy :: SProxy "cp1"
-_cp2 = SProxy :: SProxy "cp2"
+_cp1 = Proxy :: Proxy "cp1"
+_cp2 = Proxy :: Proxy "cp2"
 
 component ::
   forall m.

--- a/ui-guide/Components/MultiInput.purs
+++ b/ui-guide/Components/MultiInput.purs
@@ -3,7 +3,6 @@ module UIGuide.Component.MultiInput where
 import Prelude
 
 import Data.Maybe (Maybe(..))
-import Data.Symbol (SProxy(..))
 import Effect.Aff.Class (class MonadAff)
 import Halogen as Halogen
 import Halogen.HTML as Halogen.HTML
@@ -13,6 +12,7 @@ import Ocelot.Block.FormField as FormField
 import Ocelot.Block.Format as Format
 import Ocelot.Components.MultiInput.Component as Ocelot.Components.MultiInput.Component
 import Ocelot.HTML.Properties as Ocelot.HTML.Properties
+import Type.Proxy (Proxy(..))
 import UIGuide.Block.Backdrop as Backdrop
 import UIGuide.Block.Documentation as Documentation
 
@@ -39,7 +39,7 @@ type Output
 type ChildSlots =
   ( multiInput :: Ocelot.Components.MultiInput.Component.Slot MultiInputSlot)
 
-_multiInput = SProxy :: SProxy "multiInput"
+_multiInput = Proxy :: Proxy "multiInput"
 
 data MultiInputSlot
   = NoItem

--- a/ui-guide/Components/MultiInput.purs
+++ b/ui-guide/Components/MultiInput.purs
@@ -16,7 +16,7 @@ import Ocelot.HTML.Properties as Ocelot.HTML.Properties
 import UIGuide.Block.Backdrop as Backdrop
 import UIGuide.Block.Documentation as Documentation
 
-type Component m = Halogen.Component Halogen.HTML.HTML Query Input Output m
+type Component m = Halogen.Component Query Input Output m
 
 type ComponentHTML m = Halogen.ComponentHTML Action ChildSlots m
 

--- a/ui-guide/Components/MultiInput.purs
+++ b/ui-guide/Components/MultiInput.purs
@@ -71,7 +71,7 @@ initialState _ = {}
 handleAction :: forall m. Action -> ComponentM m Unit
 handleAction = case _ of
   Initialize -> do
-    void <<< Halogen.query _multiInput WithItems <<< Halogen.tell
+    void <<< Halogen.tell _multiInput WithItems
       $ Ocelot.Components.MultiInput.Component.SetItems items
 
 render ::

--- a/ui-guide/Components/MultiInput.purs
+++ b/ui-guide/Components/MultiInput.purs
@@ -98,12 +98,11 @@ render state =
               , error: []
               , inputId: "keywords-no-item"
               }
-              [ Halogen.HTML.slot _multiInput NoItem
+              [ Halogen.HTML.slot_ _multiInput NoItem
                   Ocelot.Components.MultiInput.Component.component
                   { minWidth
                   , placeholder
                   }
-                  (const Nothing)
               ]
           , Halogen.HTML.h3
               [ Halogen.HTML.Properties.classes Format.captionClasses ]
@@ -114,12 +113,11 @@ render state =
               , error: []
               , inputId: "keywords-with-items"
               }
-              [ Halogen.HTML.slot _multiInput WithItems
+              [ Halogen.HTML.slot_ _multiInput WithItems
                   Ocelot.Components.MultiInput.Component.component
                   { minWidth
                   , placeholder
                   }
-                  (const Nothing)
               ]
           ]
         ]

--- a/ui-guide/Components/Tab.purs
+++ b/ui-guide/Components/Tab.purs
@@ -20,7 +20,7 @@ type Input = Unit
 type Message = Void
 
 
-component :: ∀ m. H.Component HH.HTML Query Input Message m
+component :: ∀ m. H.Component Query Input Message m
 component =
   H.mkComponent
     { initialState: const unit

--- a/ui-guide/Components/Table.purs
+++ b/ui-guide/Components/Table.purs
@@ -35,7 +35,7 @@ type Message = Void
 component ::
   forall m.
   MonadAff m =>
-  H.Component HH.HTML Query Input Message m
+  H.Component Query Input Message m
 component =
   H.mkComponent
     { initialState

--- a/ui-guide/Components/Table.purs
+++ b/ui-guide/Components/Table.purs
@@ -2,7 +2,6 @@ module UIGuide.Component.Table where
 
 import Prelude
 
-import Data.Maybe (Maybe(..))
 import Data.Ratio ((%))
 import Effect.Aff.Class (class MonadAff)
 import Halogen as H
@@ -72,7 +71,7 @@ render { page } =
         [ renderTable
         , Ocelot.Block.Pager.pagerNew page 100
           [ css "flex justify-end mt-6"]
-          (\index event -> Just (Page index event))
+          (\index event -> Page index event)
         ]
       ]
     ]

--- a/ui-guide/Components/TextFields.purs
+++ b/ui-guide/Components/TextFields.purs
@@ -3,7 +3,6 @@ module UIGuide.Component.TextFields where
 import Prelude
 
 import Data.Maybe (Maybe(..))
-import Data.Symbol (SProxy(..))
 import Data.Time.Duration (Milliseconds(..))
 import Effect.Aff.Class (class MonadAff)
 import Effect.Console (log)
@@ -19,6 +18,7 @@ import Ocelot.Block.Input as Input
 import Ocelot.Block.Loading as Loading
 import Ocelot.Component.SearchBar as SearchBar
 import Ocelot.HTML.Properties (css)
+import Type.Proxy (Proxy(..))
 import UIGuide.Block.Backdrop as Backdrop
 import UIGuide.Block.Documentation as Documentation
 
@@ -34,7 +34,7 @@ type Message = Void
 type ChildSlot =
   ( search :: SearchBar.Slot Unit )
 
-_search = SProxy :: SProxy "search"
+_search = Proxy :: Proxy "search"
 
 type ChildQuery = SearchBar.Query
 

--- a/ui-guide/Components/TextFields.purs
+++ b/ui-guide/Components/TextFields.purs
@@ -38,7 +38,7 @@ _search = SProxy :: SProxy "search"
 
 type ChildQuery = SearchBar.Query
 
-component :: ∀ m. MonadAff m => H.Component HH.HTML Query Input Message m
+component :: ∀ m. MonadAff m => H.Component Query Input Message m
 component =
   H.mkComponent
     { initialState: const unit

--- a/ui-guide/Components/TextFields.purs
+++ b/ui-guide/Components/TextFields.purs
@@ -432,7 +432,7 @@ cnDocumentationBlocks =
             [ css "w-50" ]
             [ HH.slot _search unit SearchBar.component
               { debounceTime: Just (Milliseconds 250.0) }
-              ( Just <<< HandleSearch )
+              HandleSearch
             ]
           ]
         ]
@@ -448,7 +448,7 @@ cnDocumentationBlocks =
               { debounceTime: Just (Milliseconds 250.0)
               , keepOpen: true
               }
-              ( Just <<< HandleSearch )
+              HandleSearch
             ]
           ]
         ]
@@ -466,7 +466,7 @@ cnDocumentationBlocks =
             [ css "mr-8" ]
             [ HH.slot _search unit SearchBar.component
               { debounceTime: Just (Milliseconds 250.0) }
-              ( Just <<< HandleSearch )
+              HandleSearch
             ]
           , Button.buttonPrimary_
             [ HH.text "Neighbor" ]

--- a/ui-guide/Components/Tray.purs
+++ b/ui-guide/Components/Tray.purs
@@ -22,7 +22,7 @@ type Input = Unit
 
 type Message = Void
 
-component :: ∀ m . H.Component HH.HTML Query Input Message m
+component :: ∀ m . H.Component Query Input Message m
 component =
   H.mkComponent
     { initialState: const { open: true }

--- a/ui-guide/Components/Tray.purs
+++ b/ui-guide/Components/Tray.purs
@@ -2,7 +2,6 @@ module UIGuide.Component.Tray where
 
 import Prelude
 
-import Data.Maybe (Maybe(..))
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
@@ -45,7 +44,7 @@ component =
         }
         [ Backdrop.backdrop_
           [ Button.button
-            [ HE.onClick (const $ Just Toggle) ]
+            [ HE.onClick \_ -> Toggle ]
             [ HH.text "toggle tray" ]
           , Tray.tray
             [ Tray.open state.open ]

--- a/ui-guide/Components/Type.purs
+++ b/ui-guide/Components/Type.purs
@@ -19,7 +19,7 @@ type Input = Unit
 
 type Message = Void
 
-component :: ∀ m. H.Component HH.HTML Query Input Message m
+component :: ∀ m. H.Component Query Input Message m
 component =
   H.mkComponent
     { initialState: const unit

--- a/ui-guide/Components/Typeaheads.purs
+++ b/ui-guide/Components/Typeaheads.purs
@@ -5,7 +5,6 @@ import Control.Parallel as Control.Parallel
 import Data.Array (head, take)
 import Data.Maybe (Maybe(..))
 import Data.Newtype (unwrap)
-import Data.Symbol (SProxy(..))
 import Effect.Aff.Class (class MonadAff)
 import Halogen as H
 import Halogen.HTML as HH
@@ -17,6 +16,7 @@ import Ocelot.Block.Format as Format
 import Ocelot.Block.ItemContainer (boldMatches) as IC
 import Ocelot.Typeahead as TA
 import Ocelot.HTML.Properties (css)
+import Type.Proxy (Proxy(..))
 import UIGuide.Block.Backdrop as Backdrop
 import UIGuide.Block.Documentation as Documentation
 import UIGuide.Utility.Async as Async
@@ -40,10 +40,10 @@ type ChildSlot =
   , cp4 :: TA.Slot Action Array Async.Location Int
   )
 
-_singleUser = SProxy :: SProxy "cp1"
-_multiUser = SProxy :: SProxy "cp2"
-_singleLocation = SProxy :: SProxy "cp3"
-_multiLocation = SProxy :: SProxy "cp4"
+_singleUser = Proxy :: Proxy "cp1"
+_multiUser = Proxy :: Proxy "cp2"
+_singleLocation = Proxy :: Proxy "cp3"
+_multiLocation = Proxy :: Proxy "cp4"
 
 
 ----------

--- a/ui-guide/Components/Typeaheads.purs
+++ b/ui-guide/Components/Typeaheads.purs
@@ -51,7 +51,7 @@ _multiLocation = SProxy :: SProxy "cp4"
 
 component :: ∀ m
   . MonadAff m
- => H.Component HH.HTML Query Unit Void m
+ => H.Component Query Unit Void m
 component =
   H.mkComponent
   { initialState: const unit

--- a/ui-guide/Components/Typeaheads.purs
+++ b/ui-guide/Components/Typeaheads.purs
@@ -147,7 +147,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "location"
               }
-              [ HH.slot _singleLocation 0 TA.single
+              [ HH.slot_ _singleLocation 0 TA.single
                 ( ( TA.syncSingle
                     { renderFuzzy: HH.span_ <<< IC.boldMatches "name"
                     , itemToObject: Async.locationToObject
@@ -157,7 +157,7 @@ cnDocumentationBlocks =
                     ]
                   ) { insertable = TA.Insertable Async.stringToLocation }
                 )
-                ( const Nothing )
+
               ]
             , HH.h3
               [ HP.classes Format.captionClasses ]
@@ -168,7 +168,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "location-hydrated"
               }
-              [ HH.slot _singleLocation 1 TA.single
+              [ HH.slot_ _singleLocation 1 TA.single
                 ( ( TA.asyncSingle
                     { renderFuzzy: HH.span_ <<< IC.boldMatches "name"
                     , itemToObject: Async.locationToObject
@@ -179,7 +179,6 @@ cnDocumentationBlocks =
                     ]
                   ) { insertable = TA.Insertable Async.stringToLocation }
                 )
-                ( const Nothing )
               ]
             ]
           ]
@@ -195,7 +194,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "user"
               }
-              [ HH.slot _singleUser 0 TA.singleHighlightOnly
+              [ HH.slot_ _singleUser 0 TA.singleHighlightOnly
                 ( TA.asyncSingle
                   { renderFuzzy: Async.renderFuzzyUser
                   , itemToObject: Async.userToObject
@@ -205,7 +204,6 @@ cnDocumentationBlocks =
                   , HP.id_ "user"
                   ]
                 )
-                ( const Nothing )
               ]
             , HH.h3
               [ HP.classes Format.captionClasses ]
@@ -216,7 +214,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "user-hydrated"
               }
-              [ HH.slot _singleUser 1 TA.singleHighlightOnly
+              [ HH.slot_ _singleUser 1 TA.singleHighlightOnly
                 ( TA.asyncSingle
                   { renderFuzzy: Async.renderFuzzyUser
                   , itemToObject: Async.userToObject
@@ -226,7 +224,6 @@ cnDocumentationBlocks =
                   , HP.id_ "user-hydrated"
                   ]
                 )
-                ( const Nothing )
               ]
             ]
           ]
@@ -249,7 +246,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "locations"
               }
-              [ HH.slot _multiLocation 0 TA.multi
+              [ HH.slot_ _multiLocation 0 TA.multi
                 ( ( TA.asyncMulti
                     { renderFuzzy: HH.span_ <<< IC.boldMatches "name"
                     , itemToObject: Async.locationToObject
@@ -260,7 +257,6 @@ cnDocumentationBlocks =
                     ]
                   ) { insertable = TA.Insertable Async.stringToLocation }
                 )
-                ( const Nothing )
               ]
             , HH.h3
               [ HP.classes Format.captionClasses ]
@@ -271,7 +267,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "locations"
               }
-              [ HH.slot _multiLocation 1 TA.multi
+              [ HH.slot_ _multiLocation 1 TA.multi
                 ( ( TA.asyncMulti
                     { renderFuzzy: HH.span_ <<< IC.boldMatches "name"
                     , itemToObject: Async.locationToObject
@@ -282,7 +278,6 @@ cnDocumentationBlocks =
                     ]
                   ) { insertable = TA.Insertable Async.stringToLocation }
                 )
-                ( const Nothing )
               ]
             ]
           ]
@@ -298,7 +293,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "users"
               }
-              [ HH.slot _multiUser 0 TA.multiHighlightOnly
+              [ HH.slot_ _multiUser 0 TA.multiHighlightOnly
                 ( TA.asyncMulti
                   { renderFuzzy: Async.renderFuzzyUser
                   , itemToObject: Async.userToObject
@@ -308,7 +303,6 @@ cnDocumentationBlocks =
                   , HP.id_ "user"
                   ]
                 )
-                ( const Nothing )
               ]
             , HH.h3
               [ HP.classes Format.captionClasses ]
@@ -319,7 +313,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "users-hydrated"
               }
-              [ HH.slot _multiUser 1 TA.multiHighlightOnly
+              [ HH.slot_ _multiUser 1 TA.multiHighlightOnly
                 ( TA.asyncMulti
                   { renderFuzzy: Async.renderFuzzyUser
                   , itemToObject: Async.userToObject
@@ -329,7 +323,6 @@ cnDocumentationBlocks =
                   , HP.id_ "user"
                   ]
                 )
-                ( const Nothing )
               ]
             ]
           ]
@@ -352,7 +345,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "disabled-locations-empty"
               }
-              [ HH.slot _singleLocation 2 TA.single
+              [ HH.slot_ _singleLocation 2 TA.single
                 ( TA.asyncSingle
                   { renderFuzzy: HH.span_ <<< IC.boldMatches "name"
                   , itemToObject: Async.locationToObject
@@ -363,7 +356,6 @@ cnDocumentationBlocks =
                   , HP.disabled true
                   ]
                 )
-                ( const Nothing )
               ]
             , HH.h3
               [ HP.classes Format.captionClasses ]
@@ -374,7 +366,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "disabled-locations-hydrated"
               }
-              [ HH.slot _singleLocation 3 TA.single
+              [ HH.slot_ _singleLocation 3 TA.single
                 ( TA.asyncSingle
                   { renderFuzzy: HH.span_ <<< IC.boldMatches "name"
                   , itemToObject: Async.locationToObject
@@ -385,7 +377,6 @@ cnDocumentationBlocks =
                   , HP.disabled true
                   ]
                 )
-                ( const Nothing )
               ]
             , HH.h3
               [ HP.classes Format.captionClasses ]
@@ -396,7 +387,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "error-locations"
               }
-              [ HH.slot _singleLocation 4 TA.single
+              [ HH.slot_ _singleLocation 4 TA.single
                 ( TA.asyncSingle
                   { renderFuzzy: HH.span_ <<< IC.boldMatches "name"
                   , itemToObject: Async.locationToObject
@@ -406,7 +397,6 @@ cnDocumentationBlocks =
                   , HP.id_ "error-locations"
                   ]
                 )
-                ( const Nothing )
               ]
             , HH.h3
               [ HP.classes Format.captionClasses ]
@@ -417,7 +407,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "loading-locations"
               }
-              [ HH.slot _singleLocation 5 TA.single
+              [ HH.slot_ _singleLocation 5 TA.single
                 ( TA.asyncSingle
                   { renderFuzzy: HH.span_ <<< IC.boldMatches "name"
                   , itemToObject: Async.locationToObject
@@ -427,7 +417,6 @@ cnDocumentationBlocks =
                   , HP.id_ "loading-locations"
                   ]
                 )
-                ( const Nothing )
               ]
             ]
           ]
@@ -443,7 +432,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "disabled-users-empty"
               }
-              [ HH.slot _multiUser 2 TA.multiHighlightOnly
+              [ HH.slot_ _multiUser 2 TA.multiHighlightOnly
                 ( TA.asyncMulti
                   { renderFuzzy: Async.renderFuzzyUser
                   , itemToObject: Async.userToObject
@@ -454,7 +443,6 @@ cnDocumentationBlocks =
                   , HP.id_ "disabled-users-empty"
                   ]
                 )
-                ( const Nothing )
               ]
             , HH.h3
               [ HP.classes Format.captionClasses ]
@@ -465,7 +453,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "disabled-users-hydrated"
               }
-              [ HH.slot _multiUser 3 TA.multiHighlightOnly
+              [ HH.slot_ _multiUser 3 TA.multiHighlightOnly
                 ( TA.asyncMulti
                   { renderFuzzy: Async.renderFuzzyUser
                   , itemToObject: Async.userToObject
@@ -476,7 +464,6 @@ cnDocumentationBlocks =
                   , HP.id_ "disabled-users-hydrated"
                   ]
                 )
-                ( const Nothing )
               ]
             , HH.h3
               [ HP.classes Format.captionClasses ]
@@ -487,7 +474,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "error-users"
               }
-              [ HH.slot _multiUser 4 TA.multiHighlightOnly
+              [ HH.slot_ _multiUser 4 TA.multiHighlightOnly
                 ( TA.asyncMulti
                   { renderFuzzy: Async.renderFuzzyUser
                   , itemToObject: Async.userToObject
@@ -497,7 +484,6 @@ cnDocumentationBlocks =
                   , HP.id_ "error-users"
                   ]
                 )
-                ( const Nothing )
               ]
             , HH.h3
               [ HP.classes Format.captionClasses ]
@@ -508,7 +494,7 @@ cnDocumentationBlocks =
               , error: []
               , inputId: "loading-users"
               }
-              [ HH.slot _multiUser 5 TA.multiHighlightOnly
+              [ HH.slot_ _multiUser 5 TA.multiHighlightOnly
                 ( TA.asyncMulti
                   { renderFuzzy: Async.renderFuzzyUser
                   , itemToObject: Async.userToObject
@@ -518,7 +504,6 @@ cnDocumentationBlocks =
                   , HP.id_ "loading-users"
                   ]
                 )
-                ( const Nothing )
               ]
             ]
           ]
@@ -539,7 +524,7 @@ cnDocumentationBlocks =
               [ HH.h3
                 [ HP.classes Format.captionClasses ]
                 [ HH.text "Searchable Dropdown in a Header (e.g. for filtering)" ]
-              , HH.slot _singleLocation 9
+              , HH.slot_ _singleLocation 9
                 ( TA.component
                   { runSelect: const <<< Just
                   , runRemove: const (const Nothing)
@@ -560,7 +545,6 @@ cnDocumentationBlocks =
                   (HH.text <<< _.name <<< unwrap)
                   (HH.span_ <<< IC.boldMatches "name")
                 }
-                ( const Nothing )
               ]
             ]
           ]
@@ -570,7 +554,7 @@ cnDocumentationBlocks =
             [ HH.h3
               [ HP.classes Format.captionClasses ]
               [ HH.text "Searchable Dropdown in a Toolbar (e.g. for filtering)" ]
-            , HH.slot _singleLocation 10
+            , HH.slot_ _singleLocation 10
               ( TA.component
                 { runSelect: const <<< Just
                 , runRemove: const (const Nothing)
@@ -591,7 +575,6 @@ cnDocumentationBlocks =
                 (HH.text <<< _.name <<< unwrap)
                 (HH.span_ <<< IC.boldMatches "name")
               }
-              ( const Nothing )
             ]
           ]
         ]

--- a/ui-guide/Components/Typeaheads.purs
+++ b/ui-guide/Components/Typeaheads.purs
@@ -14,8 +14,8 @@ import Ocelot.Block.Card as Card
 import Ocelot.Block.FormField as FormField
 import Ocelot.Block.Format as Format
 import Ocelot.Block.ItemContainer (boldMatches) as IC
-import Ocelot.Typeahead as TA
 import Ocelot.HTML.Properties (css)
+import Ocelot.Typeahead as TA
 import Type.Proxy (Proxy(..))
 import UIGuide.Block.Backdrop as Backdrop
 import UIGuide.Block.Documentation as Documentation
@@ -75,20 +75,20 @@ component =
     handleAction = case _ of
       Initialize -> do
         _ <- Control.Parallel.parSequence_
-          [ H.queryAll _singleUser $ H.tell $ TA.ReplaceItems Loading
-          , H.queryAll _multiUser $ H.tell $ TA.ReplaceItems Loading
-          , H.queryAll _singleLocation $ H.tell $ TA.ReplaceItems Loading
-          , H.queryAll _multiLocation $ H.tell $ TA.ReplaceItems Loading
+          [ H.queryAll _singleUser $ H.mkTell $ TA.ReplaceItems Loading
+          , H.queryAll _multiUser $ H.mkTell $ TA.ReplaceItems Loading
+          , H.queryAll _singleLocation $ H.mkTell $ TA.ReplaceItems Loading
+          , H.queryAll _multiLocation $ H.mkTell $ TA.ReplaceItems Loading
           ]
 
         _ <- Control.Parallel.parSequence_
           [ fetchAndSetLocations, fetchAndSetUsers ]
 
         _ <- Control.Parallel.parSequence_
-          [ H.query _singleLocation 4 $ H.tell $ TA.ReplaceItems $ Failure ""
-          , H.query _singleLocation 5 $ H.tell $ TA.ReplaceItems Loading
-          , H.query _multiUser 4 $ H.tell $ TA.ReplaceItems $ Failure ""
-          , H.query _multiUser 5 $ H.tell $ TA.ReplaceItems Loading
+          [ H.query _singleLocation 4 $ H.mkTell $ TA.ReplaceItems $ Failure ""
+          , H.query _singleLocation 5 $ H.mkTell $ TA.ReplaceItems Loading
+          , H.query _multiUser 4 $ H.mkTell $ TA.ReplaceItems $ Failure ""
+          , H.query _multiUser 5 $ H.mkTell $ TA.ReplaceItems Loading
           ]
 
         pure unit
@@ -99,10 +99,10 @@ component =
 
       case remoteLocations, selectedLocations of
         items@(Success _), Success xs -> do
-          void $ H.queryAll _singleLocation $ H.tell $ TA.ReplaceItems items
+          void $ H.queryAll _singleLocation $ H.mkTell $ TA.ReplaceItems items
           void $ H.query _singleLocation 1 $ TA.ReplaceSelected (head xs) unit
           void $ H.query _singleLocation 3 $ TA.ReplaceSelected (head xs) unit
-          void $ H.queryAll _multiLocation $ H.tell $ TA.ReplaceItems items
+          void $ H.queryAll _multiLocation $ H.mkTell $ TA.ReplaceItems items
           void $ H.query _multiLocation 1 $ TA.ReplaceSelected (take 4 xs) unit
         _, _ -> pure unit
 
@@ -112,11 +112,11 @@ component =
 
       case remoteUsers, selectedUsers of
         items@(Success _), Success xs -> do
-          void $ H.queryAll _singleUser $ H.tell $ TA.ReplaceItems items
-          void $ H.queryAll _multiUser $ H.tell $ TA.ReplaceItems items
-          void $ H.query _singleUser 1 $ TA.ReplaceSelected (head xs) unit
-          void $ H.query _multiUser 1 $ TA.ReplaceSelected (take 4 xs) unit
-          void $ H.query _multiUser 3 $ TA.ReplaceSelected (take 4 xs) unit
+          void $ H.queryAll _singleUser $ H.mkTell $ TA.ReplaceItems items
+          void $ H.queryAll _multiUser $ H.mkTell $ TA.ReplaceItems items
+          void $ H.tell _singleUser 1 $ TA.ReplaceSelected (head xs)
+          void $ H.tell _multiUser 1 $ TA.ReplaceSelected (take 4 xs)
+          void $ H.tell _multiUser 3 $ TA.ReplaceSelected (take 4 xs)
         _, _ -> pure unit
 
 ----------

--- a/yarn.lock
+++ b/yarn.lock
@@ -5181,10 +5181,10 @@ purescript-installer@^0.2.0:
     which "^1.3.1"
     zen-observable "^0.8.14"
 
-purescript@^0.13.8:
-  version "0.13.8"
-  resolved "https://registry.yarnpkg.com/purescript/-/purescript-0.13.8.tgz#acab6f3008d75b8046478c8c1d6124079dc96f7e"
-  integrity sha512-1ZyVEVFLgcEcjPXxJYeVEyYn66DF2DnOLTWzo/K/MrQUF2chdLSyZ8sJpcarWyrz2HxXaubYceYbo5KexKzynA==
+purescript@0.14.1:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/purescript/-/purescript-0.14.1.tgz#dac33e11391bc35361b187ae85f19578a286747a"
+  integrity sha512-dh87XeDP/JGe/3DKBMglkRuIRfGLGkL8beuLIl9KemzckgyuD+j7VK15eVb9n5Exp3DIr6SNEuGG4FjuQQ7Rpg==
   dependencies:
     purescript-installer "^0.2.0"
 


### PR DESCRIPTION
## What does this pull request do?

Upgrade `purescript` to `0.14.1` and pin the new spago package set with `halogen` to `v6.1.2`.

Fix a bunch of breaking changes from various repos
- [`generic-rep`](https://github.com/purescript-deprecated/purescript-generics-rep) is deprecated and mostly moved into `prelude` with some module name changes
- [`globals`](https://github.com/purescript-deprecated/purescript-globals) is deprecated and URI component encode/decode functions are moved to [`js-uri`](https://github.com/purescript-contrib/purescript-js-uri)
- [`ordered-collections`](https://github.com/purescript/purescript-ordered-collections/pull/38) moved left biased `Semigroup` and `Monoid` instances from `Data.Map.Map` to a new data-type `Data.Map.SemigroupMap` (`Safe.Coerce.coerce` could save the wrapping and unwrapping of newtype now so not too inconvenient, but new instances use `unionWith append` instead of `union` that require `Semigroup` instance on value too so it's not a drop-in replacement of the old instances)
- breaking changes on halogen are summarized well in [v6 change log](https://github.com/purescript-halogen/purescript-halogen/blob/master/docs/changelog/v6.md)

## Where should the reviewer start?

One commit per breaking change.
