### PR TITLE
FBCM-5115 Add an `Ord` instance for `Cents`

### DIFF
--- a/src/Data/Currency.purs
+++ b/src/Data/Currency.purs
@@ -27,6 +27,7 @@ import Prim.TypeError (class Warn, Text)
 newtype Cents = Cents BigInt
 derive instance newtypeCents :: Newtype Cents _
 derive newtype instance eqCents :: Eq Cents
+derive newtype instance ordCents :: Ord Cents
 
 instance encodeJsonCents :: EncodeJson Cents where
   encodeJson = encodeJson <<< centsToNumber


### PR DESCRIPTION
## What does this pull request do?

This instance allows us not only to compare `Cents` values but also to use them in a `Set`, which requires an `Ord` instance.