### PR TITLE
AS-1348 Add Time Range to TimePicker

### DIFF
--- a/src/DateTimePicker.purs
+++ b/src/DateTimePicker.purs
@@ -148,7 +148,10 @@ render { date, time, targetDate, disabled } =
     , HH.div
       [ css "flex-1" ]
       [ HH.slot _timepicker unit TimePicker.component
-        { selection: time, disabled }
+        { disabled
+        , interval: Nothing -- TODO AS-1344
+        , selection: time
+        }
         (Just <<< HandleTime)
       ]
     ]

--- a/src/Slider.purs
+++ b/src/Slider.purs
@@ -3,7 +3,8 @@
 -- |   * mark: static node on track
 -- | * axis
 module Ocelot.Slider
-  ( Interval(..)
+  ( Input
+  , Interval(..)
   , Output(..)
   , Query(..)
   , Slot

--- a/src/TimePicker.purs
+++ b/src/TimePicker.purs
@@ -185,6 +185,7 @@ embeddedHandleAction = case _ of
   OnBlur -> do
     { selection } <- H.get
     when (isNothing selection) handleSearch
+    H.modify_ _ { visibility = S.Off }
 
 embeddedHandleMessage
   :: forall m
@@ -321,9 +322,8 @@ handleSearch = do
     "" -> setSelection Nothing
     _  -> case guessTime search of
       Nothing -> pure unit
-      Just t  -> do
-        setSelection (Just t)
-        H.modify_ _ { visibility = S.Off }
+      Just t  -> setSelection (Just t)
+  H.modify_ _ { visibility = S.Off }
   H.raise $ Searched search
 
 initialState :: Input -> State

--- a/src/TimePicker.purs
+++ b/src/TimePicker.purs
@@ -344,7 +344,7 @@ initialState { selection, disabled } =
 -- check if a time point is within a **closed** interval
 isWithinInterval :: Interval -> Time -> Boolean
 isWithinInterval interval x =
-  Data.Foldable.or
+  Data.Foldable.and
     [ maybe true (_ <= x) interval.start
     , maybe true (x <= _) interval.end
     ]

--- a/src/TimePicker.purs
+++ b/src/TimePicker.purs
@@ -354,14 +354,18 @@ handleQuery = case _ of
 
 handleSearch :: forall m. MonadAff m => CompositeComponentM m Unit
 handleSearch = do
-  search <- H.gets _.search
-  case search of
+  state <- H.get
+  case state.search of
     "" -> setSelection Nothing
-    _  -> case guessTime search of
+    _  -> case guessTime state.search of
       Nothing -> pure unit
-      Just t  -> setSelection (Just t)
+      Just t  -> case state.interval of
+        Nothing -> setSelection (Just t)
+        Just interval
+          | isWithinInterval interval t -> setSelection (Just t)
+          | otherwise -> pure unit
   H.modify_ _ { visibility = S.Off }
-  H.raise $ Searched search
+  H.raise $ Searched state.search
 
 initialState :: Input -> State
 initialState input =

--- a/src/TimePicker.purs
+++ b/src/TimePicker.purs
@@ -246,18 +246,20 @@ embeddedInput state =
   }
 
 embeddedReceive :: forall m. CompositeInput -> CompositeComponentM m Unit
-embeddedReceive input = case input.interval of
-  Nothing -> pure unit
-  Just interval -> do
-    old <- H.get
-    H.modify_ _ { interval = input.interval }
-    case old.selection of
-      Just selection
-        | isWithinInterval interval selection -> synchronize
-        | otherwise -> do
-            H.modify_ _ { search = "" }
-            setSelection Nothing
-      Nothing -> synchronize
+embeddedReceive input = do
+  old <- H.get
+  H.modify_ _ { interval = input.interval }
+  case input.interval of
+    Nothing -> pure unit
+    Just interval -> do
+      case old.selection of
+        Just selection
+          | isWithinInterval interval selection -> pure unit
+          | otherwise -> do
+              H.modify_ _ { search = "" }
+              setSelection Nothing
+        Nothing -> pure unit
+  synchronize
 
 embeddedRender :: forall m. CompositeComponentRender m
 embeddedRender s =

--- a/src/TimePicker.purs
+++ b/src/TimePicker.purs
@@ -16,6 +16,7 @@ module Ocelot.TimePicker
   , EmbeddedAction(..)
   , EmbeddedChildSlots
   , Input
+  , Interval
   , Output(..)
   , Query(..)
   , Slot
@@ -24,6 +25,7 @@ module Ocelot.TimePicker
   , StateRow
   , TimeUnit
   , component
+  , isWithinInterval
   ) where
 
 import Prelude
