### PR TITLE
AS-1554 Upgrade Purescript to 0.14.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "browserify": "^16.5.1",
     "parcel": "1.12.4",
     "parcel-bundler": "1.12.3",
-    "purescript": "0.14.1",
+    "purescript": "0.14.3",
     "spago": "^0.15.2"
   },
   "dependencies": {

--- a/packages.dhall
+++ b/packages.dhall
@@ -128,27 +128,24 @@ let halogen-renderless =
 
 let html-parser-halogen =
       { dependencies = [ "string-parsers", "halogen" ]
-      , repo =
-          "https://github.com/rnons/purescript-html-parser-halogen.git"
+      , repo = "https://github.com/rnons/purescript-html-parser-halogen.git"
       , version = "v1.0.0-rc.2"
       }
 
 let svg-parser =
       { dependencies = [ "prelude", "string-parsers" ]
-      , repo =
-          "https://github.com/citizennet/purescript-svg-parser.git"
+      , repo = "https://github.com/citizennet/purescript-svg-parser.git"
       , version = "v2.0.0"
       }
 
 let svg-parser-halogen =
       { dependencies = [ "svg-parser", "halogen" ]
-      , repo =
-          "https://github.com/rnons/purescript-svg-parser-halogen.git"
+      , repo = "https://github.com/rnons/purescript-svg-parser-halogen.git"
       , version = "v2.0.0-rc.1"
       }
 
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.1-20210506/packages.dhall sha256:d199e142515f9cc15838d8e6d724a98cd0ca776ceb426b7b36e841311643e3ef
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.2-20210713/packages.dhall sha256:654c3148cb995f642c73b4508d987d9896e2ad3ea1d325a1e826c034c0d3cd7b
 
 let overrides = {=}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5181,10 +5181,10 @@ purescript-installer@^0.2.0:
     which "^1.3.1"
     zen-observable "^0.8.14"
 
-purescript@0.14.1:
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/purescript/-/purescript-0.14.1.tgz#dac33e11391bc35361b187ae85f19578a286747a"
-  integrity sha512-dh87XeDP/JGe/3DKBMglkRuIRfGLGkL8beuLIl9KemzckgyuD+j7VK15eVb9n5Exp3DIr6SNEuGG4FjuQQ7Rpg==
+purescript@0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/purescript/-/purescript-0.14.3.tgz#8a725c5dc640afeebb1fe9e2512477827ca05ee8"
+  integrity sha512-lAzHU/tcmxF4n3YUwUTwG/sIwHzjUq1zsIOBNmaVpbm7hxM+RhOTKMJdwdbTeCjxlilyVPWOLUQ6Exll4DYuMA==
   dependencies:
     purescript-installer "^0.2.0"
 


### PR DESCRIPTION
## What does this pull request do?

This is a non-breaking upgrade so nothing besides bumping the version of `purescript` package and pinning latest package set.

One thing to note is I thought after the new release we can drop the CI step installing `libtinfo` like advertised in [INSTALL.md](https://github.com/purescript/purescript/blob/master/INSTALL.md#the-curses-library) but just tested and it still wouldn't work without explicitly installing `libtinfo` and `libncurses` in the CI environment for some reason.