### PR TITLE
AS-1358 Add DateTime Range to DateTimePicker

### DIFF
--- a/src/DatePicker.purs
+++ b/src/DatePicker.purs
@@ -386,7 +386,7 @@ embeddedReceive ::
   CompositeComponentM m Unit
 embeddedReceive input = do
   old <- H.get
-  H.modify_ _ { interval = input.interval }
+  H.modify_ _ { disabled = input.disabled, interval = input.interval }
   case input.interval of
     Nothing -> pure unit
     Just interval -> do
@@ -484,7 +484,7 @@ handleAction = case _ of
   PassingOutput output ->
     H.raise output
   PassingReceive input -> do
-    H.modify_ _ { interval = input.interval }
+    H.modify_ _ { disabled = input.disabled, interval = input.interval }
 
 -- NOTE passing query to the embedded component
 handleQuery :: forall m a. Query a -> ComponentM m (Maybe a)

--- a/src/DateTimePicker.purs
+++ b/src/DateTimePicker.purs
@@ -196,9 +196,7 @@ render state =
     , HH.div
       [ css "flex-1" ]
       [ HH.slot _timepicker unit TimePicker.component
-        { disabled:
-            state.disabled
-              || (Data.Maybe.isJust state.interval && Data.Maybe.isNothing state.date)
+        { disabled: state.disabled
         , interval: do
             interval <- state.interval
             pure

--- a/src/DateTimePicker.purs
+++ b/src/DateTimePicker.purs
@@ -32,6 +32,7 @@ import Type.Data.Symbol (SProxy(..))
 data Action
   = HandleDate DatePicker.Output
   | HandleTime TimePicker.Output
+  | Receive Input
 
 type ChildSlots =
   ( datepicker :: DatePicker.Slot Unit
@@ -90,6 +91,7 @@ component = H.mkComponent
   , eval: H.mkEval H.defaultEval
       { handleAction = handleAction
       , handleQuery = handleQuery
+      , receive = Just <<< Receive
       }
   }
 
@@ -113,6 +115,8 @@ handleAction = case _ of
       H.raise $ SelectionChanged (DateTime <$> date' <*> time')
       H.modify_ _ { time = time' }
     _ -> H.raise $ TimeOutput msg
+  Receive input -> do
+    H.modify_ _ { interval = input.interval }
 
 handleQuery :: forall m a. Query a -> ComponentM m (Maybe a)
 handleQuery = case _ of

--- a/src/DateTimePicker.purs
+++ b/src/DateTimePicker.purs
@@ -15,7 +15,8 @@ module Ocelot.DateTimePicker
   ) where
 
 import Prelude
-import Data.DateTime (Date, DateTime(..), Month, Time, Year, date, time)
+import Data.DateTime (Date, DateTime(..), Month, Time, Year)
+import Data.DateTime as Date.DateTime
 import Data.Maybe (Maybe(..))
 import Data.Maybe as Data.Maybe
 import Data.Tuple.Nested (type (/\))
@@ -129,8 +130,8 @@ handleQuery = case _ of
     void $ H.query _datepicker unit $ H.tell $ DatePicker.SetDisabled disabled
     void $ H.query _timepicker unit $ H.tell $ TimePicker.SetDisabled disabled
   SetSelection dateTime a -> Just a <$ do
-    let date' = date <$> dateTime
-        time' = time <$> dateTime
+    let date' = dateTime <#> Date.DateTime.date
+        time' = dateTime <#> Date.DateTime.time
     void $ H.query _datepicker unit $ H.tell $ DatePicker.SetSelection date'
     void $ H.query _timepicker unit $ H.tell $ TimePicker.SetSelection time'
     H.modify_ _ { date = date', time = time' }
@@ -139,11 +140,11 @@ handleQuery = case _ of
 
 initialState :: Input -> State
 initialState input =
-  { date: date <$> input.selection
+  { date: input.selection <#> Date.DateTime.date
   , disabled: input.disabled
   , interval: input.interval
   , targetDate: input.targetDate
-  , time: time <$> input.selection
+  , time: input.selection <#> Date.DateTime.time
   }
 
 render :: forall m. MonadAff m => ComponentRender m

--- a/src/DateTimePicker.purs
+++ b/src/DateTimePicker.purs
@@ -17,6 +17,7 @@ module Ocelot.DateTimePicker
 import Prelude
 import Data.DateTime (Date, DateTime(..), Month, Time, Year, date, time)
 import Data.Maybe (Maybe(..))
+import Data.Maybe as Data.Maybe
 import Data.Tuple.Nested (type (/\))
 import Effect.Aff.Class (class MonadAff)
 import Halogen as H
@@ -146,7 +147,7 @@ initialState input =
   }
 
 render :: forall m. MonadAff m => ComponentRender m
-render { date, time, targetDate, disabled } =
+render { date, time, targetDate, disabled, interval } =
   HH.div
     [ css "flex" ]
     [ HH.div
@@ -162,7 +163,9 @@ render { date, time, targetDate, disabled } =
     , HH.div
       [ css "flex-1" ]
       [ HH.slot _timepicker unit TimePicker.component
-        { disabled
+        { disabled:
+            disabled
+              || (Data.Maybe.isJust interval && Data.Maybe.isNothing date)
         , interval: Nothing -- TODO AS-1344
         , selection: time
         }

--- a/src/DateTimePicker.purs
+++ b/src/DateTimePicker.purs
@@ -6,6 +6,7 @@ module Ocelot.DateTimePicker
   , ComponentM
   , ComponentRender
   , Input
+  , Interval
   , Output(..)
   , Query(..)
   , Slot
@@ -21,8 +22,8 @@ import Effect.Aff.Class (class MonadAff)
 import Halogen as H
 import Halogen.HTML as HH
 import Ocelot.DatePicker as DatePicker
-import Ocelot.TimePicker as TimePicker
 import Ocelot.HTML.Properties (css)
+import Ocelot.TimePicker as TimePicker
 import Type.Data.Symbol (SProxy(..))
 
 --------
@@ -46,9 +47,15 @@ type ComponentM m a = H.HalogenM State Action ChildSlots Output m a
 type ComponentRender m = State -> ComponentHTML m
 
 type Input =
-  { selection :: Maybe DateTime
+  { disabled :: Boolean
+  , interval :: Maybe Interval
+  , selection :: Maybe DateTime
   , targetDate :: Maybe (Year /\ Month)
-  , disabled :: Boolean
+  }
+
+type Interval =
+  { start :: Maybe DateTime
+  , end :: Maybe DateTime
   }
 
 data Output
@@ -67,9 +74,10 @@ type Slot = H.Slot Query Output
 
 type State =
   { date :: Maybe Date
-  , time :: Maybe Time
-  , targetDate :: Maybe (Year /\ Month)
   , disabled :: Boolean
+  , interval :: Maybe Interval
+  , targetDate :: Maybe (Year /\ Month)
+  , time :: Maybe Time
   }
 
 ------------
@@ -125,11 +133,12 @@ handleQuery = case _ of
   SendTimeQuery q a -> Just a <$ H.query _timepicker unit q
 
 initialState :: Input -> State
-initialState { selection, targetDate, disabled } =
-  { date: date <$> selection
-  , time: time <$> selection
-  , targetDate
-  , disabled
+initialState input =
+  { date: date <$> input.selection
+  , disabled: input.disabled
+  , interval: input.interval
+  , targetDate: input.targetDate
+  , time: time <$> input.selection
   }
 
 render :: forall m. MonadAff m => ComponentRender m

--- a/src/TimePicker.purs
+++ b/src/TimePicker.purs
@@ -248,7 +248,7 @@ embeddedInput state =
 embeddedReceive :: forall m. CompositeInput -> CompositeComponentM m Unit
 embeddedReceive input = do
   old <- H.get
-  H.modify_ _ { interval = input.interval }
+  H.modify_ _ { disabled = input.disabled, interval = input.interval }
   case input.interval of
     Nothing -> pure unit
     Just interval -> do
@@ -342,7 +342,7 @@ handleAction = case _ of
   PassingOutput output ->
     H.raise output
   PassingReceive input -> do
-    H.modify_ _ { interval = input.interval }
+    H.modify_ _ { disabled = input.disabled, interval = input.interval }
 
 handleQuery :: forall m a. Query a -> ComponentM m (Maybe a)
 handleQuery = case _ of

--- a/ui-guide/Components/DatePickers.purs
+++ b/ui-guide/Components/DatePickers.purs
@@ -385,9 +385,10 @@ cnDocumentationBlocks state =
               , inputId: "start"
               }
               [ HH.slot _dtp 0 DateTimePicker.component
-                { targetDate: Nothing
+                { disabled: false
+                , interval: Nothing -- TODO AS-1358
                 , selection: Nothing
-                , disabled: false
+                , targetDate: Nothing
                 }
                 (const Nothing)
               ]
@@ -399,9 +400,10 @@ cnDocumentationBlocks state =
               , inputId: "start-disabled"
               }
               [ HH.slot _dtp 2 DateTimePicker.component
-                { targetDate: Nothing
+                { disabled: true
+                , interval: Nothing -- TODO AS-1358
                 , selection: Nothing
-                , disabled: true
+                , targetDate: Nothing
                 }
                 (const Nothing)
               ]
@@ -418,9 +420,10 @@ cnDocumentationBlocks state =
               , inputId: "end"
               }
               [ HH.slot _dtp 1 DateTimePicker.component
-                { targetDate: Nothing
+                { disabled: false
+                , interval: Nothing -- TODO AS-1358
                 , selection: Just $ DateTime (unsafeMkDate 2019 1 1) (unsafeMkTime 0 0 0 0)
-                , disabled: false
+                , targetDate: Nothing
                 }
                 (const Nothing)
               ]
@@ -432,9 +435,10 @@ cnDocumentationBlocks state =
               , inputId: "end-disabled"
               }
               [ HH.slot _dtp 3 DateTimePicker.component
-                { targetDate: Nothing
+                { disabled: true
+                , interval: Nothing -- TODO AS-1358
                 , selection: Just $ DateTime (unsafeMkDate 2019 1 1) (unsafeMkTime 0 0 0 0)
-                , disabled: true
+                , targetDate: Nothing
                 }
                 (const Nothing)
               ]

--- a/ui-guide/Components/DatePickers.purs
+++ b/ui-guide/Components/DatePickers.purs
@@ -45,6 +45,7 @@ data Query a
 data Action 
   = HandleDatePicker DatePicker.Output
   | HandleDateSlider Ocelot.Slider.Output
+  | HandleDateTimePicker DateTimePicker.Output
   | HandleTimePicker TimePicker.Output
   | HandleTimeSlider Ocelot.Slider.Output
   | Initialize
@@ -113,6 +114,11 @@ component =
               )
             H.modify_ _ { dateInterval = { start, end } }
           _ -> pure unit
+      HandleDateTimePicker output -> case output of
+        DateTimePicker.SelectionChanged mDateTime -> do
+          H.liftEffect $ Effect.Class.Console.log $ "DateTimePicker SelectionChanged: " <> show mDateTime
+        DateTimePicker.DateOutput _ -> pure unit
+        DateTimePicker.TimeOutput _ -> pure unit
       HandleTimePicker output -> case output of
         TimePicker.SelectionChanged mTime -> do
           H.liftEffect $ Effect.Class.Console.log $ "TimePicker SelectionChanged: " <> show mTime
@@ -373,74 +379,150 @@ cnDocumentationBlocks state =
       { header: "DateTime Pickers"
       , subheader: "We've combined them. Deal with it."
       }
-      [ Backdrop.backdrop_
-        [ content
-          [ Card.card
-            [ css "flex-1" ]
-            [ Format.caption_ [ HH.text "Standard" ]
-            , FormField.field_
-              { label: HH.text "Start"
-              , helpText: [ HH.text "Choose a start date and time." ]
-              , error: []
-              , inputId: "start"
-              }
-              [ HH.slot _dtp 0 DateTimePicker.component
-                { disabled: false
-                , interval: Nothing -- TODO AS-1358
-                , selection: Nothing
-                , targetDate: Nothing
-                }
-                (const Nothing)
-              ]
-            , Format.caption_ [ HH.text "Standard Disabled" ]
-            , FormField.field_
-              { label: HH.text "Start"
-              , helpText: [ HH.text "Choose a start date and time." ]
-              , error: []
-              , inputId: "start-disabled"
-              }
-              [ HH.slot _dtp 2 DateTimePicker.component
-                { disabled: true
-                , interval: Nothing -- TODO AS-1358
-                , selection: Nothing
-                , targetDate: Nothing
-                }
-                (const Nothing)
+      [ Halogen.HTML.div
+        [ css "flex-1" ]
+        [ Backdrop.backdrop_
+          [ Backdrop.content_
+            [ Card.card_
+              [ Halogen.HTML.slot _dateSlider "DateTime Pickers"
+                Ocelot.Slider.component
+                dateSliderInput
+                (Just <<< HandleDateSlider)
+              , Halogen.HTML.slot _timeSlider "DateTime Pickers"
+                Ocelot.Slider.component
+                timeSliderInput
+                (Just <<< HandleTimeSlider)
+              , Halogen.HTML.div
+                [ css "flex" ]
+                [ Halogen.HTML.div
+                  [ css "flex-1" ]
+                  [ Format.caption_ [ HH.text "Standard - With Interval" ]
+                  , FormField.field_
+                    { label: HH.text "Start"
+                    , helpText: [ HH.text "Choose a start date and time." ]
+                    , error: []
+                    , inputId: "start"
+                    }
+                    [ HH.slot _dtp 4 DateTimePicker.component
+                      { disabled: false
+                      , interval:
+                        Just
+                        { start:
+                          DateTime
+                          <$> state.dateInterval.start
+                          <*> state.timeInterval.start
+                        , end:
+                          DateTime
+                          <$> state.dateInterval.end
+                          <*> state.timeInterval.end
+                        }
+                      , selection: Nothing
+                      , targetDate: Nothing
+                      }
+                      (Just <<< HandleDateTimePicker)
+                    ]
+                  ]
+                , Halogen.HTML.div
+                  [ css "flex-1 ml-16" ]
+                  [ Format.caption_ [ HH.text "Hydrated - With Interval" ]
+                  , FormField.field_
+                    { label: HH.text "End"
+                    , helpText: [ HH.text "Choose an end date and time." ]
+                    , error: []
+                    , inputId: "end"
+                    }
+                    [ HH.slot _dtp 5 DateTimePicker.component
+                      { disabled: false
+                      , interval:
+                          Just
+                            { start:
+                              DateTime
+                              <$> state.dateInterval.start
+                              <*> state.timeInterval.start
+                            , end:
+                              DateTime
+                              <$> state.dateInterval.end
+                              <*> state.timeInterval.end
+                            }
+                      , selection: Just $ DateTime (unsafeMkDate 2019 1 1) (unsafeMkTime 0 0 0 0)
+                      , targetDate: Nothing
+                      }
+                      (Just <<< HandleDateTimePicker)
+                    ]
+                  ]
+                ]
               ]
             ]
           ]
-        , content
-          [ Card.card
-            [ css "flex-1" ]
-            [ Format.caption_ [ HH.text "Hydrated" ]
-            , FormField.field_
-              { label: HH.text "End"
-              , helpText: [ HH.text "Choose an end date and time." ]
-              , error: []
-              , inputId: "end"
-              }
-              [ HH.slot _dtp 1 DateTimePicker.component
-                { disabled: false
-                , interval: Nothing -- TODO AS-1358
-                , selection: Just $ DateTime (unsafeMkDate 2019 1 1) (unsafeMkTime 0 0 0 0)
-                , targetDate: Nothing
+        , Backdrop.backdrop_
+          [ content
+            [ Card.card
+              [ css "flex-1" ]
+              [ Format.caption_ [ HH.text "Standard - Without Interval" ]
+              , FormField.field_
+                { label: HH.text "Start"
+                , helpText: [ HH.text "Choose a start date and time." ]
+                , error: []
+                , inputId: "start"
                 }
-                (const Nothing)
+                [ HH.slot _dtp 0 DateTimePicker.component
+                  { disabled: false
+                  , interval: Nothing
+                  , selection: Nothing
+                  , targetDate: Nothing
+                  }
+                  (Just <<< HandleDateTimePicker)
+                ]
+              , Format.caption_ [ HH.text "Standard Disabled" ]
+              , FormField.field_
+                { label: HH.text "Start"
+                , helpText: [ HH.text "Choose a start date and time." ]
+                , error: []
+                , inputId: "start-disabled"
+                }
+                [ HH.slot _dtp 2 DateTimePicker.component
+                  { disabled: true
+                  , interval: Nothing
+                  , selection: Nothing
+                  , targetDate: Nothing
+                  }
+                  (Just <<< HandleDateTimePicker)
+                ]
               ]
-            , Format.caption_ [ HH.text "Hydrated Disabled" ]
-            , FormField.field_
-              { label: HH.text "End"
-              , helpText: [ HH.text "Choose an end date and time." ]
-              , error: []
-              , inputId: "end-disabled"
-              }
-              [ HH.slot _dtp 3 DateTimePicker.component
-                { disabled: true
-                , interval: Nothing -- TODO AS-1358
-                , selection: Just $ DateTime (unsafeMkDate 2019 1 1) (unsafeMkTime 0 0 0 0)
-                , targetDate: Nothing
+            ]
+          , content
+            [ Card.card
+              [ css "flex-1" ]
+              [ Format.caption_ [ HH.text "Hydrated - Without Interval" ]
+              , FormField.field_
+                { label: HH.text "End"
+                , helpText: [ HH.text "Choose an end date and time." ]
+                , error: []
+                , inputId: "end"
                 }
-                (const Nothing)
+                [ HH.slot _dtp 1 DateTimePicker.component
+                  { disabled: false
+                  , interval: Nothing
+                  , selection: Just $ DateTime (unsafeMkDate 2019 1 1) (unsafeMkTime 0 0 0 0)
+                  , targetDate: Nothing
+                  }
+                  (Just <<< HandleDateTimePicker)
+                ]
+              , Format.caption_ [ HH.text "Hydrated Disabled" ]
+              , FormField.field_
+                { label: HH.text "End"
+                , helpText: [ HH.text "Choose an end date and time." ]
+                , error: []
+                , inputId: "end-disabled"
+                }
+                [ HH.slot _dtp 3 DateTimePicker.component
+                  { disabled: true
+                  , interval: Nothing
+                  , selection: Just $ DateTime (unsafeMkDate 2019 1 1) (unsafeMkTime 0 0 0 0)
+                  , targetDate: Nothing
+                  }
+                  (Just <<< HandleDateTimePicker)
+                ]
               ]
             ]
           ]


### PR DESCRIPTION
## What does this pull request do?

Add an `interval :: Maybe Interval` state to `DateTimePicker` to control the `Date` and `Time` available to select.
- if `interval = Nothing`, user can freely select `Date` and `Time` in whichever order
- if `interval = Just _`, `TimePicker` is disabled until user make a selection on `Date`

## How should this be manually tested?

- [x] `make build-ui`
- [x] go to `dist/index.html#date-pickers` > `DateTime Pickers` section
- [x] open console for monitoring the log
- [x] the date pickers marked as `Without Interval` (in the lower sub-section) should work like normal
- [x] assuming `Tue, Jan 1 2019, 12:00AM` is selected by DateTimePicker `Hydrated - With Interval`, narrow the Date range by the slider to exclude year `2019` (e.g. `2020 - 2023`)
  - its Date selection should be cleared
  - its Time selection should stay the same (`12:00AM`) with TimePicker disabled
  - there should be a `DateTimePicker SelectionChanged: Nothing` output logged
- [x] open its DatePicker
  - the available dates should all fall within the interval specified on the slider (from the first day of the beginning year to the last day of the ending year)
  - unavailable dates are crossed out
- [x] expand Date range to include year `2019` again, and narrow Time range to exclude `12:00AM` (e.g. `1:00AM - 11:59PM`)
- [x] select `Tue, Jan 1 2019` (the first day of the interval) again on its DatePicker
  - Time selection should be cleared
  - there should be a `DateTimePicker SelectionChanged: Nothing` output logged
- [x] open its TimePicker
  - the available time points should start from the earliest of the Time interval (`1:00AM` if Time interval is `1:00AM - 11:59PM`)
- [x] select a Time on its TimePicker
  - there should be a `DateTimePicker SelectionChanged: Just _` output logged
- [x] narrow Time range to exclude current selection
  - its Date selection should remain the same
  - the Time selection should be cleared
  - there should be a `DateTimePicker SelectionChanged: Nothing` output logged
- [x] select the last day of the interval
  - you can narrow Date range to `2019 - 2021`
  - type `12 31` in DatePicker and press Enter
- [ ] narrow the right boundary of Time range
  - it should be reflected by available time points in the TimePicker

## Other Notes:

Note that this PR doesn't merge onto branch `origin/main` but `origin/halogen-v5` which is currently pinned at tag `v0.28.2`, the last commit that's still on `purescript 0.13.8` and `halogen` v5. It's because this subtask under ticket AS-1344 is for OMS and there `purescript` and `halogen` haven't been upgraded yet. The plan is when this PR is approved and merged I'm going to make a separate PR rebasing the commits to `origin/main`. This branch `origin/halogen-v5` will stay until OMS finishes the upgrade.