@@ -33,6 +35,7 @@ import Data.Array as Array
 import Data.Array.NonEmpty (catMaybes, head)
 import Data.DateTime (time)
 import Data.Either (either, hush)
+import Data.Foldable as Data.Foldable
 import Data.Formatter.DateTime (unformatDateTime)
 import Data.FunctorWithIndex (mapWithIndex)
 import Data.Maybe (Maybe(..), fromMaybe, isNothing, maybe)
@@ -99,6 +102,11 @@ type EmbeddedChildSlots = () -- No extension
 type Input =
   { selection :: Maybe Time
   , disabled :: Boolean
+  }
+
+type Interval =
+  { start :: Maybe Time
+  , end :: Maybe Time
   }
 
 data Meridiem
@@ -332,6 +340,14 @@ initialState { selection, disabled } =
   , timeUnits: generateTimes selection
   , disabled
   }
+
+-- check if a time point is within a **closed** interval
+isWithinInterval :: Interval -> Time -> Boolean
+isWithinInterval interval x =
+  Data.Foldable.or
+    [ maybe true (_ <= x) interval.start
+    , maybe true (x <= _) interval.end
+    ]
 
 meridiemToString :: Meridiem -> String
 meridiemToString = case _ of

--- a/src/TimePicker.purs
+++ b/src/TimePicker.purs
@@ -256,7 +256,7 @@ embeddedReceive input = case input.interval of
         | isWithinInterval interval selection -> synchronize
         | otherwise -> do
             H.modify_ _ { search = "" }
-            setSelectionWithoutRaising Nothing
+            setSelection Nothing
       Nothing -> synchronize
 
 embeddedRender :: forall m. CompositeComponentRender m

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -5,6 +5,7 @@ import Effect (Effect)
 import Test.Ocelot.Data.Currency as Test.Ocelot.Data.Currency
 import Test.Ocelot.Data.IntervalTree as Test.Ocelot.Data.IntervalTree
 import Test.Ocelot.HTML.Properties as Test.Ocelot.HTML.Properties
+import Test.Ocelot.TimePicker as Test.Ocelot.TimePicker
 import Test.Ocelot.Typeahead as Test.Ocelot.Typeahead
 import Test.Unit as Test.Unit
 import Test.Unit.Main as Test.Unit.Main
@@ -14,5 +15,6 @@ main = Test.Unit.Main.runTest do
   Test.Unit.suite "Ocelet.Data.Currency" Test.Ocelot.Data.Currency.suite
   Test.Ocelot.Data.IntervalTree.suite
   Test.Ocelot.HTML.Properties.suite
+  Test.Ocelot.TimePicker.suite
   Test.Ocelot.Typeahead.suite
 

