### PR TITLE
AS-1452 Add MultiInput variant of Typeahead

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-ocelot",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "private": true,
   "scripts": {
     "build-all": "make build",

--- a/src/Components/MultiInput/Component.purs
+++ b/src/Components/MultiInput/Component.purs
@@ -195,8 +195,8 @@ handleEditItem index = do
       $ updateItem index
         ( \item -> case item of
             Display _ -> Edit { inputBox: { text, width }, previous: text }
-            Edit status -> item
-            New status -> item
+            Edit _ -> item
+            New _ -> item
         )
     Control.Monad.Maybe.Trans.lift
       $ focusItem index
@@ -369,7 +369,7 @@ cancelEditing index = do
         Display _ -> pure unit
         Edit { previous } -> do
           void $ updateItem index (\_ -> Display { text: previous })
-        New { inputBox: { text } } -> do
+        New _ -> do
           void $ updateItem index (\_ -> old.new)
 
 commitEditing ::

--- a/src/Typeahead.purs
+++ b/src/Typeahead.purs
@@ -155,7 +155,7 @@ data EmbeddedAction action (f :: Type -> Type) item (m :: Type -> Type)
   | Raise action
 
 type EmbeddedChildSlots 
-  = () -- NOTE no extension
+  = () :: Row Type -- NOTE no extension
 
 type Input action f item m 
   = { items :: Network.RemoteData.RemoteData String (Array item)
@@ -925,7 +925,7 @@ synchronize = do
   case getNewItems st of
     Network.RemoteData.Success items -> do
       Halogen.modify_ _ { fuzzyItems = items }
-    Network.RemoteData.Failure err -> do
+    Network.RemoteData.Failure _ -> do
       Halogen.modify_
         _ { visibility = Select.Off
           , fuzzyItems = []

--- a/src/Typeahead.purs
+++ b/src/Typeahead.purs
@@ -64,6 +64,7 @@ import Control.Comonad.Store as Control.Comonad.Store
 import DOM.HTML.Indexed as DOM.HTML.Indexed
 import Data.Array ((!!), (:))
 import Data.Array as Data.Array
+import Data.Foldable as Data.Foldable
 import Data.Fuzzy as Data.Fuzzy
 import Data.Maybe (Maybe(..))
 import Data.Maybe as Data.Maybe
@@ -238,6 +239,7 @@ type StateStore action f item m
 component
   :: forall action f item m
   . Control.Alternative.Plus f
+  => Data.Foldable.Foldable f
   => Eq item
   => Effect.Aff.Class.MonadAff m
   => Operations f item
@@ -587,6 +589,7 @@ embeddedHandleMultiInput = case _ of
 embeddedHandleQuery
   :: forall action f item m a
   . Control.Alternative.Plus f
+  => Data.Foldable.Foldable f
   => Eq item
   => Effect.Aff.Class.MonadAff m
   => Query f item a
@@ -699,6 +702,7 @@ getNewItems' st =
 handleAction
   :: forall action f item m
   . Control.Alternative.Plus f
+  => Data.Foldable.Foldable f
   => Eq item
   => Effect.Aff.Class.MonadAff m
   => Action action f item m
@@ -729,6 +733,7 @@ handleQuery = case _ of
 initialState
   :: forall action f item m
   . Control.Alternative.Plus f
+  => Data.Foldable.Foldable f
   => Eq item
   => Effect.Aff.Class.MonadAff m
   => Operations f item
@@ -783,6 +788,7 @@ linkClasses = if _
 renderAdapter
   :: forall action f item m
   . Control.Alternative.Plus f
+  => Data.Foldable.Foldable f
   => Eq item
   => Effect.Aff.Class.MonadAff m
   => CompositeComponentRender action f item m
@@ -1008,18 +1014,26 @@ renderToolbarSearchDropdown defaultLabel resetLabel renderItem renderFuzzy st =
 
 replaceSelected
   :: forall action f item m
-  . Eq item
+  . Data.Foldable.Foldable f
+  => Eq item
   => Effect.Aff.Class.MonadAff m
   => f item
   -> CompositeComponentM action f item m Unit
 replaceSelected selected = do
   st <- Halogen.modify _ { selected = selected }
+  Halogen.tell _multiInput unit
+    $ Ocelot.Components.MultiInput.Component.SetItems
+        ( Data.Array.mapMaybe (Data.Array.head <<< Foreign.Object.values <<< st.itemToObject)
+            <<< Data.Array.fromFoldable
+            $ selected
+        )
   Halogen.raise $ SelectionChanged ReplacementQuery st.selected
   synchronize
 
 spec
   :: forall action f item m
   . Control.Alternative.Plus f
+  => Data.Foldable.Foldable f
   => Eq item
   => Effect.Aff.Class.MonadAff m
   => CompositeComponentRender action f item m

--- a/src/Typeahead.purs
+++ b/src/Typeahead.purs
@@ -556,6 +556,17 @@ embeddedHandleMultiInput
   -> CompositeComponentM action f item m Unit
 embeddedHandleMultiInput = case _ of
   Ocelot.Components.MultiInput.Component.ItemsUpdated _ -> pure unit
+  Ocelot.Components.MultiInput.Component.ItemRemoved text -> do
+    state <- Halogen.get
+    case
+      do
+        items <- Network.RemoteData.toMaybe state.items
+        Data.Array.find
+          (Data.Array.elem text <<< Foreign.Object.values <<< state.itemToObject)
+          items
+      of
+      Nothing -> pure unit
+      Just item -> embeddedRemove item
   Ocelot.Components.MultiInput.Component.On htmlEvents -> case htmlEvents of
     Ocelot.Components.MultiInput.Component.Blur ->
       Select.handleAction embeddedHandleAction embeddedHandleMessage

--- a/src/Typeahead.purs
+++ b/src/Typeahead.purs
@@ -18,7 +18,7 @@ module Ocelot.Typeahead
   , DefaultSyncTypeaheadInput
   , EmbeddedAction(..)
   , EmbeddedChildSlots
-  , Input 
+  , Input
   , Insertable(..)
   , Operations
   , Output(..)
@@ -101,49 +101,49 @@ type ChildSlots action f item =
   ( select :: Select.Slot (Query f item) EmbeddedChildSlots (Output action f item) Unit
   )
 
-type Component action f item m 
+type Component action f item m
   = Halogen.Component (Query f item) (Input action f item m) (Output action f item) m
 
-type ComponentHTML action f item m 
+type ComponentHTML action f item m
   = Halogen.ComponentHTML (Action action f item m) (ChildSlots action f item) m
 
-type ComponentRender action f item m 
+type ComponentRender action f item m
   = State f item m -> ComponentHTML action f item m
 
-type ComponentM action f item m a 
+type ComponentM action f item m a
   = Halogen.HalogenM (StateStore action f item m) (Action action f item m) (ChildSlots action f item) (Output action f item) m a
 
-type CompositeAction action f item m 
+type CompositeAction action f item m
   = Select.Action (EmbeddedAction action f item m)
 
-type CompositeComponent action f item m 
+type CompositeComponent action f item m
   = Halogen.Component (CompositeQuery f item) (CompositeInput f item m) (Output action f item) m
 
-type CompositeComponentHTML action f item m 
+type CompositeComponentHTML action f item m
   = Halogen.ComponentHTML (CompositeAction action f item m) EmbeddedChildSlots m
 
-type CompositeComponentM action f item m a 
+type CompositeComponentM action f item m a
   = Halogen.HalogenM (CompositeState f item m) (CompositeAction action f item m) EmbeddedChildSlots (Output action f item) m a
 
-type CompositeComponentRender action f item m 
+type CompositeComponentRender action f item m
   = (CompositeState f item m) -> CompositeComponentHTML action f item m
 
-type CompositeInput f item m 
+type CompositeInput f item m
   = Select.Input (StateRow f item m)
 
-type CompositeQuery f item 
+type CompositeQuery f item
   = Select.Query (Query f item) EmbeddedChildSlots
 
-type CompositeState f item m 
+type CompositeState f item m
   = Select.State (StateRow f item m)
 
-type DefaultAsyncTypeaheadInput item m 
+type DefaultAsyncTypeaheadInput item m
   = { itemToObject :: item -> Foreign.Object.Object String
     , renderFuzzy :: Data.Fuzzy.Fuzzy item -> Halogen.HTML.PlainHTML
     , async :: String -> m (Network.RemoteData.RemoteData String (Array item))
     }
 
-type DefaultSyncTypeaheadInput item 
+type DefaultSyncTypeaheadInput item
   = { itemToObject :: item -> Foreign.Object.Object String
     , renderFuzzy :: Data.Fuzzy.Fuzzy item -> Halogen.HTML.PlainHTML
     }
@@ -154,10 +154,10 @@ data EmbeddedAction action (f :: Type -> Type) item (m :: Type -> Type)
   | RemoveAll
   | Raise action
 
-type EmbeddedChildSlots 
+type EmbeddedChildSlots
   = () :: Row Type -- NOTE no extension
 
-type Input action f item m 
+type Input action f item m
   = { items :: Network.RemoteData.RemoteData String (Array item)
     , insertable :: Insertable item
     , keepOpen :: Boolean
@@ -172,7 +172,7 @@ data Insertable item
   = NotInsertable
   | Insertable (String -> item)
 
-type Operations f item 
+type Operations f item
   = { runSelect :: item -> f item -> f item
     , runRemove :: item -> f item -> f item
     , runFilterFuzzy :: Array (Data.Fuzzy.Fuzzy item) -> Array (Data.Fuzzy.Fuzzy item)
@@ -201,16 +201,16 @@ data SelectionCause
 
 derive instance eqSelectionCause :: Eq SelectionCause
 
-type Slot action f item id 
+type Slot action f item id
   = Halogen.Slot (Query f item) (Output action f item) id
 
-type Spec action f item m 
+type Spec action f item m
   = Select.Spec (StateRow f item m) (Query f item) (EmbeddedAction action f item m) EmbeddedChildSlots (CompositeInput f item m) (Output action f item) m
 
-type State f item m 
+type State f item m
   = Record (StateRow f item m)
 
-type StateRow f item m 
+type StateRow f item m
   = ( items :: Network.RemoteData.RemoteData String (Array item) -- NOTE pst.items, Parent(Typeahead)
     , insertable :: Insertable item
     , keepOpen :: Boolean
@@ -223,7 +223,7 @@ type StateRow f item m
     , fuzzyItems :: Array (Data.Fuzzy.Fuzzy item) -- NOTE cst.items, Child(Select)
     )
 
-type StateStore action f item m 
+type StateStore action f item m
   = Control.Comonad.Store.Store (State f item m) (ComponentHTML action f item m)
 
 -------------
@@ -264,9 +264,9 @@ singleHighlightOnly ::
   forall action item m.
   Eq item =>
   Effect.Aff.Class.MonadAff m =>
-  Component action Maybe item m 
+  Component action Maybe item m
 singleHighlightOnly = component
-  { runSelect: const <<< Just 
+  { runSelect: const <<< Just
   , runRemove: const (const Nothing)
   , runFilterFuzzy: identity
   , runFilterItems: \items -> Data.Maybe.maybe items (\item -> Data.Array.filter (_ /= item) items)
@@ -293,7 +293,7 @@ multiHighlightOnly ::
   Eq item =>
   Effect.Aff.Class.MonadAff m =>
   Component action Array item m
-multiHighlightOnly = component 
+multiHighlightOnly = component
   { runSelect: (:)
   , runRemove: Data.Array.filter <<< (/=)
   , runFilterFuzzy: identity
@@ -409,8 +409,8 @@ defFilterFuzzy ::
   Eq item =>
   Array (Data.Fuzzy.Fuzzy item) ->
   Array (Data.Fuzzy.Fuzzy item)
-defFilterFuzzy = 
-  Data.Array.sort 
+defFilterFuzzy =
+  Data.Array.sort
     <<< Data.Array.filter (\(Data.Fuzzy.Fuzzy { ratio }) -> ratio > (2 % 3))
 
 defRenderContainer
@@ -515,11 +515,11 @@ embeddedHandleQuery = case _ of
     Halogen.modify_ _ { items = items }
     synchronize
   Reset a -> Just a <$ do
-    st <- 
-      Halogen.modify 
-        _ 
+    st <-
+      Halogen.modify
+        _
           { selected = Control.Alternate.empty :: f item
-          , items = Network.RemoteData.NotAsked 
+          , items = Network.RemoteData.NotAsked
           }
     Halogen.raise $ SelectionChanged ResetQuery st.selected
     synchronize
@@ -548,18 +548,18 @@ embeddedInput { items, selected, insertable, keepOpen, itemToObject, ops, async,
   , config: { debounceTime } -- NOTE overhead
   }
 
-getNewItems :: 
-  forall f item m. 
-  Effect.Aff.Class.MonadAff m => 
-  Eq item => 
-  CompositeState f item m -> 
+getNewItems ::
+  forall f item m.
+  Effect.Aff.Class.MonadAff m =>
+  Eq item =>
+  CompositeState f item m ->
   Network.RemoteData.RemoteData String (Array (Data.Fuzzy.Fuzzy item))
-getNewItems st = st.items <#> \items -> 
-  getNewItems' 
-    { insertable: st.insertable 
+getNewItems st = st.items <#> \items ->
+  getNewItems'
+    { insertable: st.insertable
     , itemToObject: st.itemToObject
     , runFilterFuzzy: st.ops.runFilterFuzzy
-    , runFilterItems: st.ops.runFilterItems 
+    , runFilterItems: st.ops.runFilterItems
     , search: st.search
     , selected: st.selected
     }
@@ -568,7 +568,7 @@ getNewItems st = st.items <#> \items ->
 getNewItems' ::
   forall f item state.
   { insertable :: Insertable item
-  , itemToObject :: item -> Foreign.Object.Object String 
+  , itemToObject :: item -> Foreign.Object.Object String
   , runFilterFuzzy :: Array (Data.Fuzzy.Fuzzy item) -> Array (Data.Fuzzy.Fuzzy item)
   , runFilterItems :: Array item -> f item -> Array item
   , search :: String
@@ -656,17 +656,17 @@ inputProps disabled iprops = if disabled
   then iprops'
   else Select.Setters.setInputProps iprops'
   where
-    iprops' = 
+    iprops' =
       [ Halogen.HTML.Properties.disabled disabled
       , Halogen.HTML.Properties.autocomplete false
-      , Ocelot.HTML.Properties.css "focus:next:text-blue-88" 
-      ] 
+      , Ocelot.HTML.Properties.css "focus:next:text-blue-88"
+      ]
       <&> iprops
 
 isDisabled :: ∀ i. Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLinput i) -> Boolean
 isDisabled = Data.Array.foldr f false
   where
-    f (Halogen.HTML.Properties.IProp (Halogen.HTML.Core.Property "disabled" disabled)) 
+    f (Halogen.HTML.Properties.IProp (Halogen.HTML.Core.Property "disabled" disabled))
       | coercePropValue disabled == true = (||) true
     f _ = (||) false
 

--- a/src/Typeahead.purs
+++ b/src/Typeahead.purs
@@ -55,7 +55,7 @@ module Ocelot.Typeahead
   ) where
 
 import Prelude
-import Control.Alternative as Control.Alternate
+import Control.Alternative as Control.Alternative
 import Control.Comonad as Control.Comonad
 import Control.Comonad.Store as Control.Comonad.Store
 import DOM.HTML.Indexed as DOM.HTML.Indexed
@@ -231,7 +231,7 @@ type StateStore action f item m
 
 component
   :: forall action f item m
-  . Control.Alternate.Plus f
+  . Control.Alternative.Plus f
   => Eq item
   => Effect.Aff.Class.MonadAff m
   => Operations f item
@@ -439,7 +439,7 @@ disabledClasses = Halogen.HTML.ClassName <$>
 embeddedHandleAction
   :: forall action f item m
   . Eq item
-  => Control.Alternate.Plus f
+  => Control.Alternative.Plus f
   => Effect.Aff.Class.MonadAff m
   => EmbeddedAction action f item m
   -> CompositeComponentM action f item m Unit
@@ -452,7 +452,7 @@ embeddedHandleAction = case _ of
     synchronize
   RemoveAll -> do
     st <- Halogen.modify \st ->
-      st { selected = Control.Alternate.empty :: f item
+      st { selected = Control.Alternative.empty :: f item
          , visibility = Select.Off
          }
     Halogen.raise $ SelectionChanged RemovalQuery st.selected
@@ -495,7 +495,7 @@ embeddedHandleMessage = case _ of
 
 embeddedHandleQuery
   :: forall action f item m a
-  . Control.Alternate.Plus f
+  . Control.Alternative.Plus f
   => Eq item
   => Effect.Aff.Class.MonadAff m
   => Query f item a
@@ -518,7 +518,7 @@ embeddedHandleQuery = case _ of
     st <-
       Halogen.modify
         _
-          { selected = Control.Alternate.empty :: f item
+          { selected = Control.Alternative.empty :: f item
           , items = Network.RemoteData.NotAsked
           }
     Halogen.raise $ SelectionChanged ResetQuery st.selected
@@ -596,7 +596,7 @@ getNewItems' st =
 -- NOTE update Dropdown render function if it relies on external state
 handleAction
   :: forall action f item m
-  . Control.Alternate.Plus f
+  . Control.Alternative.Plus f
   => Eq item
   => Effect.Aff.Class.MonadAff m
   => Action action f item m
@@ -626,7 +626,7 @@ handleQuery = case _ of
 
 initialState
   :: forall action f item m
-  . Control.Alternate.Plus f
+  . Control.Alternative.Plus f
   => Eq item
   => Effect.Aff.Class.MonadAff m
   => Operations f item
@@ -643,7 +643,7 @@ initialState ops
       , disabled
       , ops
       , config: {debounceTime}
-      , selected: Control.Alternate.empty :: f item
+      , selected: Control.Alternative.empty :: f item
       , fuzzyItems: []
       }
 
@@ -680,7 +680,7 @@ linkClasses = if _
 
 renderAdapter
   :: forall action f item m
-  . Control.Alternate.Plus f
+  . Control.Alternative.Plus f
   => Eq item
   => Effect.Aff.Class.MonadAff m
   => CompositeComponentRender action f item m
@@ -898,7 +898,7 @@ replaceSelected selected = do
 
 spec
   :: forall action f item m
-  . Control.Alternate.Plus f
+  . Control.Alternative.Plus f
   => Eq item
   => Effect.Aff.Class.MonadAff m
   => CompositeComponentRender action f item m

--- a/src/Typeahead.purs
+++ b/src/Typeahead.purs
@@ -524,6 +524,11 @@ embeddedHandleMessage = case _ of
         st <- Halogen.modify \st -> st { selected = st.ops.runSelect item st.selected }
         when (not st.keepOpen) do
           Halogen.modify_ _ { visibility = Select.Off }
+        case Data.Array.head (Foreign.Object.values (st.itemToObject item )) of
+          Nothing -> pure unit
+          Just text -> do
+            void $ Halogen.tell _multiInput unit
+              $ Ocelot.Components.MultiInput.Component.SelectItem text
         Halogen.raise $ SelectionChanged SelectionMessage st.selected
         Halogen.raise $ Selected item
         synchronize

--- a/src/Typeahead.purs
+++ b/src/Typeahead.purs
@@ -449,10 +449,7 @@ embeddedHandleAction = case _ of
   HandleMultiInput output -> embeddedHandleMultiInput output
   Initialize -> do
     synchronize
-  Remove item -> do
-    st <- Halogen.modify \st -> st { selected = st.ops.runRemove item st.selected }
-    Halogen.raise $ SelectionChanged RemovalQuery st.selected
-    synchronize
+  Remove item -> embeddedRemove item
   RemoveAll -> do
     st <- Halogen.modify \st ->
       st { selected = Control.Alternative.empty :: f item
@@ -576,6 +573,17 @@ embeddedInput { items, selected, insertable, keepOpen, itemToObject, ops, async,
   , disabled
   , config: { debounceTime } -- NOTE overhead
   }
+
+embeddedRemove
+  :: forall action f item m
+  . Eq item
+  => Effect.Aff.Class.MonadAff m
+  => item
+  -> CompositeComponentM action f item m Unit
+embeddedRemove item = do
+  st <- Halogen.modify \st -> st { selected = st.ops.runRemove item st.selected }
+  Halogen.raise $ SelectionChanged RemovalQuery st.selected
+  synchronize
 
 getNewItems ::
   forall f item m.

--- a/ui-guide/Components/Typeaheads.purs
+++ b/ui-guide/Components/Typeaheads.purs
@@ -88,6 +88,7 @@ component =
           [ fetchAndSetLocations
           , fetchAndSetUsers
           , void $ H.queryAll _multiInput $ H.mkTell $ TA.ReplaceItems (pure ["new", "space", "citizennet", "conde"])
+          , H.tell _multiInput 1 $ TA.ReplaceSelected ["new", "conde"]
           ]
 
         _ <- Control.Parallel.parSequence_
@@ -352,6 +353,30 @@ cnDocumentationBlocks =
               , inputId: "tags"
               }
               [ HH.slot_ _multiInput 0 TA.multi
+                ( ( TA.syncMultiInput
+                    { renderFuzzy: HH.span_ <<< IC.boldMatches "name"
+                    , itemToObject: Foreign.Object.fromHomogeneous <<< { name: _ }
+                    }
+                    []
+                    { minWidth: 50.0
+                    , placeholder:
+                      { primary: "At least one of these values..."
+                      , secondary: "And..."
+                      }
+                    }
+                  ) { insertable = TA.Insertable identity }
+                )
+              ]
+            , HH.h3
+              [ HP.classes Format.captionClasses ]
+              [ HH.text "Standard Hydrated" ]
+            , FormField.field_
+              { label: HH.text "Tag"
+              , helpText: []
+              , error: []
+              , inputId: "tags"
+              }
+              [ HH.slot_ _multiInput 1 TA.multi
                 ( ( TA.syncMultiInput
                     { renderFuzzy: HH.span_ <<< IC.boldMatches "name"
                     , itemToObject: Foreign.Object.fromHomogeneous <<< { name: _ }


### PR DESCRIPTION
## What does this pull request do?

Add a new variant of `Typeahead` (`asyncMultiInput` and `syncMultiInput`) that combines `MultiInput` text field and `Typeahead` fuzzy search dropdown for Tags field.

Talked to Dave on potential solutions. Ideally we want to rebuild `MultiInput` using `Select` logic within `Typeahead`. As an intermediate step, we nest current `MultiInput` inside `Typeahead` and synchronize state between using `Query` and `Output` (both manage a list of selections which has to be in sync).

## How should this be manually tested?

- [x] `make` and then open `dist/index.html#typeaheads`
- [x] go to `Typeaheads - Multi-Input` section
- [x] click on the tag field under `Standard`
  - typeahead dropdown should show up
- [x] type in something and select an option using mouse click
  - typeahead fuzzy search should narrow available options
  - selection should be committed to the list in MultiInput
  - open typeahead dropdown and the selected option should be filtered out
- [x] type in something, navigate between options using up/down arrow keys, select an option by pressing `Enter`
  - selection should be committed to the list in MultiInput
  - open typeahead dropdown and the selected option should be filtered out
- [x] remove a selected item by clicking `x` button
  - open typeahead dropdown and the removed option should be available again
- [x] click on a selected item, edit the result, and then press `Enter`
  - change should be committed
  - open typeahead dropdown and the previous selection should be available again
- [x] type in something that's not initially available in the typeahead dropdown and press `Enter`
  - the new keyword should be commited to the list in MultiInput
