### PR TITLE
Upgrade Purescript to 0.14.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "browserify": "^16.5.1",
     "parcel": "1.12.4",
     "parcel-bundler": "1.12.3",
-    "purescript": "0.14.3",
+    "purescript": "0.14.4",
     "purescript-psa": "0.8.2",
     "spago": "^0.15.2"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "parcel-bundler": "1.12.3",
     "purescript": "0.14.4",
     "purescript-psa": "0.8.2",
-    "spago": "^0.15.2"
+    "spago": "0.20.3"
   },
   "dependencies": {
     "big-integer": "^1.6.31",

--- a/packages.dhall
+++ b/packages.dhall
@@ -145,7 +145,7 @@ let svg-parser-halogen =
       }
 
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.2-20210713/packages.dhall sha256:654c3148cb995f642c73b4508d987d9896e2ad3ea1d325a1e826c034c0d3cd7b
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.4-20210905/packages.dhall sha256:140f3630801f2b02d5f3a405d4872e0af317e4ef187016a6b00f97d59d6275c6
 
 let overrides = {=}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5774,10 +5774,10 @@ source-map@^0.5.0, source-map@^0.5.6, source-map@~0.5.3:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-spago@^0.15.2:
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/spago/-/spago-0.15.2.tgz#4ef59ae21f269fdab1d903d6c83c0cba1e415c06"
-  integrity sha512-RaH7AaY8Dzb9uhzDdhN5fMXAYQm5/Js7Qnb7M9NgbapV29dS7gMy7vQ6i6FAoLEqzbvBDzbSjQ+VabLQmaGbEQ==
+spago@0.20.3:
+  version "0.20.3"
+  resolved "https://registry.yarnpkg.com/spago/-/spago-0.20.3.tgz#f72a096456f580f6eb64fc850c371f8cb97b139f"
+  integrity sha512-R4CWLP5IbaWoNIpS1QAUuDK2LKlKYqT5gBKVZL7ILilvCwdwS72u3NbGZbvx7VCRRZz4lG7zXUkqKNow7zh6wQ==
   dependencies:
     request "^2.88.0"
     tar "^4.4.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5186,10 +5186,10 @@ purescript-psa@0.8.2:
   resolved "https://registry.yarnpkg.com/purescript-psa/-/purescript-psa-0.8.2.tgz#ee20c40f02cd0c5ed6dd3dd93ef02d9c466f17bc"
   integrity sha512-4Olf0aQQrNCfcDLXQI3gJgINEQ+3U+4QPLmQ2LHX2L/YOXSwM7fOGIUs/wMm/FQnwERUyQmHKQTJKB4LIjE2fg==
 
-purescript@0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/purescript/-/purescript-0.14.3.tgz#8a725c5dc640afeebb1fe9e2512477827ca05ee8"
-  integrity sha512-lAzHU/tcmxF4n3YUwUTwG/sIwHzjUq1zsIOBNmaVpbm7hxM+RhOTKMJdwdbTeCjxlilyVPWOLUQ6Exll4DYuMA==
+purescript@0.14.4:
+  version "0.14.4"
+  resolved "https://registry.yarnpkg.com/purescript/-/purescript-0.14.4.tgz#16096b589a5c81aa5813c805dc16c0b9f5b7a854"
+  integrity sha512-9Lq2qvyVkQoKUBSNOEBKIJjtD5sDwThurSt3SRdtSseaA03p1Fk7VxbUr9HV/gHLVZPIkOhPtjvZGUNs5U2PDA==
   dependencies:
     purescript-installer "^0.2.0"
 


### PR DESCRIPTION
## What does this pull request do?

Upgrade dev dependencies
- `purescript`: from `0.14.2` to `0.14.4`
- `spago`: from `0.15.2` to `0.20.3`
- `package-sets`: from `psc-0.14.2-20210713` to `psc-0.14.4-20210905`