--- a/test/Test/TimePicker.purs
+++ b/test/Test/TimePicker.purs
@@ -1,0 +1,121 @@
+module Test.Ocelot.TimePicker (suite) where
+
+import Prelude
+import Data.Maybe (Maybe(..))
+import Data.Time as Data.Time
+import Ocelot.Data.DateTime as Ocelot.Data.DateTime
+import Ocelot.TimePicker as Ocelot.TimePicker
+import Test.Unit as Test.Unit
+import Test.Unit.Assert as Test.Unit.Assert
+
+suite :: Test.Unit.TestSuite
+suite =
+  Test.Unit.suite "Ocelot.TimePicker" do
+    isWithinIntervalTests
+
+isWithinIntervalTests :: Test.Unit.TestSuite
+isWithinIntervalTests =
+  Test.Unit.suite "isWithinInterval" do
+    Test.Unit.test "empty Interval always returns true" do
+      -- [-,-]
+      let
+        interval :: Ocelot.TimePicker.Interval
+        interval = { start: Nothing, end: Nothing }
+
+        given :: Data.Time.Time
+        given = Ocelot.Data.DateTime.defaultTime
+      isWithinInterval interval given true
+
+    Test.Unit.suite "left open interval" do
+      -- [12h,-]
+      let
+        interval :: Ocelot.TimePicker.Interval
+        interval =
+          { start: Just (Ocelot.Data.DateTime.unsafeMkTime 12 0 0 0)
+          , end: Nothing
+          }
+      Test.Unit.test "on" do -- [12h
+        let
+          given :: Data.Time.Time
+          given = Ocelot.Data.DateTime.unsafeMkTime 12 0 0 0
+        isWithinInterval interval given true
+      Test.Unit.test "within" do -- [12h, 13h
+        let
+          given :: Data.Time.Time
+          given = Ocelot.Data.DateTime.unsafeMkTime 13 0 0 0
+        isWithinInterval interval given true
+      Test.Unit.test "outside" do -- 0h [12h,
+        let
+          given :: Data.Time.Time
+          given = Ocelot.Data.DateTime.unsafeMkTime 0 0 0 0
+        isWithinInterval interval given false
+
+    Test.Unit.suite "right open interval" do
+      -- [-,12h]
+      let
+        interval :: Ocelot.TimePicker.Interval
+        interval =
+          { start: Nothing
+          , end: Just (Ocelot.Data.DateTime.unsafeMkTime 12 0 0 0)
+          }
+      Test.Unit.test "on" do -- 12h]
+        let
+          given :: Data.Time.Time
+          given = Ocelot.Data.DateTime.unsafeMkTime 12 0 0 0
+        isWithinInterval interval given true
+      Test.Unit.test "within" do -- 11h ,12h]
+        let
+          given :: Data.Time.Time
+          given = Ocelot.Data.DateTime.unsafeMkTime 11 0 0 0
+        isWithinInterval interval given true
+      Test.Unit.test "outside" do -- ,12h] 13h
+        let
+          given :: Data.Time.Time
+          given = Ocelot.Data.DateTime.unsafeMkTime 13 0 0 0
+        isWithinInterval interval given false
+
+    Test.Unit.suite "closed interval" do
+      -- [6h,18h]
+      let
+        interval :: Ocelot.TimePicker.Interval
+        interval =
+          { start: Just (Ocelot.Data.DateTime.unsafeMkTime 6 0 0 0)
+          , end: Just (Ocelot.Data.DateTime.unsafeMkTime 18 0 0 0)
+          }
+      Test.Unit.test "outside left boundary" do -- 5h [6h,
+        let
+          given :: Data.Time.Time
+          given = Ocelot.Data.DateTime.unsafeMkTime 5 0 0 0
+        isWithinInterval interval given false
+      Test.Unit.test "on left" do -- [6h,
+        let
+          given :: Data.Time.Time
+          given = Ocelot.Data.DateTime.unsafeMkTime 6 0 0 0
+        isWithinInterval interval given true
+      Test.Unit.test "within" do -- [6h, 12h ,18h]
+        let
+          given :: Data.Time.Time
+          given = Ocelot.Data.DateTime.unsafeMkTime 12 0 0 0
+        isWithinInterval interval given true
+      Test.Unit.test "on right" do -- ,18h]
+        let
+          given :: Data.Time.Time
+          given = Ocelot.Data.DateTime.unsafeMkTime 18 0 0 0
+        isWithinInterval interval given true
+      Test.Unit.test "outside right boundary" do -- ,18h] 19h
+        let
+          given :: Data.Time.Time
+          given = Ocelot.Data.DateTime.unsafeMkTime 19 0 0 0
+        isWithinInterval interval given false
+
+isWithinInterval ::
+  Ocelot.TimePicker.Interval ->
+  Data.Time.Time ->
+  Boolean ->
+  Test.Unit.Test
+isWithinInterval interval time expected =
+  let
+    actual :: Boolean
+    actual = Ocelot.TimePicker.isWithinInterval interval time
+  in
+    Test.Unit.Assert.equal expected actual

