### PR TITLE
AS-1521 Bugfix MultiInput Variant of Typeahead #2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-ocelot",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "private": true,
   "scripts": {
     "build-all": "make build",

--- a/src/Typeahead.purs
+++ b/src/Typeahead.purs
@@ -70,6 +70,7 @@ import Data.Maybe (Maybe(..))
 import Data.Maybe as Data.Maybe
 import Data.Newtype as Data.Newtype
 import Data.Rational ((%))
+import Data.String as Data.String
 import Data.Time.Duration as Data.Time.Duration
 import Effect.Aff.Class as Effect.Aff.Class
 import Foreign.Object as Foreign.Object
@@ -588,7 +589,8 @@ embeddedHandleMultiInput = case _ of
     Ocelot.Components.MultiInput.Component.Blur -> do
       state <- Halogen.get
       Data.Foldable.for_ state.highlightedIndex \idx -> do
-        embeddedHandleSelected false idx
+        when (not Data.String.null state.search) do
+          embeddedHandleSelected false idx
       Select.handleAction embeddedHandleAction embeddedHandleMessage
         $ Select.SetVisibility Select.Off
     Ocelot.Components.MultiInput.Component.Focus ->


### PR DESCRIPTION
## What does this pull request do?

When clicking to open typeahead dropdown and then closing it on blur, the first option disappears. This is due to another mismatch of item selection behavior between MultiInput text field and Typeahead Select. When search text is empty MultiInput won't commit any item but from #195 Typeahead Select will select the highlighted item (first one in the list). Fix this by checking on blur whether search text is empty or not.