### PR TITLE
AS-1787 Add ToggleSingle Query to Tree component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-ocelot",
-  "version": "0.31.2",
+  "version": "0.32.1",
   "private": true,
   "scripts": {
     "build-all": "make build",


### PR DESCRIPTION
## What does this pull request do?

Add `ToggleSingle` query to `Ocelot.Component.Tree` component for (un)checking a single path without re-expanding other selections (`SetSelections` expands all selected paths).