--- a/test/Test/TimePicker.purs
+++ b/test/Test/TimePicker.purs
@@ -108,6 +108,25 @@ isWithinIntervalTests =
           given = Ocelot.Data.DateTime.unsafeMkTime 19 0 0 0
         isWithinInterval interval given false
 
+    Test.Unit.suite "invalid interval" do
+      -- ,6h] [18h,
+      let
+        interval :: Ocelot.TimePicker.Interval
+        interval =
+          { start: Just (Ocelot.Data.DateTime.unsafeMkTime 18 0 0 0)
+          , end: Just (Ocelot.Data.DateTime.unsafeMkTime 6 0 0 0)
+          }
+      Test.Unit.test "within left boundary" do -- ,6h] [18h, 19h
+        let
+          given :: Data.Time.Time
+          given = Ocelot.Data.DateTime.unsafeMkTime 19 0 0 0
+        isWithinInterval interval given false
+      Test.Unit.test "within right boundary" do -- 5h ,6h] [18h,
+        let
+          given :: Data.Time.Time
+          given = Ocelot.Data.DateTime.unsafeMkTime 5 0 0 0
+        isWithinInterval interval given false
+
 isWithinInterval ::
   Ocelot.TimePicker.Interval ->
   Data.Time.Time ->

--- a/ui-guide/Components/DatePickers.purs
+++ b/ui-guide/Components/DatePickers.purs
@@ -41,7 +41,8 @@ type State =
 
 data Query a
 data Action 
-  = HandleTimeSlider Ocelot.Slider.Output
+  = HandleTimePicker TimePicker.Output
+  | HandleTimeSlider Ocelot.Slider.Output
   | Initialize
   | ToggleDisabled
 
@@ -77,6 +78,12 @@ component =
   }
   where
     handleAction = case _ of  
+      HandleTimePicker output -> case output of
+        TimePicker.SelectionChanged mTime -> do
+          H.liftEffect $ Effect.Class.Console.log $ "TimePicker SelectionChanged: " <> show mTime
+        TimePicker.VisibilityChanged _ -> pure unit
+        TimePicker.Searched query -> do
+          H.liftEffect $ Effect.Class.Console.log $ "TimePicker Searched: " <> query
       HandleTimeSlider output -> case output of
         Ocelot.Slider.ValueChanged points -> case points of
           [ startPercent, endPercent ] -> do
@@ -249,7 +256,7 @@ cnDocumentationBlocks state =
                   , interval: Just state.timeInterval
                   , selection: Nothing
                   }
-                  (const Nothing)
+                  (Just <<< HandleTimePicker)
                 ]
               , Format.caption_ [ HH.text "Standard Disabled" ]
               , FormField.fieldMid_
@@ -263,7 +270,7 @@ cnDocumentationBlocks state =
                   , interval: Just state.timeInterval
                   , selection: Nothing
                   }
-                  (const Nothing)
+                  (Just <<< HandleTimePicker)
                 ]
               ]
             ]
@@ -282,7 +289,7 @@ cnDocumentationBlocks state =
                   , interval: Just state.timeInterval
                   , selection: Just $ unsafeMkTime 12 0 0 0
                   }
-                  (const Nothing)
+                  (Just <<< HandleTimePicker)
                 ]
               , Format.caption_ [ HH.text "Hydrated Disabled" ]
               , FormField.fieldMid_
@@ -296,7 +303,7 @@ cnDocumentationBlocks state =
                   , interval: Just state.timeInterval
                   , selection: Just $ unsafeMkTime 12 0 0 0
                   }
-                  (const Nothing)
+                  (Just <<< HandleTimePicker)
                 ]
               ]
             ]

