### PR TITLE
AS-1356 Bugfix: Switch year/month when selecting date from previous/next month

### DIFF
--- a/src/DatePicker.purs
+++ b/src/DatePicker.purs
@@ -282,15 +282,7 @@ embeddedHandleAction = case _ of
         , calendarItems = calendarItems
         }
     synchronize
-  ToggleMonth dir -> do
-    st <- H.get
-    let y = fst st.targetDate
-        m = snd st.targetDate
-        newDate = case dir of
-            Next -> ODT.nextMonth (canonicalDate y m bottom)
-            Prev -> ODT.prevMonth (canonicalDate y m bottom)
-    H.modify_ _ { targetDate = (year newDate) /\ (month newDate) }
-    synchronize
+  ToggleMonth dir -> toggleMonth dir
   Key ev -> do
     H.modify_ _ { visibility = S.On }
     let preventIt = H.liftEffect $ preventDefault $ KE.toEvent ev
@@ -668,6 +660,21 @@ synchronize = do
         Nothing -> identity
         Just date -> _ { search = ODT.formatDate date }
   H.modify_ (update <<< _ { calendarItems = calendarItems })
+
+toggleMonth ::
+  forall m.
+  MonadAff m =>
+  Direction ->
+  CompositeComponentM m Unit
+toggleMonth dir = do
+  st <- H.get
+  let y = fst st.targetDate
+      m = snd st.targetDate
+      newDate = case dir of
+        Next -> ODT.nextMonth (canonicalDate y m bottom)
+        Prev -> ODT.prevMonth (canonicalDate y m bottom)
+  H.modify_ _ { targetDate = (year newDate) /\ (month newDate) }
+  synchronize
 
 toObject :: Date -> Object String
 toObject d =


### PR DESCRIPTION
## What does this pull request do?

When selecting a date from previous/next month, the year and month on the calendar are not updated to the year and month of the selected date. Like this
<img src="https://user-images.githubusercontent.com/18127498/119043125-b518f500-b986-11eb-8f49-4235eb3ede76.png" width=300px />

Fixed behavior is

before selecting | after selecting
--- | ---
<img src="https://user-images.githubusercontent.com/18127498/119043625-3c666880-b987-11eb-9348-2cce5c08e1a8.png" width=300px /> | <img src="https://user-images.githubusercontent.com/18127498/119043667-4720fd80-b987-11eb-8d52-c653558192c7.png" width=300px />