--- a/ui-guide/Components/DatePickers.purs
+++ b/ui-guide/Components/DatePickers.purs
@@ -384,7 +384,7 @@ timeSliderInput =
   , disabled: false
   , layout: config
   , marks: Just marks
-  , minDistance: Just { percent: 4.16 }
+  , minDistance: Nothing
   , renderIntervals: Data.Array.foldMap renderInterval
   }
   where

--- a/ui-guide/Components/DatePickers.purs
+++ b/ui-guide/Components/DatePickers.purs
@@ -1,22 +1,32 @@
 module UIGuide.Component.DatePickers where
 
 import Prelude
+
+import Data.Array as Data.Array
 import Data.DateTime (DateTime(..))
+import Data.Int as Data.Int
 import Data.Maybe (Maybe(..))
 import Data.Symbol (SProxy(..))
+import Data.Time as Data.Time
 import Effect.Aff.Class (class MonadAff)
+import Effect.Class.Console as Effect.Class.Console
 import Halogen as H
 import Halogen.HTML as HH
+import Halogen.HTML as Halogen.HTML
 import Halogen.HTML.Events as HE
+import Halogen.Svg.Attributes as Halogen.Svg.Attributes
 import Ocelot.Block.Button as Button
 import Ocelot.Block.Card as Card
 import Ocelot.Block.FormField as FormField
 import Ocelot.Block.Format as Format
+import Ocelot.Data.DateTime (unsafeMkDate, unsafeMkTime)
+import Ocelot.Data.DateTime as Ocelot.Data.DateTime
 import Ocelot.DatePicker as DatePicker
 import Ocelot.DateTimePicker as DateTimePicker
-import Ocelot.TimePicker as TimePicker
-import Ocelot.Data.DateTime (unsafeMkDate, unsafeMkTime)
 import Ocelot.HTML.Properties (css)
+import Ocelot.Slider as Ocelot.Slider
+import Ocelot.Slider.Render as Ocelot.Slider.Render
+import Ocelot.TimePicker as TimePicker
 import UIGuide.Block.Backdrop as Backdrop
 import UIGuide.Block.Documentation as Documentation
 
@@ -26,11 +36,14 @@ import UIGuide.Block.Documentation as Documentation
 
 type State = 
   { disabled :: Boolean -- | Global enable/disable toggle
+  , timeInterval :: TimePicker.Interval
   }
 
 data Query a
 data Action 
-  = ToggleDisabled
+  = HandleTimeSlider Ocelot.Slider.Output
+  | Initialize
+  | ToggleDisabled
 
 ----------
 -- Child paths
@@ -39,11 +52,13 @@ type ChildSlot =
   ( datePicker :: DatePicker.Slot Int
   , timePicker :: TimePicker.Slot Int
   , dtp :: DateTimePicker.Slot Int
+  , timeSlider :: Ocelot.Slider.Slot String
   )
 
 _datePicker = SProxy :: SProxy "datePicker"
 _timePicker = SProxy :: SProxy "timePicker"
 _dtp = SProxy :: SProxy "dtp"
+_timeSlider = SProxy :: SProxy "timeSlider"
 
 ----------
 -- Component definition
@@ -57,10 +72,32 @@ component =
   , render
   , eval: H.mkEval H.defaultEval
     { handleAction = handleAction
+    , initialize = Just Initialize
     }
   }
   where
     handleAction = case _ of  
+      HandleTimeSlider output -> case output of
+        Ocelot.Slider.ValueChanged points -> case points of
+          [ startPercent, endPercent ] -> do
+            let
+              getIndex :: { percent :: Number } -> Int
+              getIndex = Data.Int.round <<< (_ * 0.24) <<< _.percent
+
+              start :: Maybe Data.Time.Time
+              start = Data.Array.index Ocelot.Data.DateTime.defaultTimeRange (getIndex startPercent)
+
+              end :: Maybe Data.Time.Time
+              end = Data.Array.index Ocelot.Data.DateTime.defaultTimeRange (getIndex endPercent)
+
+            H.liftEffect <<< Effect.Class.Console.log $
+              ( "start: " <> show (map Ocelot.Data.DateTime.formatTime start)
+                  <> ", end: " <> show (map Ocelot.Data.DateTime.formatTime end)
+              )
+            H.modify_ _ { timeInterval = { start, end } }
+          _ -> pure unit
+      Initialize -> do
+        void $ H.queryAll _timeSlider $ H.tell $ Ocelot.Slider.ReplaceThumbs [ { percent: 0.0 } , { percent: 100.0 }]
       ToggleDisabled -> do
         st <- H.modify \s -> s { disabled = not s.disabled }
         void $ H.query _datePicker 0 $ H.tell $ DatePicker.SetDisabled st.disabled
@@ -71,12 +108,18 @@ component =
         void $ H.query _dtp 1 $ H.tell $ DateTimePicker.SetDisabled st.disabled
         
     initialState :: Unit -> State
-    initialState _ = { disabled: false }
+    initialState _ =
+      { disabled: false
+      , timeInterval:
+          { start: Data.Array.head Ocelot.Data.DateTime.defaultTimeRange
+          , end: Data.Array.last Ocelot.Data.DateTime.defaultTimeRange
+          }
+      }
 
     render
       :: State
       -> H.ComponentHTML Action ChildSlot m
-    render _ = cnDocumentationBlocks
+    render = cnDocumentationBlocks
 
 ----------
 -- HTML
@@ -86,8 +129,8 @@ content = Backdrop.content [ css "flex" ]
 
 cnDocumentationBlocks :: ∀ m
   . MonadAff m
- => H.ComponentHTML Action ChildSlot m
-cnDocumentationBlocks =
+ => State -> H.ComponentHTML Action ChildSlot m
+cnDocumentationBlocks state =
   HH.div_
     [ HH.h1
       [ css "font-normal mb-6" ] 
@@ -178,70 +221,83 @@ cnDocumentationBlocks =
       { header: "Time Pickers"
       , subheader: "It's a time picker. Deal with it."
       }
-      [ Backdrop.backdrop_
-        [ content
-          [ Card.card
-            [ css "flex-1" ]
-            [ Format.caption_ [ HH.text "Standard" ]
-            , FormField.fieldMid_
-              { label: HH.text "Start"
-              , helpText: [ HH.text "Choose a start time." ]
-              , error: []
-              , inputId: "start-time"
-              }
-              [ HH.slot _timePicker 0 TimePicker.component
-                { disabled: false
-                , interval: Nothing
-                , selection: Nothing
-                }
-                (const Nothing)
-              ]
-            , Format.caption_ [ HH.text "Standard Disabled" ]
-            , FormField.fieldMid_
-              { label: HH.text "Start"
-              , helpText: [ HH.text "Choose a start time." ]
-              , error: []
-              , inputId: "start-time-disabled"
-              }
-              [ HH.slot _timePicker 2 TimePicker.component
-                { disabled: true
-                , interval: Nothing
-                , selection: Nothing
-                }
-                (const Nothing)
+      [ Halogen.HTML.div
+        [ css "flex-1" ]
+        [ Backdrop.backdrop_
+          [ Backdrop.content_
+            [ Card.card_
+              [ Halogen.HTML.slot _timeSlider "Time Pickers"
+                Ocelot.Slider.component
+                timeSliderInput
+                (Just <<< HandleTimeSlider)
               ]
             ]
           ]
-        , content
-          [ Card.card
-            [ css "flex-1" ]
-            [ Format.caption_ [ HH.text "Hydrated" ]
-            , FormField.fieldMid_
-              { label: HH.text "End"
-              , helpText: [ HH.text "Choose an end time." ]
-              , error: []
-              , inputId: "end-time"
-              }
-              [ HH.slot _timePicker 1 TimePicker.component
-                { disabled: false
-                , interval: Nothing
-                , selection: Just $ unsafeMkTime 12 0 0 0
+        , Backdrop.backdrop_
+          [ content
+            [ Card.card
+              [ css "flex-1" ]
+              [ Format.caption_ [ HH.text "Standard" ]
+              , FormField.fieldMid_
+                { label: HH.text "Start"
+                , helpText: [ HH.text "Choose a start time." ]
+                , error: []
+                , inputId: "start-time"
                 }
-                (const Nothing)
+                [ HH.slot _timePicker 0 TimePicker.component
+                  { disabled: false
+                  , interval: Just state.timeInterval
+                  , selection: Nothing
+                  }
+                  (const Nothing)
+                ]
+              , Format.caption_ [ HH.text "Standard Disabled" ]
+              , FormField.fieldMid_
+                { label: HH.text "Start"
+                , helpText: [ HH.text "Choose a start time." ]
+                , error: []
+                , inputId: "start-time-disabled"
+                }
+                [ HH.slot _timePicker 2 TimePicker.component
+                  { disabled: true
+                  , interval: Just state.timeInterval
+                  , selection: Nothing
+                  }
+                  (const Nothing)
+                ]
               ]
-            , Format.caption_ [ HH.text "Hydrated Disabled" ]
-            , FormField.fieldMid_
-              { label: HH.text "End"
-              , helpText: [ HH.text "Choose an end time." ]
-              , error: []
-              , inputId: "end-time-disabled"
-              }
-              [ HH.slot _timePicker 3 TimePicker.component
-                { disabled: true
-                , interval: Nothing
-                , selection: Just $ unsafeMkTime 12 0 0 0
+            ]
+          , content
+            [ Card.card
+              [ css "flex-1" ]
+              [ Format.caption_ [ HH.text "Hydrated" ]
+              , FormField.fieldMid_
+                { label: HH.text "End"
+                , helpText: [ HH.text "Choose an end time." ]
+                , error: []
+                , inputId: "end-time"
                 }
-                (const Nothing)
+                [ HH.slot _timePicker 1 TimePicker.component
+                  { disabled: false
+                  , interval: Just state.timeInterval
+                  , selection: Just $ unsafeMkTime 12 0 0 0
+                  }
+                  (const Nothing)
+                ]
+              , Format.caption_ [ HH.text "Hydrated Disabled" ]
+              , FormField.fieldMid_
+                { label: HH.text "End"
+                , helpText: [ HH.text "Choose an end time." ]
+                , error: []
+                , inputId: "end-time-disabled"
+                }
+                [ HH.slot _timePicker 3 TimePicker.component
+                  { disabled: true
+                  , interval: Just state.timeInterval
+                  , selection: Just $ unsafeMkTime 12 0 0 0
+                  }
+                  (const Nothing)
+                ]
               ]
             ]
           ]
@@ -321,3 +377,50 @@ cnDocumentationBlocks =
         ]
       ]
     ]
+
+timeSliderInput :: Ocelot.Slider.Input
+timeSliderInput =
+  { axis: Just axis
+  , disabled: false
+  , layout: config
+  , marks: Just marks
+  , minDistance: Just { percent: 4.16 }
+  , renderIntervals: Data.Array.foldMap renderInterval
+  }
+  where
+  axis :: Array { label :: String, percent :: Number }
+  axis = Data.Array.mapWithIndex toLabel Ocelot.Data.DateTime.defaultTimeRange
+    where
+    toLabel :: Int -> Data.Time.Time -> { label :: String, percent :: Number }
+    toLabel index time =
+      { label: Ocelot.Data.DateTime.formatTime time
+      , percent: (Data.Int.toNumber index) / 0.24
+      }
+
+  marks :: Array { percent :: Number }
+  marks = Data.Array.mapWithIndex toMark Ocelot.Data.DateTime.defaultTimeRange
+    where
+    toMark :: Int -> Data.Time.Time -> { percent :: Number }
+    toMark index time = { percent: (Data.Int.toNumber index) / 0.24 }
+
+  renderInterval :: Ocelot.Slider.Interval -> Array Halogen.HTML.PlainHTML
+  renderInterval = case _ of
+    Ocelot.Slider.StartToThumb _ -> []
+    Ocelot.Slider.BetweenThumbs { left, right } ->
+      [ Ocelot.Slider.Render.interval config
+          { start: left, end: right }
+          [ Halogen.Svg.Attributes.fill (pure (Halogen.Svg.Attributes.RGB 126 135 148)) ]
+      ]
+    Ocelot.Slider.ThumbToEnd _ -> []
+
+  config :: Ocelot.Slider.Render.Config
+  config =
+    { axisHeight: 30.0
+    , betweenThumbAndAxis: 30.0
+    , betweenTopAndThumb: 20.0
+    , frameWidth: { px: 1000.0 }
+    , margin: 50.0
+    , trackWidth: 1800.0
+    , trackRadius: 5.0
+    , thumbRadius: 20.0
+    }

--- a/ui-guide/Components/DatePickers.purs
+++ b/ui-guide/Components/DatePickers.purs
@@ -190,8 +190,9 @@ cnDocumentationBlocks =
               , inputId: "start-time"
               }
               [ HH.slot _timePicker 0 TimePicker.component
-                { selection: Nothing
-                , disabled: false
+                { disabled: false
+                , interval: Nothing
+                , selection: Nothing
                 }
                 (const Nothing)
               ]
@@ -203,8 +204,9 @@ cnDocumentationBlocks =
               , inputId: "start-time-disabled"
               }
               [ HH.slot _timePicker 2 TimePicker.component
-                { selection: Nothing
-                , disabled: true
+                { disabled: true
+                , interval: Nothing
+                , selection: Nothing
                 }
                 (const Nothing)
               ]
@@ -221,8 +223,9 @@ cnDocumentationBlocks =
               , inputId: "end-time"
               }
               [ HH.slot _timePicker 1 TimePicker.component
-                { selection: Just $ unsafeMkTime 12 0 0 0
-                , disabled: false
+                { disabled: false
+                , interval: Nothing
+                , selection: Just $ unsafeMkTime 12 0 0 0
                 }
                 (const Nothing)
               ]
@@ -234,8 +237,9 @@ cnDocumentationBlocks =
               , inputId: "end-time-disabled"
               }
               [ HH.slot _timePicker 3 TimePicker.component
-                { selection: Just $ unsafeMkTime 12 0 0 0
-                , disabled: true
+                { disabled: true
+                , interval: Nothing
+                , selection: Just $ unsafeMkTime 12 0 0 0
                 }
                 (const Nothing)
               ]


### PR DESCRIPTION
## What does this pull request do?

Add an `interval :: Maybe Interval` state to `TimePicker` to control the time points available to select. We could have an `Array` of `Interval`s rather than `Maybe` for finer control but my understanding of AS-1344 doesn't need that granularity so stay with a simpler change for now.

## How should this be manually tested?

- [x] `make build-ui`
- [x] go to `dist/index.html#date-pickers` > `Time Pickers` section
- [x] open console for monitoring the log
- [x] before modifying the time range by the slider, the time pickers should work like normal
- [x] assuming `12:00PM` is selected by one of the time picker, narrow the time range by the slider to exclude `12:00PM`
  - the selection should be cleared
  - there should be a `SelectionChanged: Nothing` output logged
- [x] open one of the time pickers
  - the available time points should all fall within the interval specified on the slider
- [x] assuming `1:00AM` is excluded by the slider, type in `1am` in one of the TimePicker search box and press Enter
  - `1:00AM` shouldn't be selected as it's out of range


## Other Notes:

Note that this PR doesn't merge onto branch `origin/main` but `origin/halogen-v5` which is currently pinned at tag `v0.28.2`, the last commit that's still on `purescript 0.13.8` and `halogen` v5. It's because this subtask under ticket AS-1344 is for OMS and there `purescript` and `halogen` haven't been upgraded yet. The plan is when this PR is approved and merged I'm going to make a separate PR rebasing the commits to `origin/main`. This branch `origin/halogen-v5` will stay until OMS finishes the upgrade.
