### PR TITLE
FBCM-5217 [Bugfix] Disabled Typeahead Still Allows Changing Selection

### DIFF
--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "ide",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "last",
+  "unicode": "never",
+  "width": null
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "browserify": "^16.5.1",
     "parcel": "2.2.1",
-    "purescript": "0.14.4",
+    "purescript": "0.14.9",
     "purescript-psa": "0.8.2",
     "spago": "0.20.3",
     "yarn-audit-fix": "^9.0.9"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "parcel": "2.2.1",
     "purescript": "0.14.9",
     "purescript-psa": "0.8.2",
+    "purs-tidy": "0.9.2",
     "spago": "0.20.3",
     "yarn-audit-fix": "^9.0.9"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-ocelot",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "private": true,
   "scripts": {
     "build-all": "make build",

--- a/src/Blocks/Badge.purs
+++ b/src/Blocks/Badge.purs
@@ -27,63 +27,63 @@ baseClasses = HH.ClassName <$>
 badgeClasses :: Array HH.ClassName
 badgeClasses = baseClasses <>
   ( HH.ClassName <$>
-    [ "w-8"
-    , "h-8"
-    ]
+      [ "w-8"
+      , "h-8"
+      ]
   )
 
-badge
-  :: ∀ p i
-   . Array (IProp HTMLspan i)
-  -> Array (HTML p i)
-  -> HTML p i
+badge ::
+  forall p i.
+  Array (IProp HTMLspan i) ->
+  Array (HTML p i) ->
+  HTML p i
 badge = blockBuilder HH.span badgeClasses
 
-badge_
-  :: ∀ p i
-   . Array (HTML p i)
-  -> HTML p i
+badge_ ::
+  forall p i.
+  Array (HTML p i) ->
+  HTML p i
 badge_ = badge []
 
 badgeSmallClasses :: Array HH.ClassName
 badgeSmallClasses = baseClasses <>
   ( HH.ClassName <$>
-    [ "w-6"
-    , "h-6"
-    , "text-sm"
-    ]
+      [ "w-6"
+      , "h-6"
+      , "text-sm"
+      ]
   )
 
-badgeSmall
-  :: ∀ p i
-   . Array (IProp HTMLspan i)
-  -> Array (HTML p i)
-  -> HTML p i
+badgeSmall ::
+  forall p i.
+  Array (IProp HTMLspan i) ->
+  Array (HTML p i) ->
+  HTML p i
 badgeSmall = blockBuilder HH.span badgeSmallClasses
 
-badgeSmall_
-  :: ∀ p i
-   . Array (HTML p i)
-  -> HTML p i
+badgeSmall_ ::
+  forall p i.
+  Array (HTML p i) ->
+  HTML p i
 badgeSmall_ = badgeSmall []
 
 badgeLargeClasses :: Array HH.ClassName
 badgeLargeClasses = baseClasses <>
   ( HH.ClassName <$>
-    [ "w-12"
-    , "h-12"
-    ]
+      [ "w-12"
+      , "h-12"
+      ]
   )
 
-badgeLarge
-  :: ∀ p i
-   . Array (IProp HTMLspan i)
-  -> Array (HTML p i)
-  -> HTML p i
+badgeLarge ::
+  forall p i.
+  Array (IProp HTMLspan i) ->
+  Array (HTML p i) ->
+  HTML p i
 badgeLarge = blockBuilder HH.span badgeLargeClasses
 
-badgeLarge_
-  :: ∀ p i
-   . Array (HTML p i)
-  -> HTML p i
+badgeLarge_ ::
+  forall p i.
+  Array (HTML p i) ->
+  HTML p i
 badgeLarge_ = badgeLarge []

--- a/src/Blocks/Builder.purs
+++ b/src/Blocks/Builder.purs
@@ -6,15 +6,15 @@ import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
 import Ocelot.HTML.Properties (IProp, (<&>))
 
-blockBuilder
-  :: ∀ r p i
-   . ( Array (IProp r i)
-       -> Array (HH.HTML p i)
-       -> HH.HTML p i
-     )
-  -> Array HH.ClassName
-  -> Array (IProp r i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+blockBuilder ::
+  forall r p i.
+  ( Array (IProp r i) ->
+    Array (HH.HTML p i) ->
+    HH.HTML p i
+  ) ->
+  Array HH.ClassName ->
+  Array (IProp r i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 blockBuilder elem classes iprops =
   elem $ [ HP.classes classes ] <&> iprops

--- a/src/Blocks/Card.purs
+++ b/src/Blocks/Card.purs
@@ -20,47 +20,46 @@ innerCardClasses = HH.ClassName <$>
   [ "m-6"
   ]
 
-baseCard
-  :: ∀ p i
-   . Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+baseCard ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 baseCard iprops =
   HH.div
-    ( [ HP.classes baseCardClasses ] <&> iprops )
+    ([ HP.classes baseCardClasses ] <&> iprops)
 
-baseCard_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+baseCard_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 baseCard_ = baseCard []
 
-
-innerCard
-  :: ∀ p i
-   . Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+innerCard ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 innerCard iprops =
   HH.div
-    ( [ HP.classes innerCardClasses ] <&> iprops )
+    ([ HP.classes innerCardClasses ] <&> iprops)
 
-innerCard_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+innerCard_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 innerCard_ = innerCard []
 
-card
-  :: ∀ p i
-   . Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+card ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 card iprops html =
   baseCard iprops [ innerCard_ html ]
 
-card_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+card_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 card_ = card []

--- a/src/Blocks/Checkbox.purs
+++ b/src/Blocks/Checkbox.purs
@@ -73,28 +73,28 @@ checkboxClasses = HH.ClassName <$>
   , "after:shadow"
   ]
 
-checkbox
-  :: ∀ p i
-   . Array (HH.IProp HTMLlabel i)
-  -> Array (HH.IProp HTMLinput i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+checkbox ::
+  forall p i.
+  Array (HH.IProp HTMLlabel i) ->
+  Array (HH.IProp HTMLinput i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 checkbox iprops inprops html =
   HH.label
-    ( [ HP.classes labelClasses ] <&> iprops )
+    ([ HP.classes labelClasses ] <&> iprops)
     ( [ HH.input
-        ( [ HP.classes inputClasses
-          , HP.type_ InputCheckbox
-          ] <&> inprops
-        )
+          ( [ HP.classes inputClasses
+            , HP.type_ InputCheckbox
+            ] <&> inprops
+          )
       , HH.span [ HP.classes checkboxClasses ] []
       ]
-      <> html
+        <> html
     )
 
-checkbox_
-  :: ∀ p i
-   . Array (HH.IProp HTMLinput i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+checkbox_ ::
+  forall p i.
+  Array (HH.IProp HTMLinput i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 checkbox_ = checkbox []

--- a/src/Blocks/Choice.purs
+++ b/src/Blocks/Choice.purs
@@ -18,19 +18,19 @@ choiceClasses = HH.ClassName <$>
   , "overflow-hidden"
   ]
 
-choice
-  :: ∀ p i
-   .  Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+choice ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 choice iprops =
   HH.div
-    ( [ HP.classes choiceClasses ] <&> iprops )
+    ([ HP.classes choiceClasses ] <&> iprops)
 
-choice_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+choice_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 choice_ =
   choice []
 
@@ -44,38 +44,38 @@ headerClasses = HH.ClassName <$>
   , "border-grey-90"
   ]
 
-header
-  :: ∀ p i
-   .  Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+header ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 header iprops =
   HH.div
-    ( [ HP.classes headerClasses ] <&> iprops )
+    ([ HP.classes headerClasses ] <&> iprops)
 
-header_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+header_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 header_ =
   header []
 
 bodyClasses :: Array HH.ClassName
 bodyClasses = HH.ClassName <$> [ "flex" ]
 
-body
-  :: ∀ p i
-   . Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+body ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 body iprops =
   HH.div
-    ( [ HP.classes bodyClasses ] <&> iprops )
+    ([ HP.classes bodyClasses ] <&> iprops)
 
-body_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+body_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 body_ =
   body []
 
@@ -91,19 +91,19 @@ optionClasses = HH.ClassName <$>
   , "cursor-pointer"
   ]
 
-option
-  :: ∀ p i
-   . Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+option ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 option iprops =
   HH.div
-    ( [ HP.classes optionClasses ] <&> iprops )
+    ([ HP.classes optionClasses ] <&> iprops)
 
-option_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+option_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 option_ =
   option []
 

--- a/src/Blocks/Conditional.purs
+++ b/src/Blocks/Conditional.purs
@@ -3,38 +3,38 @@ module Ocelot.Block.Conditional where
 import DOM.HTML.Indexed (HTMLspan)
 import Halogen.HTML as HH
 
-conditional
-  :: ∀ p i
-   . Boolean
-  -> Array (HH.IProp HTMLspan i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+conditional ::
+  forall p i.
+  Boolean ->
+  Array (HH.IProp HTMLspan i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 conditional cond props html =
   HH.span props if cond then html else []
 
-conditional_
-  :: ∀ p i
-   . Boolean
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+conditional_ ::
+  forall p i.
+  Boolean ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 conditional_ cond =
   conditional cond []
 
-alt
-  :: ∀ p i
-   . Boolean
-  -> Array (HH.IProp HTMLspan i)
-  -> Array (HH.HTML p i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+alt ::
+  forall p i.
+  Boolean ->
+  Array (HH.IProp HTMLspan i) ->
+  Array (HH.HTML p i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 alt cond props html1 html2 =
   HH.span props if cond then html1 else html2
 
-alt_
-  :: ∀ p i
-   . Boolean
-  -> Array (HH.HTML p i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+alt_ ::
+  forall p i.
+  Boolean ->
+  Array (HH.HTML p i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 alt_ cond =
   alt cond []

--- a/src/Blocks/Diagram.purs
+++ b/src/Blocks/Diagram.purs
@@ -1,6 +1,7 @@
 module Ocelot.Block.Diagram where
 
 import Prelude
+
 import DOM.HTML.Indexed (HTMLdiv, HTMLspan)
 import Halogen.HTML as Halogen.HTML
 import Halogen.HTML.Properties as Halogen.HTML.Properties

--- a/src/Blocks/Expandable.purs
+++ b/src/Blocks/Expandable.purs
@@ -25,8 +25,8 @@ data Status
 instance read :: Read Status where
   read = case _ of
     "collapsed" -> pure Collapsed
-    "expanded"  -> pure Expanded
-    _   -> Nothing
+    "expanded" -> pure Expanded
+    _ -> Nothing
 
 instance isPropStatus :: IsProp Status where
   toPropValue = propFromString <<< toProp
@@ -34,7 +34,7 @@ instance isPropStatus :: IsProp Status where
 toProp :: Status -> String
 toProp = case _ of
   Collapsed -> "collapsed"
-  Expanded  -> "expanded"
+  Expanded -> "expanded"
 
 toBoolean :: Status -> Boolean
 toBoolean Collapsed = false
@@ -82,91 +82,93 @@ contentSharedClasses = HH.ClassName <$>
 contentClasses :: Status -> Array HH.ClassName
 contentClasses status_ = contentSharedClasses <>
   ( case status_ of
-    Collapsed -> HH.ClassName <$>
-      [ "max-h-0"
-      , "opacity-0"
-      , "overflow-hidden"
-      , "transition-1/4-in"
-      ]
-    Expanded -> HH.ClassName <$>
-      [ "max-h-full"
-      , "opacity-1"
-      , "transition-1/2-out"
-      ]
+      Collapsed -> HH.ClassName <$>
+        [ "max-h-0"
+        , "opacity-0"
+        , "overflow-hidden"
+        , "transition-1/4-in"
+        ]
+      Expanded -> HH.ClassName <$>
+        [ "max-h-full"
+        , "opacity-1"
+        , "transition-1/2-out"
+        ]
   )
 
-type HTMLexpandable = Interactive ( expanded :: Status )
+type HTMLexpandable = Interactive (expanded :: Status)
 
-status :: ∀ r i. Status -> HP.IProp ( expanded :: Status | r ) i
+status :: forall r i. Status -> HP.IProp (expanded :: Status | r) i
 status = HP.prop (PropName "expanded")
 
 -- Takes a row of `IProps` containing the `expanded` label
 -- and returns a `Tuple` containing the extracted value as
 -- well as the original row, minus the `expanded` label
-extractStatus
-  :: ∀ r i
-   . Array (HH.IProp ( expanded :: Status | r) i)
-  -> Tuple Status (Array (HH.IProp r i))
+extractStatus ::
+  forall r i.
+  Array (HH.IProp (expanded :: Status | r) i) ->
+  Tuple Status (Array (HH.IProp r i))
 extractStatus =
   foldr f (Tuple Expanded [])
   where
-    f (HP.IProp (Property "expanded" expanded)) =
-      lmap (const $ coerceExpanded expanded)
-    f iprop = rmap $ (flip snoc) $ coerceR iprop
+  f (HP.IProp (Property "expanded" expanded)) =
+    lmap (const $ coerceExpanded expanded)
+  f iprop = rmap $ (flip snoc) $ coerceR iprop
 
-    coerceExpanded :: PropValue -> Status
-    coerceExpanded = fromMaybe Expanded <<< read <<< unsafeCoerce
+  coerceExpanded :: PropValue -> Status
+  coerceExpanded = fromMaybe Expanded <<< read <<< unsafeCoerce
 
-    coerceR :: HH.IProp ( expanded :: Status | r ) i -> HH.IProp r i
-    coerceR = unsafeCoerce
+  coerceR :: HH.IProp (expanded :: Status | r) i -> HH.IProp r i
+  coerceR = unsafeCoerce
 
-heading
-  :: ∀ p i
-   . Array (HH.IProp HTMLexpandable i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+heading ::
+  forall p i.
+  Array (HH.IProp HTMLexpandable i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 heading iprops html =
-  let (Tuple status_ iprops') = extractStatus iprops in
-  HH.header
-    ( [ HP.classes headingClasses ] <&> iprops' )
-    [ HH.div
-      [ HP.classes headingInnerClasses ]
-      html
-    , HH.div_
-      [ chevron_ status_ ]
-    ]
+  let
+    (Tuple status_ iprops') = extractStatus iprops
+  in
+    HH.header
+      ([ HP.classes headingClasses ] <&> iprops')
+      [ HH.div
+          [ HP.classes headingInnerClasses ]
+          html
+      , HH.div_
+          [ chevron_ status_ ]
+      ]
 
-chevron
-  :: ∀ p i
-   . Status
-  -> Array (HH.IProp HTMLspan i)
-  -> HH.HTML p i
+chevron ::
+  forall p i.
+  Status ->
+  Array (HH.IProp HTMLspan i) ->
+  HH.HTML p i
 chevron status_ iprops =
   ( case status_ of
-    Collapsed -> Icon.expand
-    Expanded  -> Icon.collapse
+      Collapsed -> Icon.expand
+      Expanded -> Icon.collapse
   )
-  ( [ HP.classes chevronClasses ] <&> iprops )
+    ([ HP.classes chevronClasses ] <&> iprops)
 
-chevron_
-  :: ∀ p i
-   . Status
-  -> HH.HTML p i
+chevron_ ::
+  forall p i.
+  Status ->
+  HH.HTML p i
 chevron_ status_ = chevron status_ []
 
-content
-  :: ∀ p i
-   . Status
-  -> Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+content ::
+  forall p i.
+  Status ->
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 content status_ iprops =
   HH.div
-    ( [ HP.classes $ contentClasses status_ ] <&> iprops )
+    ([ HP.classes $ contentClasses status_ ] <&> iprops)
 
-content_
-  :: ∀ p i
-   . Status
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+content_ ::
+  forall p i.
+  Status ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 content_ status_ = content status_ []

--- a/src/Blocks/FormField.purs
+++ b/src/Blocks/FormField.purs
@@ -17,10 +17,10 @@ fieldClasses = HH.ClassName <$>
 helpTextClasses :: Array HH.ClassName
 helpTextClasses = Format.mutedClasses <>
   ( HH.ClassName <$>
-    [ "block"
-    , "font-light"
-    , "pt-3"
-    ]
+      [ "block"
+      , "font-light"
+      , "pt-3"
+      ]
   )
 
 errorTextClasses :: Array HH.ClassName
@@ -46,133 +46,133 @@ type FieldConfig p i =
   , error :: Array (HH.HTML p i)
   }
 
-field'
-  :: ∀ p i
-   . FieldConfig p i
-  -> Array (HH.IProp HTMLdiv i)
-  -> HH.HTML p i
-  -> HH.HTML p i
+field' ::
+  forall p i.
+  FieldConfig p i ->
+  Array (HH.IProp HTMLdiv i) ->
+  HH.HTML p i ->
+  HH.HTML p i
 field' config iprops html =
   HH.div
-    ( [ HP.classes fieldClasses ] <&> iprops )
+    ([ HP.classes fieldClasses ] <&> iprops)
     [ HH.label
-      [ HP.classes labelClasses
-      , HP.for config.inputId
-      ]
-      [ HH.fromPlainHTML config.label ]
+        [ HP.classes labelClasses
+        , HP.for config.inputId
+        ]
+        [ HH.fromPlainHTML config.label ]
     , html
     , error_ config.error
     , helpText_ config.helpText
     ]
 
-field
-  :: ∀ p i
-   . FieldConfig p i
-  -> Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+field ::
+  forall p i.
+  FieldConfig p i ->
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 field config iprops html =
   field'
     config
     iprops
-    ( HH.div [ css "my-1" ] html )
+    (HH.div [ css "my-1" ] html)
 
-field_
-  :: ∀ p i
-   . FieldConfig p i
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+field_ ::
+  forall p i.
+  FieldConfig p i ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 field_ config = field config []
 
-fieldSmall
-  :: ∀ p i
-   . FieldConfig p i
-  -> Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+fieldSmall ::
+  forall p i.
+  FieldConfig p i ->
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 fieldSmall config iprops html =
   field'
     config
     iprops
-    ( HH.div [ css "my-1 md:w-1/4" ] html )
+    (HH.div [ css "my-1 md:w-1/4" ] html)
 
-fieldSmall_
-  :: ∀ p i
-   . FieldConfig p i
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+fieldSmall_ ::
+  forall p i.
+  FieldConfig p i ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 fieldSmall_ config = fieldSmall config []
 
-fieldMid
-  :: ∀ p i
-   . FieldConfig p i
-  -> Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+fieldMid ::
+  forall p i.
+  FieldConfig p i ->
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 fieldMid config iprops html =
   field'
     config
     iprops
-    ( HH.div [ css "my-1 md:w-1/2" ] html )
+    (HH.div [ css "my-1 md:w-1/2" ] html)
 
-fieldMid_
-  :: ∀ p i
-   . FieldConfig p i
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+fieldMid_ ::
+  forall p i.
+  FieldConfig p i ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 fieldMid_ config = fieldMid config []
 
-fieldset
-  :: ∀ p i
-   . FieldConfig p i
-  -> Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+fieldset ::
+  forall p i.
+  FieldConfig p i ->
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 fieldset config iprops html =
   HH.div
-    ( [ HP.classes fieldClasses ] <&> iprops )
+    ([ HP.classes fieldClasses ] <&> iprops)
     [ HH.fieldset
-      []
-      [ HH.legend
-        [ HP.classes labelClasses ]
-        [ HH.fromPlainHTML config.label ]
-      , HH.div
-        [ css "my-1" ]
-        html
-      , error_ config.error
-      , helpText_ config.helpText
-      ]
+        []
+        [ HH.legend
+            [ HP.classes labelClasses ]
+            [ HH.fromPlainHTML config.label ]
+        , HH.div
+            [ css "my-1" ]
+            html
+        , error_ config.error
+        , helpText_ config.helpText
+        ]
     ]
 
-fieldset_
-  :: ∀ p i
-   . FieldConfig p i
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+fieldset_ ::
+  forall p i.
+  FieldConfig p i ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 fieldset_ config = fieldset config []
 
-error
-  :: ∀ p i
-   . Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+error ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 error iprops = HH.div $ [ HP.classes errorTextClasses ] <&> iprops
 
-error_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+error_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 error_ = error []
 
-helpText
-  :: ∀ p i
-   . Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+helpText ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 helpText iprops = HH.div $ [ HP.classes helpTextClasses ] <&> iprops
 
-helpText_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+helpText_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 helpText_ = helpText []

--- a/src/Blocks/FormPanel.purs
+++ b/src/Blocks/FormPanel.purs
@@ -18,12 +18,12 @@ buttonClasses = HH.ClassName <$>
   , "text-blue-82"
   ]
 
-formPanel
-  :: ∀ p i
-   . FormPanelProps
-  -> Array (HH.IProp HTMLbutton i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+formPanel ::
+  forall p i.
+  FormPanelProps ->
+  Array (HH.IProp HTMLbutton i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 formPanel props iprops html =
   HH.div
     [ HP.class_ (HH.ClassName "w-full") ]
@@ -35,7 +35,6 @@ formPanel props iprops html =
         [ (HH.fromPlainHTML (props.renderToggle props.isOpen)) ]
     ]
   where
-    contentClasses =
-      if props.isOpen
-        then [ HH.ClassName "mb-6" ]
-        else [ HH.ClassName "hidden" ]
+  contentClasses =
+    if props.isOpen then [ HH.ClassName "mb-6" ]
+    else [ HH.ClassName "hidden" ]

--- a/src/Blocks/Format.purs
+++ b/src/Blocks/Format.purs
@@ -20,8 +20,8 @@ headingClasses = HH.ClassName <$>
 headingDarkClasses :: Array HH.ClassName
 headingDarkClasses = headingClasses <>
   ( HH.ClassName <$>
-    [ "text-white"
-    ]
+      [ "text-white"
+      ]
   )
 
 subHeadingClasses :: Array HH.ClassName
@@ -37,8 +37,8 @@ subHeadingClasses = HH.ClassName <$>
 subHeadingDarkClasses :: Array HH.ClassName
 subHeadingDarkClasses = subHeadingClasses <>
   ( HH.ClassName <$>
-    [ "text-white"
-    ]
+      [ "text-white"
+      ]
   )
 
 contentHeadingClasses :: Array HH.ClassName
@@ -90,108 +90,108 @@ pClasses = HH.ClassName <$>
   [ "mb-6"
   ]
 
-heading
-  :: ∀ p i
-   . Array (HH.IProp HTMLh1 i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+heading ::
+  forall p i.
+  Array (HH.IProp HTMLh1 i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 heading iprops =
   HH.h1
-    ( [ HP.classes headingClasses ] <&> iprops )
+    ([ HP.classes headingClasses ] <&> iprops)
 
-heading_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+heading_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 heading_ = heading []
 
-headingDark
-  :: ∀ p i
-   . Array (HH.IProp HTMLh1 i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+headingDark ::
+  forall p i.
+  Array (HH.IProp HTMLh1 i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 headingDark iprops =
   HH.h1
-    ( [ HP.classes headingDarkClasses ] <&> iprops )
+    ([ HP.classes headingDarkClasses ] <&> iprops)
 
-headingDark_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+headingDark_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 headingDark_ = headingDark []
 
-subHeading
-  :: ∀ p i
-   . Array (HH.IProp HTMLh2 i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+subHeading ::
+  forall p i.
+  Array (HH.IProp HTMLh2 i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 subHeading iprops html =
   HH.h2
-    ( [ HP.classes subHeadingClasses ] <&> iprops )
+    ([ HP.classes subHeadingClasses ] <&> iprops)
     html
 
-subHeading_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+subHeading_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 subHeading_ = subHeading []
 
-subHeadingDark
-  :: ∀ p i
-   . Array (HH.IProp HTMLh2 i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+subHeadingDark ::
+  forall p i.
+  Array (HH.IProp HTMLh2 i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 subHeadingDark iprops =
   HH.h2
-    ( [ HP.classes subHeadingDarkClasses ] <&> iprops )
+    ([ HP.classes subHeadingDarkClasses ] <&> iprops)
 
-subHeadingDark_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+subHeadingDark_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 subHeadingDark_ = subHeadingDark []
 
-contentHeading
-  :: ∀ p i
-   . Array (HH.IProp HTMLh3 i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+contentHeading ::
+  forall p i.
+  Array (HH.IProp HTMLh3 i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 contentHeading iprops =
   HH.h3
-    ( [ HP.classes contentHeadingClasses ] <&> iprops )
+    ([ HP.classes contentHeadingClasses ] <&> iprops)
 
-contentHeading_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+contentHeading_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 contentHeading_ = contentHeading []
 
-caption
-  :: ∀ p i
-   . Array (HH.IProp HTMLh4 i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+caption ::
+  forall p i.
+  Array (HH.IProp HTMLh4 i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 caption iprops =
   HH.h4
-    ( [ HP.classes captionClasses ] <&> iprops )
+    ([ HP.classes captionClasses ] <&> iprops)
 
-caption_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+caption_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 caption_ = caption []
 
-p
-  :: ∀ p i
-   . Array (HH.IProp HTMLp i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+p ::
+  forall p i.
+  Array (HH.IProp HTMLp i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 p iprops =
   HH.p
-      ( [ HP.classes pClasses ] <&> iprops )
+    ([ HP.classes pClasses ] <&> iprops)
 
-p_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+p_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 p_ = p []

--- a/src/Blocks/Header.purs
+++ b/src/Blocks/Header.purs
@@ -26,20 +26,20 @@ innerClasses = HH.ClassName <$>
   , "h-24"
   ]
 
-header
-  :: ∀ p i
-   . Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+header ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 header iprops =
   HH.header [ HP.classes outerClasses ]
-  <<< pure
-  <<< HH.div ( [ HP.classes innerClasses ] <&> iprops )
+    <<< pure
+    <<< HH.div ([ HP.classes innerClasses ] <&> iprops)
 
-header_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+header_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 header_ = header []
 
 type FormHeaderProps p i =
@@ -49,51 +49,51 @@ type FormHeaderProps p i =
   , brand :: Maybe String
   }
 
-stickyFormHeader
-  :: ∀ p i page
-   . Eq page
-  => FormHeaderProps p i
-  -> NavigationTab.TabConfig page
-  -> HH.HTML p i
+stickyFormHeader ::
+  forall p i page.
+  Eq page =>
+  FormHeaderProps p i ->
+  NavigationTab.TabConfig page ->
+  HH.HTML p i
 stickyFormHeader hConfig tConfig =
   HH.div
     [ HP.class_ $ HH.ClassName "h-40" ]
     [ HH.div
-      [ HP.classes Layout.stickyClasses ]
-      [ formHeader hConfig
-      , NavigationTab.navigationTabs tConfig [ HP.class_ $ HH.ClassName "px-16" ]
-      ]
+        [ HP.classes Layout.stickyClasses ]
+        [ formHeader hConfig
+        , NavigationTab.navigationTabs tConfig [ HP.class_ $ HH.ClassName "px-16" ]
+        ]
     ]
 
-stickyHeader_ :: ∀ p i. FormHeaderProps p i -> HH.HTML p i
+stickyHeader_ :: forall p i. FormHeaderProps p i -> HH.HTML p i
 stickyHeader_ config =
   HH.div
     [ HP.class_ $ HH.ClassName "h-24" ]
     [ HH.div
-      [ HP.classes Layout.stickyClasses ]
-      [ formHeader config ]
+        [ HP.classes Layout.stickyClasses ]
+        [ formHeader config ]
     ]
 
-formHeader :: ∀ p i. FormHeaderProps p i -> HH.HTML p i
+formHeader :: forall p i. FormHeaderProps p i -> HH.HTML p i
 formHeader props =
   header_ $
     case props.brand of
-      Just src  ->
+      Just src ->
         [ HH.div
-          [ css "w-16" ]
-          [ HH.img [ HP.src src ] ]
+            [ css "w-16" ]
+            [ HH.img [ HP.src src ] ]
         ]
       Nothing -> []
-    <>
-    [ HH.h2
-      [ css "flex-1 font-medium" ]
-        [ HH.span
-            [ css "text-lg text-grey-70 mr-4" ]
-            props.name
-        , HH.span
-            [ css "text-lg text-white" ]
-            props.title
+      <>
+        [ HH.h2
+            [ css "flex-1 font-medium" ]
+            [ HH.span
+                [ css "text-lg text-grey-70 mr-4" ]
+                props.name
+            , HH.span
+                [ css "text-lg text-white" ]
+                props.title
+            ]
         ]
-    ]
-    <>
-    props.buttons
+      <>
+        props.buttons

--- a/src/Blocks/Hover.purs
+++ b/src/Blocks/Hover.purs
@@ -9,35 +9,35 @@ import Ocelot.HTML.Properties (css, (<&>))
 
 data HoverAnchor = Left | Right | Top | Bottom
 
-hover
-  :: ∀ p i
-   . Array (HH.IProp HTMLdiv i)
-  -> Array HoverAnchor
-  -> HH.HTML p i
-  -> HH.HTML p i
-  -> HH.HTML p i
+hover ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array HoverAnchor ->
+  HH.HTML p i ->
+  HH.HTML p i ->
+  HH.HTML p i
 hover props anchors html hoverHtml =
   HH.div
     ([ css $ "inline-block group cursor-pointer relative " ] <&> props)
     [ HH.div
-      [ HP.classes $ hoverClasses <> anchorClasses anchors ]
-      [ hoverHtml ]
+        [ HP.classes $ hoverClasses <> anchorClasses anchors ]
+        [ hoverHtml ]
     , html
     ]
   where
-    anchorClasses :: Array HoverAnchor -> Array HH.ClassName
-    anchorClasses = map $ HH.ClassName <<< anchorClass
-    anchorClass Left = "pin-r-full"
-    anchorClass Right = "pin-l-full"
-    anchorClass Top = "pin-b-full"
-    anchorClass Bottom = "pin-t-full"
+  anchorClasses :: Array HoverAnchor -> Array HH.ClassName
+  anchorClasses = map $ HH.ClassName <<< anchorClass
+  anchorClass Left = "pin-r-full"
+  anchorClass Right = "pin-l-full"
+  anchorClass Top = "pin-b-full"
+  anchorClass Bottom = "pin-t-full"
 
-hover_
-  :: ∀ p i
-   . Array HoverAnchor
-  -> HH.HTML p i
-  -> HH.HTML p i
-  -> HH.HTML p i
+hover_ ::
+  forall p i.
+  Array HoverAnchor ->
+  HH.HTML p i ->
+  HH.HTML p i ->
+  HH.HTML p i
 hover_ = hover []
 
 hoverClasses :: Array HH.ClassName

--- a/src/Blocks/Icon.purs
+++ b/src/Blocks/Icon.purs
@@ -8,315 +8,315 @@ import Halogen.HTML.Properties as HP
 import Halogen.HTML.Properties.ARIA as HA
 import Ocelot.HTML.Properties ((<&>))
 
-icon
-  :: ∀ p i
-   . String
-  -> Array (HH.IProp HTMLspan i)
-  -> HH.HTML p i
+icon ::
+  forall p i.
+  String ->
+  Array (HH.IProp HTMLspan i) ->
+  HH.HTML p i
 icon className iprops =
   HH.span
     [ HA.label className
     , HP.classes $ HH.ClassName <$>
-      [ "inline-block"
-      ]
+        [ "inline-block"
+        ]
     ]
     [ HH.span
         ( iprops <&>
-          [ HA.hidden "true"
-          , HP.classes $ HH.ClassName <$>
-            [ className
-            , "inline-block"
+            [ HA.hidden "true"
+            , HP.classes $ HH.ClassName <$>
+                [ className
+                , "inline-block"
+                ]
             ]
-          ]
         )
         []
     ]
 
-adSet :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+adSet :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 adSet = icon "icon-adset"
 
-adSet_ :: ∀ p i. HH.HTML p i
+adSet_ :: forall p i. HH.HTML p i
 adSet_ = adSet []
 
-add :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+add :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 add = icon "icon-add"
 
-add_ :: ∀ p i. HH.HTML p i
+add_ :: forall p i. HH.HTML p i
 add_ = add []
 
-added :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+added :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 added = icon "icon-added"
 
-added_ :: ∀ p i. HH.HTML p i
+added_ :: forall p i. HH.HTML p i
 added_ = added []
 
-arrowDown :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+arrowDown :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 arrowDown = icon "icon-arrow-down"
 
-arrowDown_ :: ∀ p i. HH.HTML p i
+arrowDown_ :: forall p i. HH.HTML p i
 arrowDown_ = arrowDown []
 
-arrowLeft :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+arrowLeft :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 arrowLeft = icon "icon-arrow-left"
 
-arrowLeft_ :: ∀ p i. HH.HTML p i
+arrowLeft_ :: forall p i. HH.HTML p i
 arrowLeft_ = arrowLeft []
 
-arrowRight :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+arrowRight :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 arrowRight = icon "icon-arrow-right"
 
-arrowRight_ :: ∀ p i. HH.HTML p i
+arrowRight_ :: forall p i. HH.HTML p i
 arrowRight_ = arrowRight []
 
-arrowUp :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+arrowUp :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 arrowUp = icon "icon-arrow-up"
 
-arrowUp_ :: ∀ p i. HH.HTML p i
+arrowUp_ :: forall p i. HH.HTML p i
 arrowUp_ = arrowUp []
 
-back :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+back :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 back = icon "icon-back"
 
-back_ :: ∀ p i. HH.HTML p i
+back_ :: forall p i. HH.HTML p i
 back_ = back []
 
-campaign :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+campaign :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 campaign = icon "icon-campaign"
 
-campaign_ :: ∀ p i. HH.HTML p i
+campaign_ :: forall p i. HH.HTML p i
 campaign_ = campaign []
 
-caratDown :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+caratDown :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 caratDown = icon "icon-carat-down"
 
-caratDown_ :: ∀ p i. HH.HTML p i
+caratDown_ :: forall p i. HH.HTML p i
 caratDown_ = caratDown []
 
-caratLeft :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+caratLeft :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 caratLeft = icon "icon-carat-left"
 
-caratLeft_ :: ∀ p i. HH.HTML p i
+caratLeft_ :: forall p i. HH.HTML p i
 caratLeft_ = caratLeft []
 
-caratRight :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+caratRight :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 caratRight = icon "icon-carat-right"
 
-caratRight_ :: ∀ p i. HH.HTML p i
+caratRight_ :: forall p i. HH.HTML p i
 caratRight_ = caratRight []
 
-caratUp :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+caratUp :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 caratUp = icon "icon-carat-up"
 
-caratUp_ :: ∀ p i. HH.HTML p i
+caratUp_ :: forall p i. HH.HTML p i
 caratUp_ = caratUp []
 
-chevronLeft :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+chevronLeft :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 chevronLeft = icon "icon-chevron-left"
 
-chevronLeft_ :: ∀ p i. HH.HTML p i
+chevronLeft_ :: forall p i. HH.HTML p i
 chevronLeft_ = chevronLeft []
 
-chevronRight :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+chevronRight :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 chevronRight = icon "icon-chevron-right"
 
-chevronRight_ :: ∀ p i. HH.HTML p i
+chevronRight_ :: forall p i. HH.HTML p i
 chevronRight_ = chevronRight []
 
-close :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+close :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 close = icon "icon-close"
 
-close_ :: ∀ p i. HH.HTML p i
+close_ :: forall p i. HH.HTML p i
 close_ = close []
 
-collapse :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+collapse :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 collapse = icon "icon-collapse"
 
-collapse_ :: ∀ p i. HH.HTML p i
+collapse_ :: forall p i. HH.HTML p i
 collapse_ = collapse []
 
-dataSources :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+dataSources :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 dataSources = icon "icon-data-sources"
 
-dataSources_ :: ∀ p i. HH.HTML p i
+dataSources_ :: forall p i. HH.HTML p i
 dataSources_ = dataSources []
 
-delete :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+delete :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 delete = icon "icon-delete"
 
-delete_ :: ∀ p i. HH.HTML p i
+delete_ :: forall p i. HH.HTML p i
 delete_ = delete []
 
-deleteCircle :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+deleteCircle :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 deleteCircle = icon "icon-delete-circle"
 
-deleteCircle_ :: ∀ p i. HH.HTML p i
+deleteCircle_ :: forall p i. HH.HTML p i
 deleteCircle_ = deleteCircle []
 
-demographics :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+demographics :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 demographics = icon "icon-demographics"
 
-demographics_ :: ∀ p i. HH.HTML p i
+demographics_ :: forall p i. HH.HTML p i
 demographics_ = demographics []
 
-download :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+download :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 download = icon "icon-download"
 
-download_ :: ∀ p i. HH.HTML p i
+download_ :: forall p i. HH.HTML p i
 download_ = download []
 
-error :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+error :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 error = icon "icon-error"
 
-error_ :: ∀ p i. HH.HTML p i
+error_ :: forall p i. HH.HTML p i
 error_ = error []
 
-expand :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+expand :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 expand = icon "icon-expand"
 
-expand_ :: ∀ p i. HH.HTML p i
+expand_ :: forall p i. HH.HTML p i
 expand_ = expand []
 
-facebook :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+facebook :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 facebook = icon "icon-facebook"
 
-facebook_ :: ∀ p i. HH.HTML p i
+facebook_ :: forall p i. HH.HTML p i
 facebook_ = facebook []
 
-google :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+google :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 google = icon "icon-google"
 
-google_ :: ∀ p i. HH.HTML p i
+google_ :: forall p i. HH.HTML p i
 google_ = google []
 
-info :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+info :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 info = icon "icon-info"
 
-info_ :: ∀ p i. HH.HTML p i
+info_ :: forall p i. HH.HTML p i
 info_ = info []
 
-instagram :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+instagram :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 instagram = icon "icon-instagram"
 
-instagram_ :: ∀ p i. HH.HTML p i
+instagram_ :: forall p i. HH.HTML p i
 instagram_ = instagram []
 
-linkedIn :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+linkedIn :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 linkedIn = icon "icon-linkedin"
 
-linkedIn_ :: ∀ p i. HH.HTML p i
+linkedIn_ :: forall p i. HH.HTML p i
 linkedIn_ = linkedIn []
 
-menu :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+menu :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 menu = icon "icon-menu"
 
-menu_ :: ∀ p i. HH.HTML p i
+menu_ :: forall p i. HH.HTML p i
 menu_ = menu []
 
-navigate :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+navigate :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 navigate = icon "icon-navigate"
 
-navigate_ :: ∀ p i. HH.HTML p i
+navigate_ :: forall p i. HH.HTML p i
 navigate_ = navigate []
 
-options :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+options :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 options = icon "icon-options"
 
-options_ :: ∀ p i. HH.HTML p i
+options_ :: forall p i. HH.HTML p i
 options_ = options []
 
-pinterest :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+pinterest :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 pinterest = icon "icon-pinterest"
 
-pinterest_ :: ∀ p i. HH.HTML p i
+pinterest_ :: forall p i. HH.HTML p i
 pinterest_ = pinterest []
 
-plus :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+plus :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 plus = icon "icon-plus"
 
-plus_ :: ∀ p i. HH.HTML p i
+plus_ :: forall p i. HH.HTML p i
 plus_ = plus []
 
-reddit :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+reddit :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 reddit = icon "icon-reddit"
 
-reddit_ :: ∀ p i. HH.HTML p i
+reddit_ :: forall p i. HH.HTML p i
 reddit_ = reddit []
 
-refresh :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+refresh :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 refresh = icon "icon-refresh"
 
-refresh_ :: ∀ p i. HH.HTML p i
+refresh_ :: forall p i. HH.HTML p i
 refresh_ = refresh []
 
-search :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+search :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 search = icon "icon-search"
 
-search_ :: ∀ p i. HH.HTML p i
+search_ :: forall p i. HH.HTML p i
 search_ = search []
 
-selected :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+selected :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 selected = icon "icon-selected"
 
-selected_ :: ∀ p i. HH.HTML p i
+selected_ :: forall p i. HH.HTML p i
 selected_ = selected []
 
-settings :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+settings :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 settings = icon "icon-settings"
 
-settings_ :: ∀ p i. HH.HTML p i
+settings_ :: forall p i. HH.HTML p i
 settings_ = settings []
 
-share :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+share :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 share = icon "icon-share"
 
-share_ :: ∀ p i. HH.HTML p i
+share_ :: forall p i. HH.HTML p i
 share_ = share []
 
-snapchat :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+snapchat :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 snapchat = icon "icon-snapchat"
 
-snapchat_ :: ∀ p i. HH.HTML p i
+snapchat_ :: forall p i. HH.HTML p i
 snapchat_ = snapchat []
 
-success :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+success :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 success = icon "icon-success"
 
-success_ :: ∀ p i. HH.HTML p i
+success_ :: forall p i. HH.HTML p i
 success_ = success []
 
-taboola :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+taboola :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 taboola = icon "icon-taboola"
 
-taboola_ :: ∀ p i. HH.HTML p i
+taboola_ :: forall p i. HH.HTML p i
 taboola_ = taboola []
 
-tiktok :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+tiktok :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 tiktok = icon "icon-tiktok"
 
-tiktok_ :: ∀ p i. HH.HTML p i
+tiktok_ :: forall p i. HH.HTML p i
 tiktok_ = tiktok []
 
-timeline :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+timeline :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 timeline = icon "icon-timeline"
 
-timeline_ :: ∀ p i. HH.HTML p i
+timeline_ :: forall p i. HH.HTML p i
 timeline_ = timeline []
 
-tip :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+tip :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 tip = icon "icon-tip"
 
-tip_ :: ∀ p i. HH.HTML p i
+tip_ :: forall p i. HH.HTML p i
 tip_ = tip []
 
-twitter :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+twitter :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 twitter = icon "icon-twitter"
 
-twitter_ :: ∀ p i. HH.HTML p i
+twitter_ :: forall p i. HH.HTML p i
 twitter_ = twitter []
 
-youtube :: ∀ p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
+youtube :: forall p i. Array (HH.IProp HTMLspan i) -> HH.HTML p i
 youtube = icon "icon-youtube"
 
-youtube_ :: ∀ p i. HH.HTML p i
+youtube_ :: forall p i. HH.HTML p i
 youtube_ = youtube []
 

--- a/src/Blocks/Input.purs
+++ b/src/Blocks/Input.purs
@@ -24,13 +24,13 @@ inputSharedClasses = HH.ClassName <$>
 inputClasses :: Array HH.ClassName
 inputClasses = inputSharedClasses <>
   ( HH.ClassName <$>
-    [ "border-l-2"
-    , "border-r-2"
-    , "w-full"
-    , "px-3"
-    , "focus:border-blue-88"
-    , "!focus:!disabled:hover:border-grey-70"
-    ]
+      [ "border-l-2"
+      , "border-r-2"
+      , "w-full"
+      , "px-3"
+      , "focus:border-blue-88"
+      , "!focus:!disabled:hover:border-grey-70"
+      ]
   )
 
 inputGroupClasses :: Array HH.ClassName
@@ -43,39 +43,39 @@ inputGroupClasses = HH.ClassName <$>
 mainItemClasses :: Array HH.ClassName
 mainItemClasses = inputSharedClasses <>
   ( HH.ClassName <$>
-    [ "w-full"
-    , "focus:border-blue-88"
-    , "focus:sibling:border-blue-88"
-    , "group-hover:!focus:!disabled:border-grey-70"
-    , "group-hover:!focus:!disabled:sibling:border-grey-70"
-    , "disabled:sibling:bg-grey-95"
-    ]
+      [ "w-full"
+      , "focus:border-blue-88"
+      , "focus:sibling:border-blue-88"
+      , "group-hover:!focus:!disabled:border-grey-70"
+      , "group-hover:!focus:!disabled:sibling:border-grey-70"
+      , "disabled:sibling:bg-grey-95"
+      ]
   )
 
 centerClasses :: Array HH.ClassName
 centerClasses = inputSharedClasses <>
   ( HH.ClassName <$>
-    [ "pl-1"
-    , "pr-1"
-    ]
+      [ "pl-1"
+      , "pr-1"
+      ]
   )
 
 leftClasses :: Array HH.ClassName
 leftClasses = inputSharedClasses <>
   ( HH.ClassName <$>
-    [ "border-l-2"
-    , "pl-3"
-    , "pr-1"
-    ]
+      [ "border-l-2"
+      , "pl-3"
+      , "pr-1"
+      ]
   )
 
 rightClasses :: Array HH.ClassName
 rightClasses = inputSharedClasses <>
   ( HH.ClassName <$>
-    [ "border-r-2"
-    , "pr-3"
-    , "pl-1"
-    ]
+      [ "border-r-2"
+      , "pr-3"
+      , "pl-1"
+      ]
   )
 
 mainCenterClasses :: Array HH.ClassName
@@ -90,11 +90,11 @@ mainRightClasses = mainItemClasses <> rightClasses
 addonClasses :: Array HH.ClassName
 addonClasses = inputSharedClasses <>
   ( HH.ClassName <$>
-    [ "cursor-pointer"
-    , "flex"
-    , "items-center"
-    , "text-grey-70"
-    ]
+      [ "cursor-pointer"
+      , "flex"
+      , "items-center"
+      , "text-grey-70"
+      ]
   )
 
 addonCenterClasses :: Array HH.ClassName
@@ -103,8 +103,8 @@ addonCenterClasses = addonClasses <> centerClasses
 addonLeftClassess :: Array HH.ClassName
 addonLeftClassess = addonClasses <> leftClasses <>
   ( HH.ClassName <$>
-    [ "order-start"
-    ]
+      [ "order-start"
+      ]
   )
 
 addonRightClasses :: Array HH.ClassName
@@ -116,198 +116,198 @@ borderClasses = []
 borderLeftClasses :: Array HH.ClassName
 borderLeftClasses = borderClasses <>
   ( HH.ClassName <$>
-    [ "border-r"
-    , "pr-3"
-    , "order-start"
-    ]
+      [ "border-r"
+      , "pr-3"
+      , "order-start"
+      ]
   )
 
 borderRightClasses :: Array HH.ClassName
 borderRightClasses = borderClasses <>
   ( HH.ClassName <$>
-    [ "border-l"
-    , "pl-3"
-    ]
+      [ "border-l"
+      , "pl-3"
+      ]
   )
 
 textareaClasses :: Array HH.ClassName
 textareaClasses = inputClasses <>
   ( HH.ClassName <$>
-    [ "min-h-40"
-    ]
+      [ "min-h-40"
+      ]
   )
 
-input
-  :: ∀ p i
-   . Array (HH.IProp HTMLinput i)
-  -> HH.HTML p i
+input ::
+  forall p i.
+  Array (HH.IProp HTMLinput i) ->
+  HH.HTML p i
 input iprops =
-  HH.input ( [ HP.classes inputClasses ] <&> iprops )
+  HH.input ([ HP.classes inputClasses ] <&> iprops)
 
-inputGroup
-  :: ∀ p i
-   . Array (HH.IProp HTMLlabel i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+inputGroup ::
+  forall p i.
+  Array (HH.IProp HTMLlabel i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 inputGroup = inputGroup' HH.label
 
-inputGroup'
-  :: ∀ p r i
-   . (Array (HH.IProp (GlobalAttributes r) i) -> Array (HH.HTML p i) -> HH.HTML p i)
-  -> Array (HH.IProp (GlobalAttributes r) i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+inputGroup' ::
+  forall p r i.
+  (Array (HH.IProp (GlobalAttributes r) i) -> Array (HH.HTML p i) -> HH.HTML p i) ->
+  Array (HH.IProp (GlobalAttributes r) i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 inputGroup' elem iprops html =
   elem
-    ( [ HP.classes inputGroupClasses ] <&> iprops )
+    ([ HP.classes inputGroupClasses ] <&> iprops)
     html
 
-inputGroup_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+inputGroup_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 inputGroup_ = inputGroup []
 
-inputCenter
-  :: ∀ p i
-   . Array (HH.IProp HTMLinput i)
-  -> HH.HTML p i
+inputCenter ::
+  forall p i.
+  Array (HH.IProp HTMLinput i) ->
+  HH.HTML p i
 inputCenter iprops =
   HH.input
-    ( [ HP.classes mainCenterClasses ] <&> iprops )
+    ([ HP.classes mainCenterClasses ] <&> iprops)
 
-inputLeft
-  :: ∀ p i
-   . Array (HH.IProp HTMLinput i)
-  -> HH.HTML p i
+inputLeft ::
+  forall p i.
+  Array (HH.IProp HTMLinput i) ->
+  HH.HTML p i
 inputLeft iprops =
   HH.input
-    ( [ HP.classes mainLeftClasses ] <&> iprops )
+    ([ HP.classes mainLeftClasses ] <&> iprops)
 
-inputRight
-  :: ∀ p i
-   . Array (HH.IProp HTMLinput i)
-  -> HH.HTML p i
+inputRight ::
+  forall p i.
+  Array (HH.IProp HTMLinput i) ->
+  HH.HTML p i
 inputRight iprops =
   HH.input
-    ( [ HP.classes mainRightClasses ] <&> iprops )
+    ([ HP.classes mainRightClasses ] <&> iprops)
 
-addonCenter
-  :: ∀ p i
-   . Array (HH.IProp HTMLspan i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+addonCenter ::
+  forall p i.
+  Array (HH.IProp HTMLspan i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 addonCenter iprops html =
   HH.span
-    ( [ HP.classes addonCenterClasses ] <&> iprops )
+    ([ HP.classes addonCenterClasses ] <&> iprops)
     html
 
-addonCenter_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+addonCenter_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 addonCenter_ = addonCenter []
 
-addonLeft
-  :: ∀ p i
-   . Array (HH.IProp HTMLspan i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+addonLeft ::
+  forall p i.
+  Array (HH.IProp HTMLspan i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 addonLeft iprops html =
   HH.span
-    ( [ HP.classes addonLeftClassess ] <&> iprops )
+    ([ HP.classes addonLeftClassess ] <&> iprops)
     html
 
-addonLeft_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+addonLeft_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 addonLeft_ = addonLeft []
 
-addonRight
-  :: ∀ p i
-   . Array (HH.IProp HTMLspan i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+addonRight ::
+  forall p i.
+  Array (HH.IProp HTMLspan i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 addonRight iprops html =
   HH.span
-    ( [ HP.classes addonRightClasses ] <&> iprops )
+    ([ HP.classes addonRightClasses ] <&> iprops)
     html
 
-addonRight_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+addonRight_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 addonRight_ = addonRight []
 
-borderLeft
-  :: ∀ p i
-   . Array (HH.IProp HTMLspan i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+borderLeft ::
+  forall p i.
+  Array (HH.IProp HTMLspan i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 borderLeft iprops html =
   addonLeft_
     [ HH.span
-      ( [ HP.classes borderLeftClasses ] <&> iprops )
-      html
+        ([ HP.classes borderLeftClasses ] <&> iprops)
+        html
     ]
 
-borderLeft_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+borderLeft_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 borderLeft_ = borderLeft []
 
-borderRight
-  :: ∀ p i
-   . Array (HH.IProp HTMLspan i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+borderRight ::
+  forall p i.
+  Array (HH.IProp HTMLspan i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 borderRight iprops html =
   addonRight_
     [ HH.span
-      ( [ HP.classes borderRightClasses ] <&> iprops )
-      html
+        ([ HP.classes borderRightClasses ] <&> iprops)
+        html
     ]
 
-borderRight_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+borderRight_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 borderRight_ = borderRight []
 
-percentage
-  :: ∀ p i
-   . Array (HH.IProp HTMLlabel i)
-  -> Array (HH.IProp HTMLinput i)
-  -> HH.HTML p i
+percentage ::
+  forall p i.
+  Array (HH.IProp HTMLlabel i) ->
+  Array (HH.IProp HTMLinput i) ->
+  HH.HTML p i
 percentage lprops iprops =
   inputGroup lprops [ inputLeft iprops, addonRight_ [ HH.text "%" ] ]
 
-percentage_
-  :: ∀ p i
-   . Array (HH.IProp HTMLinput i)
-  -> HH.HTML p i
+percentage_ ::
+  forall p i.
+  Array (HH.IProp HTMLinput i) ->
+  HH.HTML p i
 percentage_ = percentage []
 
-currency
-  :: ∀ p i
-   . Array (HH.IProp HTMLlabel i)
-  -> Array (HH.IProp HTMLinput i)
-  -> HH.HTML p i
+currency ::
+  forall p i.
+  Array (HH.IProp HTMLlabel i) ->
+  Array (HH.IProp HTMLinput i) ->
+  HH.HTML p i
 currency lprops iprops =
   inputGroup lprops [ inputRight iprops, addonLeft_ [ HH.text "$" ] ]
 
-currency_
-  :: ∀ p i
-   . Array (HH.IProp HTMLinput i)
-  -> HH.HTML p i
+currency_ ::
+  forall p i.
+  Array (HH.IProp HTMLinput i) ->
+  HH.HTML p i
 currency_ = currency []
 
-textarea
-  :: ∀ p i
-   . Array (HH.IProp HTMLtextarea i)
-  -> HH.HTML p i
+textarea ::
+  forall p i.
+  Array (HH.IProp HTMLtextarea i) ->
+  HH.HTML p i
 textarea iprops =
   HH.textarea
-    ( [ HP.classes textareaClasses ] <&> iprops )
+    ([ HP.classes textareaClasses ] <&> iprops)

--- a/src/Blocks/ItemContainer.purs
+++ b/src/Blocks/ItemContainer.purs
@@ -32,21 +32,21 @@ menuClasses = HH.ClassName <$>
 dropdownClasses :: Array HH.ClassName
 dropdownClasses = menuClasses <>
   ( HH.ClassName <$>
-    [ "absolute"
-    , "pin-t-full"
-    , "pin-l"
-    , "max-h-160"
-    , "overflow-y-auto"
-    ]
+      [ "absolute"
+      , "pin-t-full"
+      , "pin-l"
+      , "max-h-160"
+      , "overflow-y-auto"
+      ]
   )
 
 droprightClasses :: Array HH.ClassName
 droprightClasses = menuClasses <>
   ( HH.ClassName <$>
-    [ "absolute"
-    , "pin-t"
-    , "pin-l-full"
-    ]
+      [ "absolute"
+      , "pin-t"
+      , "pin-l-full"
+      ]
   )
 
 baseClasses :: Array HH.ClassName
@@ -61,22 +61,22 @@ baseClasses = HH.ClassName <$>
 selectionContainerClasses :: Array HH.ClassName
 selectionContainerClasses = baseClasses <>
   ( HH.ClassName <$>
-    [ "border-t-2"
-    ]
+      [ "border-t-2"
+      ]
   )
 
 itemContainerClasses :: Array HH.ClassName
 itemContainerClasses = baseClasses <>
   ( HH.ClassName <$>
-    [ "absolute"
-    , "shadow"
-    , "max-h-120"
-    , "overflow-y-auto"
-    , "z-50"
-    , "border-b-2"
-    , "pin-t-full"
-    , "pin-l"
-    ]
+      [ "absolute"
+      , "shadow"
+      , "max-h-120"
+      , "overflow-y-auto"
+      , "z-50"
+      , "border-b-2"
+      , "pin-t-full"
+      , "pin-l"
+      ]
   )
 
 ulClasses :: Array HH.ClassName
@@ -108,143 +108,140 @@ buttonClasses = HH.ClassName <$>
   , "group-hover:visible"
   ]
 
-dropdownButton
-  :: ∀ p r i
-   . (Array (IProp r i) -> Array (HH.HTML p i) -> HH.HTML p i)
-  -> Array (IProp r i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+dropdownButton ::
+  forall p r i.
+  (Array (IProp r i) -> Array (HH.HTML p i) -> HH.HTML p i) ->
+  Array (IProp r i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 dropdownButton button iprops html =
   button
-    ( [ css "font-medium flex items-center" ] <&> iprops )
+    ([ css "font-medium flex items-center" ] <&> iprops)
     $ html <> [ Icon.caratDown [ css "ml-3 text-xs" ] ]
 
-dropdownContainer
-  :: ∀ p action item
-   . Array (HH.HTML p (Select.Action action))
-  -> (item -> HH.PlainHTML)
-  -> (item -> Boolean)
-  -> Array item
-  -> Maybe Int
-  -> HH.HTML p (Select.Action action)
+dropdownContainer ::
+  forall p action item.
+  Array (HH.HTML p (Select.Action action)) ->
+  (item -> HH.PlainHTML) ->
+  (item -> Boolean) ->
+  Array item ->
+  Maybe Int ->
+  HH.HTML p (Select.Action action)
 dropdownContainer addlHTML renderItem selected items hix =
   HH.div
-    ( Setters.setContainerProps [ HP.classes dropdownClasses ] )
-    ( addlHTML <> renderItems )
+    (Setters.setContainerProps [ HP.classes dropdownClasses ])
+    (addlHTML <> renderItems)
   where
-    renderItems :: Array (HH.HTML p (Select.Action action))
-    renderItems =
-      [ HH.ul
+  renderItems :: Array (HH.HTML p (Select.Action action))
+  renderItems =
+    [ HH.ul
         [ HP.classes ulClasses ]
         $ mapWithIndex renderItem' items
-      ]
+    ]
 
-    renderItem' :: Int -> item -> HH.HTML p (Select.Action action)
-    renderItem' idx item =
-      dropdownItem HH.li
-        ( Setters.setItemProps idx [] )
-        [ HH.fromPlainHTML $ renderItem item ]
-        ( selected item )
-        ( hix == Just idx )
+  renderItem' :: Int -> item -> HH.HTML p (Select.Action action)
+  renderItem' idx item =
+    dropdownItem HH.li
+      (Setters.setItemProps idx [])
+      [ HH.fromPlainHTML $ renderItem item ]
+      (selected item)
+      (hix == Just idx)
 
-dropdownItem
-  :: ∀ p r i
-   . (Array (IProp r i) -> Array (HH.HTML p i) -> HH.HTML p i)
-  -> Array (IProp r i)
-  -> Array (HH.HTML p i)
-  -> Boolean
-  -> Boolean
-  -> HH.HTML p i
+dropdownItem ::
+  forall p r i.
+  (Array (IProp r i) -> Array (HH.HTML p i) -> HH.HTML p i) ->
+  Array (IProp r i) ->
+  Array (HH.HTML p i) ->
+  Boolean ->
+  Boolean ->
+  HH.HTML p i
 dropdownItem elem props html selected highlighted =
   elem
-    ( props <&> [ HP.classes itemClasses ] )
+    (props <&> [ HP.classes itemClasses ])
     $ [ Icon.selected [ HP.classes checkmarkClass ] ] <> html
   where
-    itemClasses :: Array HH.ClassName
-    itemClasses =
-      liClasses
+  itemClasses :: Array HH.ClassName
+  itemClasses =
+    liClasses
       <> [ HH.ClassName "flex" ]
-      <> ( if highlighted then [ HH.ClassName "bg-grey-lighter" ] else [] )
+      <> (if highlighted then [ HH.ClassName "bg-grey-lighter" ] else [])
       <> if selected then [ HH.ClassName "font-medium" ] else []
 
-    checkmarkClass :: Array HH.ClassName
-    checkmarkClass =
-      (HH.ClassName <$> [ "mr-2", "text-green" ])
+  checkmarkClass :: Array HH.ClassName
+  checkmarkClass =
+    (HH.ClassName <$> [ "mr-2", "text-green" ])
       <> if selected then [] else [ HH.ClassName "invisible" ]
 
 -- Provided an array of items and any additional HTML, renders the container
 -- Items should have already been treated with `boldMatches` by this point.
-itemContainer
-  :: ∀ p action
-   . Maybe Int
-  -> Array HH.PlainHTML
-  -> Array (HH.HTML p (Select.Action action))
-  -> HH.HTML p (Select.Action action)
+itemContainer ::
+  forall p action.
+  Maybe Int ->
+  Array HH.PlainHTML ->
+  Array (HH.HTML p (Select.Action action)) ->
+  HH.HTML p (Select.Action action)
 itemContainer highlightIndex itemsHTML addlHTML =
   HH.div
-    ( Setters.setContainerProps [ HP.classes itemContainerClasses ] )
-    ( renderItems <> addlHTML )
+    (Setters.setContainerProps [ HP.classes itemContainerClasses ])
+    (renderItems <> addlHTML)
   where
-    hover :: Int -> Array HH.ClassName
-    hover i = if highlightIndex == Just i then HH.ClassName <$> [ "bg-grey-lighter" ] else mempty
+  hover :: Int -> Array HH.ClassName
+  hover i = if highlightIndex == Just i then HH.ClassName <$> [ "bg-grey-lighter" ] else mempty
 
-    renderItems :: Array (HH.HTML p (Select.Action action))
-    renderItems =
-      [ HH.ul
+  renderItems :: Array (HH.HTML p (Select.Action action))
+  renderItems =
+    [ HH.ul
         [ HP.classes ulClasses ]
         $ mapWithIndex
-          ( \i h ->
-              HH.li
-                ( Setters.setItemProps i
-                  [ HP.classes $ liClasses <> hover i ]
-                )
-                [ HH.fromPlainHTML h ]
-          )
-          itemsHTML
-      ]
-
+            ( \i h ->
+                HH.li
+                  ( Setters.setItemProps i
+                      [ HP.classes $ liClasses <> hover i ]
+                  )
+                  [ HH.fromPlainHTML h ]
+            )
+            itemsHTML
+    ]
 
 -- Provided an array of selection items, renders them in a container
 -- Make sure the array of items includes the correct click handlers
-selectionContainer :: ∀ p i. Array (HH.HTML p i) -> HH.HTML p i
-selectionContainer []   =
+selectionContainer :: forall p i. Array (HH.HTML p i) -> HH.HTML p i
+selectionContainer [] =
   HH.div_ []
 selectionContainer html =
   HH.div
-  [ HP.classes selectionContainerClasses ]
-  [ HH.ul
-    [ HP.classes ulClasses ]
-    $ html <#>
-    ( \h ->
-        HH.li
-          [ HP.classes (HH.ClassName "py-2" : liClasses) ]
-          [ h ]
-    )
-  ]
+    [ HP.classes selectionContainerClasses ]
+    [ HH.ul
+        [ HP.classes ulClasses ]
+        $ html <#>
+            ( \h ->
+                HH.li
+                  [ HP.classes (HH.ClassName "py-2" : liClasses) ]
+                  [ h ]
+            )
+    ]
 
-
-selectionGroup
-  :: ∀ item i p
-   . (item -> HH.PlainHTML)
-  -> Array (HH.IProp HTMLdiv p)
-  -> Array (HH.IProp HTMLbutton p)
-  -> item
-  -> HH.HTML i p
+selectionGroup ::
+  forall item i p.
+  (item -> HH.PlainHTML) ->
+  Array (HH.IProp HTMLdiv p) ->
+  Array (HH.IProp HTMLbutton p) ->
+  item ->
+  HH.HTML i p
 selectionGroup f divprops btnprops item =
   HH.div
     ([ HP.classes $ selectionGroupClasses ] <&> divprops)
     [ HH.fromPlainHTML (f item)
     , HH.button
-      ([ HP.classes buttonClasses ] <&> btnprops)
-      [ HH.text "✕" ]
+        ([ HP.classes buttonClasses ] <&> btnprops)
+        [ HH.text "✕" ]
     ]
-
 
 -- Takes a key to the segment that you want to display highlighted.
 -- WARN: If the key you provided does not exist in the map, your item will not be
 -- rendered!
-boldMatches :: ∀ item i p. String -> Fuzzy item -> Array (HH.HTML i p)
+boldMatches :: forall item i p. String -> Fuzzy item -> Array (HH.HTML i p)
 boldMatches key (Fuzzy { segments }) = boldMatch <$> (fromMaybe [ Left key ] $ lookup key segments)
   where
-    boldMatch (Left str) = HH.text str
-    boldMatch (Right str) = HH.span [ HP.class_ $ HH.ClassName "font-bold" ] [ HH.text str ]
+  boldMatch (Left str) = HH.text str
+  boldMatch (Right str) = HH.span [ HP.class_ $ HH.ClassName "font-bold" ] [ HH.text str ]

--- a/src/Blocks/Layout.purs
+++ b/src/Blocks/Layout.purs
@@ -16,17 +16,17 @@ popoverClasses = HH.ClassName <$>
   , "rounded"
   ]
 
-popover
-  :: ∀ p i
-   . Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+popover ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 popover = blockBuilder HH.div popoverClasses
 
-popover_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+popover_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 popover_ = popover []
 
 stickyClasses :: Array HH.ClassName
@@ -39,17 +39,17 @@ stickyClasses = HH.ClassName <$>
   , "z-60"
   ]
 
-sticky
-  :: ∀ p i
-   . Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+sticky ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 sticky = blockBuilder HH.div stickyClasses
 
-sticky_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+sticky_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 sticky_ = sticky []
 
 containerClasses :: Array HH.ClassName
@@ -58,17 +58,17 @@ containerClasses = HH.ClassName <$>
   , "m-auto"
   ]
 
-container
-  :: ∀ p i
-   . Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+container ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 container = blockBuilder HH.div containerClasses
 
-container_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+container_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 container_ = container []
 
 sectionClasses :: Array HH.ClassName
@@ -76,17 +76,17 @@ sectionClasses = HH.ClassName <$>
   [ "my-8"
   ]
 
-section
-  :: ∀ p i
-   . Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+section ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 section = blockBuilder HH.div sectionClasses
 
-section_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+section_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 section_ = section []
 
 gridClasses :: Array HH.ClassName
@@ -97,17 +97,17 @@ gridClasses = HH.ClassName <$>
   , "flex"
   ]
 
-grid
-  :: ∀ p i
-   . Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+grid ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 grid = blockBuilder HH.div gridClasses
 
-grid_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+grid_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 grid_ = grid []
 
 columnClasses :: Array HH.ClassName
@@ -116,17 +116,17 @@ columnClasses = HH.ClassName <$>
   , "p-8"
   ]
 
-column
-  :: ∀ p i
-   . Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+column ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 column = blockBuilder HH.div columnClasses
 
-column_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+column_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 column_ = column []
 
 mainClasses :: Array HH.ClassName
@@ -135,17 +135,17 @@ mainClasses = HH.ClassName <$>
   , "p-8"
   ]
 
-main
-  :: ∀ p i
-   . Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+main ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 main = blockBuilder HH.div mainClasses
 
-main_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+main_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 main_ = main []
 
 sideClasses :: Array HH.ClassName
@@ -154,15 +154,15 @@ sideClasses = HH.ClassName <$>
   , "p-8"
   ]
 
-side
-  :: ∀ p i
-   . Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+side ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 side = blockBuilder HH.div sideClasses
 
-side_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+side_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 side_ = side []

--- a/src/Blocks/Loading.purs
+++ b/src/Blocks/Loading.purs
@@ -11,18 +11,19 @@ import Svg.Renderer.Halogen (parse)
 
 svgString :: String
 svgString =
-  "<svg class=\"circular\" viewBox=\"25 25 50 50\">" <>
-  "<circle class=\"path\" cx=\"50\" cy=\"50\" r=\"20\" fill=\"none\" stroke-width=\"4\" stroke-miterlimit=\"10\"/>" <>
-  "</svg>"
+  "<svg class=\"circular\" viewBox=\"25 25 50 50\">"
+    <> "<circle class=\"path\" cx=\"50\" cy=\"50\" r=\"20\" fill=\"none\" stroke-width=\"4\" stroke-miterlimit=\"10\"/>"
+    <>
+      "</svg>"
 
-svgElem :: ∀ p i. HH.HTML p i
+svgElem :: forall p i. HH.HTML p i
 svgElem = either (const $ HH.text "") identity $ parse svgString
 
-spinner :: ∀ p i. Array (HH.IProp HTMLdiv i) -> HH.HTML p i
+spinner :: forall p i. Array (HH.IProp HTMLdiv i) -> HH.HTML p i
 spinner props =
   HH.div
-    ( [ HP.class_ $ HH.ClassName "loader" ] <&> props )
+    ([ HP.class_ $ HH.ClassName "loader" ] <&> props)
     [ svgElem ]
 
-spinner_ :: ∀ p i. HH.HTML p i
+spinner_ :: forall p i. HH.HTML p i
 spinner_ = spinner []

--- a/src/Blocks/Menu.purs
+++ b/src/Blocks/Menu.purs
@@ -14,19 +14,19 @@ bodyClasses = HH.ClassName <$>
   , "w-90"
   ]
 
-body
-  :: ∀ p i
-   . Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+body ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 body iprops =
   HH.div
-    ( [ HP.classes bodyClasses ] <&> iprops )
+    ([ HP.classes bodyClasses ] <&> iprops)
 
-body_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+body_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 body_ =
   body []
 
@@ -39,19 +39,19 @@ optionClasses = HH.ClassName <$>
   , "cursor-pointer"
   ]
 
-option
-  :: ∀ p i
-   . Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+option ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 option iprops =
   HH.div
-    ( [ HP.classes optionClasses ] <&> iprops )
+    ([ HP.classes optionClasses ] <&> iprops)
 
-option_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+option_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 option_ =
   option []
 

--- a/src/Blocks/NavigationTab.purs
+++ b/src/Blocks/NavigationTab.purs
@@ -19,28 +19,28 @@ type TabConfig page =
   , activePage :: page
   }
 
-navigationTabs
-  :: ∀ p i page
-   . Eq page
-  => TabConfig page
-  -> Array (HH.IProp HTMLdiv i)
-  -> HH.HTML p i
+navigationTabs ::
+  forall p i page.
+  Eq page =>
+  TabConfig page ->
+  Array (HH.IProp HTMLdiv i) ->
+  HH.HTML p i
 navigationTabs { tabs, activePage } props =
   TabControl.tabControl config props
   where
-    config =
-      { tabs: toGeneric <$> tabs, activePage }
+  config =
+    { tabs: toGeneric <$> tabs, activePage }
 
-    toGeneric tab =
-      { name: tab.name
-      , props: [ HP.href tab.link ]
-      , page: tab.page
-      , errors: tab.errors
-      }
+  toGeneric tab =
+    { name: tab.name
+    , props: [ HP.href tab.link ]
+    , page: tab.page
+    , errors: tab.errors
+    }
 
-navigationTabs_
-  :: ∀ p i page
-   . Eq page
-  => TabConfig page
-  -> HH.HTML p i
+navigationTabs_ ::
+  forall p i page.
+  Eq page =>
+  TabConfig page ->
+  HH.HTML p i
 navigationTabs_ config = navigationTabs config []

--- a/src/Blocks/Pager.purs
+++ b/src/Blocks/Pager.purs
@@ -17,81 +17,81 @@ import Web.UIEvent.MouseEvent (MouseEvent)
 -----
 -- old CN pager (require citizennet.css)
 
-pager :: ∀ p i. Int -> Int -> (Int -> MouseEvent -> i) -> HH.HTML p i
+pager :: forall p i. Int -> Int -> (Int -> MouseEvent -> i) -> HH.HTML p i
 pager skip last query =
   HH.div
     [ HP.classes
-      [ ClassName "cn-pagination"
-      , ClassName "clearfix"
-      ]
+        [ ClassName "cn-pagination"
+        , ClassName "clearfix"
+        ]
     ]
     [ HH.ul
-      [ HP.class_ (ClassName "pagination")
-      ]
-      makePagingButtons
+        [ HP.class_ (ClassName "pagination")
+        ]
+        makePagingButtons
     ]
   where
-    makeList :: Array Int
-    makeList | last < 2 = []
-    makeList | last <= 6 = 1 .. last
-    makeList | skip < 5 = 1 .. 6 <> [last]
-    makeList | skip > (last - 4) = [1] <> (last - 5) .. last
-    makeList = [1] <> (skip - 2) .. (skip + 2) <> [last]
+  makeList :: Array Int
+  makeList | last < 2 = []
+  makeList | last <= 6 = 1 .. last
+  makeList | skip < 5 = 1 .. 6 <> [ last ]
+  makeList | skip > (last - 4) = [ 1 ] <> (last - 5) .. last
+  makeList = [ 1 ] <> (skip - 2) .. (skip + 2) <> [ last ]
 
-    makePagingButtons :: Array (HH.HTML p i)
-    makePagingButtons =
-      foldlWithIndex makePagingButtons' [] makeList
+  makePagingButtons :: Array (HH.HTML p i)
+  makePagingButtons =
+    foldlWithIndex makePagingButtons' [] makeList
 
-    makePagingButtons' :: Int -> Array (HH.HTML p i) -> Int -> Array (HH.HTML p i)
-    makePagingButtons' 0 _ btn =
-      (if skip == 1 then [] else [backArrow]) <> [button btn]
-    makePagingButtons' 1 btns btn | btn /= 2 =
-      btns <> [ellipsis] <> [button btn]
-    makePagingButtons' _ btns btn | btn == last && last < 7 && skip /= last =
-      btns <> [button btn] <> [forwardArrow]
-    makePagingButtons' _ btns btn | btn == last && last < 7 =
-      btns <> [button btn]
-    makePagingButtons' _ btns btn | btn == last && skip < (last - 3) =
-      btns <> [ellipsis] <> [button btn] <> [forwardArrow]
-    makePagingButtons' _ btns btn | btn == last =
-      btns <> [button btn] <> (if skip == last then [] else [forwardArrow])
-    makePagingButtons' _ btns btn =
-      btns <> [button btn]
+  makePagingButtons' :: Int -> Array (HH.HTML p i) -> Int -> Array (HH.HTML p i)
+  makePagingButtons' 0 _ btn =
+    (if skip == 1 then [] else [ backArrow ]) <> [ button btn ]
+  makePagingButtons' 1 btns btn | btn /= 2 =
+    btns <> [ ellipsis ] <> [ button btn ]
+  makePagingButtons' _ btns btn | btn == last && last < 7 && skip /= last =
+    btns <> [ button btn ] <> [ forwardArrow ]
+  makePagingButtons' _ btns btn | btn == last && last < 7 =
+    btns <> [ button btn ]
+  makePagingButtons' _ btns btn | btn == last && skip < (last - 3) =
+    btns <> [ ellipsis ] <> [ button btn ] <> [ forwardArrow ]
+  makePagingButtons' _ btns btn | btn == last =
+    btns <> [ button btn ] <> (if skip == last then [] else [ forwardArrow ])
+  makePagingButtons' _ btns btn =
+    btns <> [ button btn ]
 
-    arrow :: Int -> String -> HH.HTML p i
-    arrow skip' label =
-      HH.li_
-        [ HH.a
+  arrow :: Int -> String -> HH.HTML p i
+  arrow skip' label =
+    HH.li_
+      [ HH.a
           [ HE.onClick $ query skip'
           ]
           [ HH.text label
           ]
-        ]
+      ]
 
-    backArrow :: HH.HTML p i
-    backArrow = arrow (skip - 1) "←"
+  backArrow :: HH.HTML p i
+  backArrow = arrow (skip - 1) "←"
 
-    forwardArrow :: HH.HTML p i
-    forwardArrow = arrow (skip + 1) "→"
+  forwardArrow :: HH.HTML p i
+  forwardArrow = arrow (skip + 1) "→"
 
-    button :: Int -> HH.HTML p i
-    button btn =
-      HH.li_
-        [ HH.a
+  button :: Int -> HH.HTML p i
+  button btn =
+    HH.li_
+      [ HH.a
           [ HP.class_ $ ClassName (if btn == skip then "disabled" else "")
           , HE.onClick $ query btn
           ]
           [ HH.text $ show btn
           ]
-        ]
+      ]
 
-    ellipsis :: HH.HTML p i
-    ellipsis =
-      HH.li_
-        [ HH.span_
+  ellipsis :: HH.HTML p i
+  ellipsis =
+    HH.li_
+      [ HH.span_
           [ HH.text "…"
           ]
-        ]
+      ]
 
 -----
 -- A block for handling paging in list components
@@ -116,72 +116,75 @@ makePagingButtonsNew skip last query = foldlWithIndex makePagingButtons' [] make
   makeList :: Array Int
   makeList | last < 2 = []
   makeList | last <= 6 = 1 .. last
-  makeList | skip < 5 = 1 .. 6 <> [last]
-  makeList | skip > (last - 4) = [1] <> (last - 5) .. last
-  makeList = [1] <> (skip - 2) .. (skip + 2) <> [last]
+  makeList | skip < 5 = 1 .. 6 <> [ last ]
+  makeList | skip > (last - 4) = [ 1 ] <> (last - 5) .. last
+  makeList = [ 1 ] <> (skip - 2) .. (skip + 2) <> [ last ]
 
   makePagingButtons' :: Int -> Array (HH.HTML p i) -> Int -> Array (HH.HTML p i)
   makePagingButtons' 0 _ btn =
-    (if skip == 1 then [] else [backArrow]) <> [button btn]
+    (if skip == 1 then [] else [ backArrow ]) <> [ button btn ]
   makePagingButtons' 1 btns btn | btn /= 2 =
-    btns <> [ellipsis] <> [button btn]
+    btns <> [ ellipsis ] <> [ button btn ]
   makePagingButtons' _ btns btn | btn == last && last < 7 && skip /= last =
-    btns <> [button btn] <> [forwardArrow]
+    btns <> [ button btn ] <> [ forwardArrow ]
   makePagingButtons' _ btns btn | btn == last && last < 7 =
-    btns <> [button btn]
+    btns <> [ button btn ]
   makePagingButtons' _ btns btn | btn == last && skip < (last - 3) =
-    btns <> [ellipsis] <> [button btn] <> [forwardArrow]
+    btns <> [ ellipsis ] <> [ button btn ] <> [ forwardArrow ]
   makePagingButtons' _ btns btn | btn == last =
-    btns <> [button btn] <> (if skip == last then [] else [forwardArrow])
+    btns <> [ button btn ] <> (if skip == last then [] else [ forwardArrow ])
   makePagingButtons' _ btns btn =
-    btns <> [button btn]
+    btns <> [ button btn ]
 
   arrow :: Int -> HH.HTML p i -> HH.HTML p i
   arrow skip' label =
     HH.button
-    [ HE.onMouseDown $ query skip'
-    , Ocelot.HTML.Properties.css "mx-4"
-    , Ocelot.HTML.Properties.style <<< Foreign.Object.fromHomogeneous
-      $ { "line-height": "2.5rem"
-        }
-    ]
-    [ label ]
+      [ HE.onMouseDown $ query skip'
+      , Ocelot.HTML.Properties.css "mx-4"
+      , Ocelot.HTML.Properties.style <<< Foreign.Object.fromHomogeneous
+          $
+            { "line-height": "2.5rem"
+            }
+      ]
+      [ label ]
 
   backArrow :: HH.HTML p i
-  backArrow = arrow (skip - 1) (Ocelot.Block.Icon.chevronLeft [ Ocelot.HTML.Properties.css "hover:text-grey"])
+  backArrow = arrow (skip - 1) (Ocelot.Block.Icon.chevronLeft [ Ocelot.HTML.Properties.css "hover:text-grey" ])
 
   forwardArrow :: HH.HTML p i
-  forwardArrow = arrow (skip + 1) (Ocelot.Block.Icon.chevronRight [ Ocelot.HTML.Properties.css "hover:text-grey"])
+  forwardArrow = arrow (skip + 1) (Ocelot.Block.Icon.chevronRight [ Ocelot.HTML.Properties.css "hover:text-grey" ])
 
   button :: Int -> HH.HTML p i
   button btn =
     HH.button
-    (if btn == skip then disabled else active)
-    [ HH.span_
-      [ HH.text $ show btn ]
-    ]
+      (if btn == skip then disabled else active)
+      [ HH.span_
+          [ HH.text $ show btn ]
+      ]
     where
     disabled =
       [ Ocelot.HTML.Properties.css "border border-black disabled focus:outline-none inline-block text-center"
       , Ocelot.HTML.Properties.style <<< Foreign.Object.fromHomogeneous
-        $ { "border-radius": "50%"
-          , "width": "2.5rem"
-          , "line-height": "2.5rem"
-          }
+          $
+            { "border-radius": "50%"
+            , "width": "2.5rem"
+            , "line-height": "2.5rem"
+            }
       ]
 
     active =
       [ Ocelot.HTML.Properties.css "inline-block hover:bg-grey hover:text-white text-center"
       , Ocelot.HTML.Properties.style <<< Foreign.Object.fromHomogeneous
-        $ { "border-radius": "50%"
-          , "width": "2.5rem"
-          , "line-height": "2.5rem"
-          }
+          $
+            { "border-radius": "50%"
+            , "width": "2.5rem"
+            , "line-height": "2.5rem"
+            }
       , HE.onMouseDown $ query btn
       ]
 
   ellipsis :: HH.HTML p i
   ellipsis =
     HH.span
-    [ Ocelot.HTML.Properties.css "mx-2"]
-    [ HH.text "…" ]
+      [ Ocelot.HTML.Properties.css "mx-2" ]
+      [ HH.text "…" ]

--- a/src/Blocks/Popover.purs
+++ b/src/Blocks/Popover.purs
@@ -2,34 +2,34 @@ module Ocelot.Block.Popover where
 
 import Prelude
 
-import Ocelot.Block.Hover as Hover
 import DOM.HTML.Indexed (HTMLdiv)
 import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
+import Ocelot.Block.Hover as Hover
 
-popover
-  :: forall p i
-   . Array (HH.IProp HTMLdiv i)
-  -> Array Hover.HoverAnchor
-  -> HH.HTML p i
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+popover ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array Hover.HoverAnchor ->
+  HH.HTML p i ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 popover props anchors trigger hoverHtml =
   Hover.hover
     props
     anchors
     trigger
     ( HH.div
-      [ HP.classes hoverClasses ]
-      hoverHtml
+        [ HP.classes hoverClasses ]
+        hoverHtml
     )
 
-popover_
-  :: forall p i
-   . Array Hover.HoverAnchor
-  -> HH.HTML p i
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+popover_ ::
+  forall p i.
+  Array Hover.HoverAnchor ->
+  HH.HTML p i ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 popover_ =
   popover []
 

--- a/src/Blocks/Progress.purs
+++ b/src/Blocks/Progress.purs
@@ -2,29 +2,29 @@ module Ocelot.Block.Progress where
 
 import Prelude
 
-import DOM.HTML.Indexed (HTMLspan, HTMLdiv)
+import DOM.HTML.Indexed (HTMLdiv, HTMLspan)
 import Data.Ratio (Ratio, denominator, numerator)
 import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
 import Ocelot.HTML.Properties (css, (<&>))
 
 -- Passed props reach the <span>.
-bar :: ∀ p i. Ratio Number -> Array (HH.IProp HTMLdiv i) -> Array (HH.IProp HTMLspan i) -> HH.HTML p i
+bar :: forall p i. Ratio Number -> Array (HH.IProp HTMLdiv i) -> Array (HH.IProp HTMLspan i) -> HH.HTML p i
 bar r divProps spanProps =
   HH.div
-    ( [ css "bg-grey-light relative" ] <&> divProps )
+    ([ css "bg-grey-light relative" ] <&> divProps)
     [ HH.span
-      ( [ css "block", HP.attr (HH.AttrName "style") ("width: " <> value <> "%; text-indent: -9999px;") ] <&> spanProps )
-      [ HH.text $ "Progress: " <> value ]
+        ([ css "block", HP.attr (HH.AttrName "style") ("width: " <> value <> "%; text-indent: -9999px;") ] <&> spanProps)
+        [ HH.text $ "Progress: " <> value ]
     ]
   where
-    value :: String
-    value = show $ if percentage > 100.0 then 100.0 else percentage
+  value :: String
+  value = show $ if percentage > 100.0 then 100.0 else percentage
 
-    percentage :: Number
-    percentage = numerator r / denominator r * 100.0
+  percentage :: Number
+  percentage = numerator r / denominator r * 100.0
 
 -- Defaults
-bar_ :: ∀ p i. Ratio Number -> HH.HTML p i
+bar_ :: forall p i. Ratio Number -> HH.HTML p i
 bar_ r = bar r [] [ css "bg-blue" ]
 

--- a/src/Blocks/Radio.purs
+++ b/src/Blocks/Radio.purs
@@ -62,28 +62,28 @@ radioClasses = HH.ClassName <$>
   , "before:shadow"
   ]
 
-radio
-  :: ∀ p i
-   . Array (HH.IProp HTMLlabel i)
-  -> Array (HH.IProp HTMLinput i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+radio ::
+  forall p i.
+  Array (HH.IProp HTMLlabel i) ->
+  Array (HH.IProp HTMLinput i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 radio iprops inprops html =
   HH.label
-    ( [ HP.classes labelClasses ] <&> iprops )
+    ([ HP.classes labelClasses ] <&> iprops)
     ( [ HH.input
-        ( [ HP.classes inputClasses
-          , HP.type_ InputRadio
-          ] <&> inprops
-        )
+          ( [ HP.classes inputClasses
+            , HP.type_ InputRadio
+            ] <&> inprops
+          )
       , HH.span [ HP.classes radioClasses ] []
       ]
-      <> html
+        <> html
     )
 
-radio_
-  :: ∀ p i
-   . Array (HH.IProp HTMLinput i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+radio_ ::
+  forall p i.
+  Array (HH.IProp HTMLinput i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 radio_ = radio []

--- a/src/Blocks/Range.purs
+++ b/src/Blocks/Range.purs
@@ -6,10 +6,9 @@ import DOM.HTML.Indexed (HTMLinput)
 import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
 
-
-range
-  :: ∀ p i
-   . Array (HH.IProp HTMLinput i)
-  -> HH.HTML p i
+range ::
+  forall p i.
+  Array (HH.IProp HTMLinput i) ->
+  HH.HTML p i
 range iprops =
   HH.input $ iprops <> [ HP.type_ HP.InputRange ]

--- a/src/Blocks/TabControl.purs
+++ b/src/Blocks/TabControl.purs
@@ -2,7 +2,7 @@ module Ocelot.Block.TabControl where
 
 import Prelude
 
-import DOM.HTML.Indexed (HTMLdiv, HTMLa)
+import DOM.HTML.Indexed (HTMLa, HTMLdiv)
 import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
 import Ocelot.Block.Icon as Icon
@@ -82,60 +82,60 @@ errorIconClasses = HH.ClassName <$>
   , "my-px"
   ]
 
-tabControl
-  :: ∀ p i page
-   . Eq page
-  => TabConfig (Tab i) page
-  -> Array (HH.IProp HTMLdiv i)
-  -> HH.HTML p i
+tabControl ::
+  forall p i page.
+  Eq page =>
+  TabConfig (Tab i) page ->
+  Array (HH.IProp HTMLdiv i) ->
+  HH.HTML p i
 tabControl { tabs, activePage } props =
   HH.div
     [ HP.classes outerClasses ]
     [ HH.ul
-      ( [ HP.classes innerClasses ] <&> props )
-      $ singleTab activePage <$> tabs
+        ([ HP.classes innerClasses ] <&> props)
+        $ singleTab activePage <$> tabs
     ]
 
-tabControl_
-  :: ∀ p i page
-   . Eq page
-  => TabConfig (Tab i) page
-  -> HH.HTML p i
+tabControl_ ::
+  forall p i page.
+  Eq page =>
+  TabConfig (Tab i) page ->
+  HH.HTML p i
 tabControl_ config = tabControl config []
 
-singleTab
-  :: ∀ p i page
-   . Eq page
-  => page
-  -> Tab i page
-  -> HH.HTML p i
+singleTab ::
+  forall p i page.
+  Eq page =>
+  page ->
+  Tab i page ->
+  HH.HTML p i
 singleTab activePage tab =
   HH.li
     [ HP.class_ $ HH.ClassName "mr-12" ]
     [ HH.a
-      ( tab.props
-        <> [ HP.classes $ tabClasses <> conditionalTabClasses isActive ]
-      )
-      ( errorIcon
-        <>
-        [ HH.span
-          [ HP.classes tabTextClasses ]
-          [ HH.text tab.name ]
-        ]
-      )
+        ( tab.props
+            <> [ HP.classes $ tabClasses <> conditionalTabClasses isActive ]
+        )
+        ( errorIcon
+            <>
+              [ HH.span
+                  [ HP.classes tabTextClasses ]
+                  [ HH.text tab.name ]
+              ]
+        )
     ]
   where
-    isActive :: Boolean
-    isActive = tab.page == activePage
+  isActive :: Boolean
+  isActive = tab.page == activePage
 
-    errorIcon :: Array (HH.HTML p i)
-    errorIcon
-      | tab.errors > 0 && isActive == false =
+  errorIcon :: Array (HH.HTML p i)
+  errorIcon
+    | tab.errors > 0 && isActive == false =
         [ Icon.error
-          [ HP.classes $ errorIconClasses ]
+            [ HP.classes $ errorIconClasses ]
         ]
-      | otherwise = []
+    | otherwise = []
 
-    conditionalTabClasses :: IsActive -> Array HH.ClassName
-    conditionalTabClasses true = activeTabClasses
-    conditionalTabClasses false = inactiveTabClasses
+  conditionalTabClasses :: IsActive -> Array HH.ClassName
+  conditionalTabClasses true = activeTabClasses
+  conditionalTabClasses false = inactiveTabClasses

--- a/src/Blocks/Table.purs
+++ b/src/Blocks/Table.purs
@@ -14,30 +14,30 @@ tableClasses = HH.ClassName <$>
   , "border-collapse"
   ]
 
-table
-  :: ∀ p i
-   . Array (IProp HTMLtable i)
-  -> Array (HTML p i)
-  -> HTML p i
+table ::
+  forall p i.
+  Array (IProp HTMLtable i) ->
+  Array (HTML p i) ->
+  HTML p i
 table = blockBuilder HH.table tableClasses
 
-table_
-  :: ∀ p i
-   . Array (HTML p i)
-  -> HTML p i
+table_ ::
+  forall p i.
+  Array (HTML p i) ->
+  HTML p i
 table_ = table []
 
-row
-  :: ∀ p i
-   . Array (IProp HTMLtr i)
-  -> Array (HTML p i)
-  -> HTML p i
+row ::
+  forall p i.
+  Array (IProp HTMLtr i) ->
+  Array (HTML p i) ->
+  HTML p i
 row = HH.tr
 
-row_
-  :: ∀ p i
-   . Array (HTML p i)
-  -> HTML p i
+row_ ::
+  forall p i.
+  Array (HTML p i) ->
+  HTML p i
 row_ = HH.tr_
 
 headerClasses :: Array HH.ClassName
@@ -49,17 +49,17 @@ headerClasses = HH.ClassName <$>
   , "text-black-20"
   ]
 
-header
-  :: ∀ p i
-   . Array (IProp HTMLth i)
-  -> Array (HTML p i)
-  -> HTML p i
+header ::
+  forall p i.
+  Array (IProp HTMLth i) ->
+  Array (HTML p i) ->
+  HTML p i
 header = blockBuilder HH.th headerClasses
 
-header_
-  :: ∀ p i
-   . Array (HTML p i)
-  -> HTML p i
+header_ ::
+  forall p i.
+  Array (HTML p i) ->
+  HTML p i
 header_ = header []
 
 cellClasses :: Array HH.ClassName
@@ -71,15 +71,15 @@ cellClasses = HH.ClassName <$>
   , "border-grey-95"
   ]
 
-cell
-  :: ∀ p i
-   . Array (IProp HTMLtd i)
-  -> Array (HTML p i)
-  -> HTML p i
+cell ::
+  forall p i.
+  Array (IProp HTMLtd i) ->
+  Array (HTML p i) ->
+  HTML p i
 cell = blockBuilder HH.td cellClasses
 
-cell_
-  :: ∀ p i
-   . Array (HTML p i)
-  -> HTML p i
+cell_ ::
+  forall p i.
+  Array (HTML p i) ->
+  HTML p i
 cell_ = cell []

--- a/src/Blocks/Toast.purs
+++ b/src/Blocks/Toast.purs
@@ -13,11 +13,11 @@ import Halogen.HTML.Properties as HP
 import Ocelot.HTML.Properties ((<&>))
 import Unsafe.Coerce (unsafeCoerce)
 
-type Toast r = ( visible :: Boolean | r )
+type Toast r = (visible :: Boolean | r)
 
 type HTMLtoast = Toast HTMLdiv
 
-visible :: ∀ r i. Boolean -> HP.IProp ( visible :: Boolean | r ) i
+visible :: forall r i. Boolean -> HP.IProp (visible :: Boolean | r) i
 visible = HP.prop (HH.PropName "visible")
 
 -- Necessary for centering the toast
@@ -56,38 +56,36 @@ toastClasses = HH.ClassName <$>
   , "flex"
   ]
 
-toast
-  :: ∀ p i
-   . Array (HH.IProp HTMLtoast i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+toast ::
+  forall p i.
+  Array (HH.IProp HTMLtoast i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 toast iprops html =
   HH.div
-  [ HP.classes $ toastContainerClasses <> containerClasses' ]
-  [ HH.div
-    ( [ HP.classes toastClasses ] <&> iprops' )
-    html
-  ]
+    [ HP.classes $ toastContainerClasses <> containerClasses' ]
+    [ HH.div
+        ([ HP.classes toastClasses ] <&> iprops')
+        html
+    ]
   where
-    Tuple visible iprops' = pullVisibleProp iprops
-    containerClasses' =
-      if visible
-        then containerVisibleClasses
-        else containerClosedClasses
+  Tuple visible iprops' = pullVisibleProp iprops
+  containerClasses' =
+    if visible then containerVisibleClasses
+    else containerClosedClasses
 
-
-pullVisibleProp
-  :: ∀ r i
-   . Array (HH.IProp ( visible :: Boolean | r ) i)
-  -> Tuple Boolean (Array (HH.IProp r i))
+pullVisibleProp ::
+  forall r i.
+  Array (HH.IProp (visible :: Boolean | r) i) ->
+  Tuple Boolean (Array (HH.IProp r i))
 pullVisibleProp = foldr f (Tuple false [])
   where
-    f (HP.IProp (HC.Property "visible" x)) =
-      lmap $ const $ coerceExpanded x
-    f iprop = rmap $ (flip snoc) $ coerceR iprop
+  f (HP.IProp (HC.Property "visible" x)) =
+    lmap $ const $ coerceExpanded x
+  f iprop = rmap $ (flip snoc) $ coerceR iprop
 
-    coerceExpanded :: HC.PropValue -> Boolean
-    coerceExpanded = unsafeCoerce
+  coerceExpanded :: HC.PropValue -> Boolean
+  coerceExpanded = unsafeCoerce
 
-    coerceR :: HH.IProp ( visible :: Boolean | r ) i -> HH.IProp r i
-    coerceR = unsafeCoerce
+  coerceR :: HH.IProp (visible :: Boolean | r) i -> HH.IProp r i
+  coerceR = unsafeCoerce

--- a/src/Blocks/Toggle.purs
+++ b/src/Blocks/Toggle.purs
@@ -51,18 +51,18 @@ toggleClasses = HH.ClassName <$>
   , "before:shadow"
   ]
 
-toggle
-  :: ∀ p i
-   . Array (HH.IProp HTMLinput i)
-  -> HH.HTML p i
+toggle ::
+  forall p i.
+  Array (HH.IProp HTMLinput i) ->
+  HH.HTML p i
 toggle iprops =
   HH.label
     [ HP.classes labelClasses ]
     [ HH.input iprops'
     , HH.span [ HP.classes toggleClasses ] []
     ]
-    where
-      iprops' = iprops <>
-        [ HP.classes inputClasses
-        , HP.type_ InputCheckbox
-        ]
+  where
+  iprops' = iprops <>
+    [ HP.classes inputClasses
+    , HP.type_ InputCheckbox
+    ]

--- a/src/Blocks/ToggleButton.purs
+++ b/src/Blocks/ToggleButton.purs
@@ -7,17 +7,17 @@ import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
 import Ocelot.HTML.Properties ((<&>))
 
-toggleButton
-  :: ∀ p i
-   . Array (HH.IProp HTMLspan i)
-  -> Array (HH.IProp HTMLinput i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+toggleButton ::
+  forall p i.
+  Array (HH.IProp HTMLspan i) ->
+  Array (HH.IProp HTMLinput i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 toggleButton iprops inprops html =
   HH.label_
-  [ HH.input inputProps
-  , HH.span labelProps html
-  ]
+    [ HH.input inputProps
+    , HH.span labelProps html
+    ]
   where
   inputProps =
     [ HP.classes inputClasses

--- a/src/Blocks/Tooltip.purs
+++ b/src/Blocks/Tooltip.purs
@@ -8,32 +8,32 @@ import Halogen.HTML.Properties as HP
 import Ocelot.HTML.Properties (css, (<&>))
 
 -- | A tooltip which allows styling on the outer container
-tooltip
-  :: ∀ p i
-   . String
-  -> Array (HH.IProp HTMLdiv i)
-  -> HH.HTML p i
-  -> HH.HTML p i
+tooltip ::
+  forall p i.
+  String ->
+  Array (HH.IProp HTMLdiv i) ->
+  HH.HTML p i ->
+  HH.HTML p i
 tooltip msg props html =
   HH.div
     ([ css "group cursor-pointer inline-block" ] <&> props)
     [ HH.div
-      [ HP.classes tooltipClasses ]
-      [ HH.text msg ]
+        [ HP.classes tooltipClasses ]
+        [ HH.text msg ]
     , html
     ]
 
 -- | A tooltip with no extra styling
-tooltip_
-  :: ∀ p i
-   . String
-  -> HH.HTML p i
-  -> HH.HTML p i
+tooltip_ ::
+  forall p i.
+  String ->
+  HH.HTML p i ->
+  HH.HTML p i
 tooltip_ = flip tooltip []
 
 -- | A tooltip which gives access to inner and outer styling
 tooltip' ::
-  ∀ p i.
+  forall p i.
   String ->
   Array (HH.IProp HTMLdiv i) ->
   Array (HH.IProp HTMLdiv i) ->

--- a/src/Blocks/Tray.purs
+++ b/src/Blocks/Tray.purs
@@ -2,21 +2,21 @@ module Ocelot.Block.Tray where
 
 import Prelude
 
+import DOM.HTML.Indexed (HTMLdiv)
 import Data.Array (foldr, snoc)
 import Data.Bifunctor (lmap, rmap)
 import Data.Tuple (Tuple(..))
-import DOM.HTML.Indexed (HTMLdiv)
 import Halogen.HTML as HH
 import Halogen.HTML.Core as HC
 import Halogen.HTML.Properties as HP
 import Ocelot.HTML.Properties ((<&>))
 import Unsafe.Coerce (unsafeCoerce)
 
-type Tray r = ( open :: Boolean | r )
+type Tray r = (open :: Boolean | r)
 
 type HTMLtray = Tray HTMLdiv
 
-open :: ∀ r i. Boolean -> HP.IProp ( open :: Boolean | r ) i
+open :: forall r i. Boolean -> HP.IProp (open :: Boolean | r) i
 open = HP.prop (HH.PropName "open")
 
 trayClasses :: Array HH.ClassName
@@ -43,34 +43,33 @@ trayClosedClasses :: Array HH.ClassName
 trayClosedClasses = HH.ClassName <$>
   [ "-pin-b-40" ]
 
-tray
-  :: ∀ p i
-   . Array (HH.IProp HTMLtray i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+tray ::
+  forall p i.
+  Array (HH.IProp HTMLtray i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 tray iprops html = HH.div
-  ( [ HP.classes (trayClasses <> trayClasses') ] <&> iprops' )
+  ([ HP.classes (trayClasses <> trayClasses') ] <&> iprops')
   html
   where
-    Tuple open iprops' = pullOpenProp iprops
+  Tuple open iprops' = pullOpenProp iprops
 
-    trayClasses' =
-      if open
-        then trayOpenClasses
-        else trayClosedClasses
+  trayClasses' =
+    if open then trayOpenClasses
+    else trayClosedClasses
 
-pullOpenProp
-  :: ∀ r i
-   . Array (HH.IProp ( open :: Boolean | r ) i)
-  -> Tuple Boolean (Array (HH.IProp r i))
+pullOpenProp ::
+  forall r i.
+  Array (HH.IProp (open :: Boolean | r) i) ->
+  Tuple Boolean (Array (HH.IProp r i))
 pullOpenProp = foldr f (Tuple false [])
   where
-    f (HP.IProp (HC.Property "open" x)) =
-      lmap $ const $ coerceExpanded x
-    f iprop = rmap $ (flip snoc) $ coerceR iprop
+  f (HP.IProp (HC.Property "open" x)) =
+    lmap $ const $ coerceExpanded x
+  f iprop = rmap $ (flip snoc) $ coerceR iprop
 
-    coerceExpanded :: HC.PropValue -> Boolean
-    coerceExpanded = unsafeCoerce
+  coerceExpanded :: HC.PropValue -> Boolean
+  coerceExpanded = unsafeCoerce
 
-    coerceR :: HH.IProp ( open :: Boolean | r ) i -> HH.IProp r i
-    coerceR = unsafeCoerce
+  coerceR :: HH.IProp (open :: Boolean | r) i -> HH.IProp r i
+  coerceR = unsafeCoerce

--- a/src/Button.purs
+++ b/src/Button.purs
@@ -55,17 +55,16 @@ module Ocelot.Button
   , pillPrimaryClasses
   , pill_
   , rightClasses
-  )
-  where
+  ) where
 
 import Prelude
 
-import Data.Array as Data.Array
 import DOM.HTML.Indexed as DOM.HTML.Indexed
+import Data.Array as Data.Array
+import Data.Maybe (Maybe(..))
 import Halogen.HTML as Halogen.HTML
 import Halogen.HTML.Elements as Halogen.HTML.Elements
 import Halogen.HTML.Properties as Halogen.HTML.Properties
-import Data.Maybe (Maybe(..))
 import Ocelot.HTML.Properties ((<&>))
 import Ocelot.HTML.Properties as Ocelot.HTML.Properties
 import Option as Option
@@ -78,44 +77,43 @@ data PillStyle
   = Default
   | Primary
 
-type IProp r i
-  = Halogen.HTML.IProp ( class :: String | r ) i
+type IProp r i = Halogen.HTML.IProp (class :: String | r) i
 
-button
-  :: ∀ p i
-   . Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i)
-  -> Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+button ::
+  forall p i.
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i) ->
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 button = buttonBuilder buttonClasses
 
-button_
-  :: ∀ p i
-   . Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+button_ ::
+  forall p i.
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 button_ = button []
 
-buttonBuilder
-  :: ∀ p i
-   . Array Halogen.HTML.ClassName
-  -> Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i)
-  -> Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonBuilder ::
+  forall p i.
+  Array Halogen.HTML.ClassName ->
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i) ->
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonBuilder classes iprops =
   Halogen.HTML.button
-    ( [ Halogen.HTML.Properties.classes $ buttonMainClasses <> classes ] <&> iprops )
+    ([ Halogen.HTML.Properties.classes $ buttonMainClasses <> classes ] <&> iprops)
 
-buttonCenter
-  :: ∀ p i
-   . Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i)
-  -> Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonCenter ::
+  forall p i.
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i) ->
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonCenter =
   buttonGroupBuilder $ buttonClasses <> centerClasses
 
-buttonCenter_
-  :: ∀ p i
-   . Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonCenter_ ::
+  forall p i.
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonCenter_ = buttonCenter []
 
 buttonClasses :: Array Halogen.HTML.ClassName
@@ -127,32 +125,32 @@ buttonClasses = Halogen.HTML.ClassName <$>
   , "text-black-20"
   ]
 
-buttonClear
-  :: ∀ p i
-   . Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i)
-  -> Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonClear ::
+  forall p i.
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i) ->
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonClear =
   buttonBuilder buttonClearClasses
 
-buttonClear_
-  :: ∀ p i
-   . Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonClear_ ::
+  forall p i.
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonClear_ = buttonClear []
 
-buttonClearCenter
-  :: ∀ p i
-   . Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i)
-  -> Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonClearCenter ::
+  forall p i.
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i) ->
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonClearCenter =
   buttonGroupBuilder $ buttonClearClasses <> centerClasses
 
-buttonClearCenter_
-  :: ∀ p i
-   . Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonClearCenter_ ::
+  forall p i.
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonClearCenter_ = buttonClearCenter []
 
 buttonClearClasses :: Array Halogen.HTML.ClassName
@@ -164,60 +162,60 @@ buttonClearClasses = Halogen.HTML.ClassName <$>
   , "focus:text-grey-70-a30"
   ]
 
-buttonClearLeft
-  :: ∀ p i
-   . Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i)
-  -> Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonClearLeft ::
+  forall p i.
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i) ->
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonClearLeft =
   buttonGroupBuilder $ buttonClearClasses <> leftClasses
 
-buttonClearLeft_
-  :: ∀ p i
-   . Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonClearLeft_ ::
+  forall p i.
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonClearLeft_ = buttonClearLeft []
 
-buttonClearRight
-  :: ∀ p i
-   . Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i)
-  -> Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonClearRight ::
+  forall p i.
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i) ->
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonClearRight =
   buttonGroupBuilder $ buttonClearClasses <> rightClasses
 
-buttonClearRight_
-  :: ∀ p i
-   . Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonClearRight_ ::
+  forall p i.
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonClearRight_ = buttonClearRight []
 
-buttonDark
-  :: ∀ p i
-   . Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i)
-  -> Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonDark ::
+  forall p i.
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i) ->
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonDark =
   buttonBuilder buttonDarkClasses
 
-buttonDark_
-  :: ∀ p i
-   . Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonDark_ ::
+  forall p i.
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonDark_ = buttonDark []
 
-buttonDarkCenter
-  :: ∀ p i
-   . Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i)
-  -> Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonDarkCenter ::
+  forall p i.
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i) ->
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonDarkCenter =
   buttonGroupBuilder $ buttonDarkClasses <> centerClasses
 
-buttonDarkCenter_
-  :: ∀ p i
-   . Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonDarkCenter_ ::
+  forall p i.
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonDarkCenter_ = buttonDarkCenter []
 
 buttonDarkClasses :: Array Halogen.HTML.ClassName
@@ -229,58 +227,58 @@ buttonDarkClasses = Halogen.HTML.ClassName <$>
   , "text-white"
   ]
 
-buttonDarkLeft
-  :: ∀ p i
-   . Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i)
-  -> Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonDarkLeft ::
+  forall p i.
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i) ->
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonDarkLeft =
   buttonGroupBuilder $ buttonDarkClasses <> leftClasses
 
-buttonDarkLeft_
-  :: ∀ p i
-   . Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonDarkLeft_ ::
+  forall p i.
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonDarkLeft_ = buttonDarkLeft []
 
-buttonDarkRight
-  :: ∀ p i
-   . Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i)
-  -> Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonDarkRight ::
+  forall p i.
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i) ->
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonDarkRight =
   buttonGroupBuilder $ buttonDarkClasses <> rightClasses
 
-buttonDarkRight_
-  :: ∀ p i
-   . Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonDarkRight_ ::
+  forall p i.
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonDarkRight_ = buttonDarkRight []
 
-buttonGroup
-  :: ∀ p i
-   . Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLdiv i)
-  -> Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonGroup ::
+  forall p i.
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLdiv i) ->
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonGroup iprops =
   Halogen.HTML.div
-    ( [ Halogen.HTML.Properties.classes buttonGroupClasses ] <&> iprops )
+    ([ Halogen.HTML.Properties.classes buttonGroupClasses ] <&> iprops)
 
-buttonGroup_
-  :: ∀ p i
-   . Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonGroup_ ::
+  forall p i.
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonGroup_ = buttonGroup []
 
-buttonGroupBuilder
-  :: ∀ p i
-   . Array Halogen.HTML.ClassName
-  -> Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i)
-  -> Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonGroupBuilder ::
+  forall p i.
+  Array Halogen.HTML.ClassName ->
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i) ->
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonGroupBuilder classes iprops =
   Halogen.HTML.button
-    ( [ Halogen.HTML.Properties.classes $ buttonSharedClasses <> classes ] <&> iprops )
+    ([ Halogen.HTML.Properties.classes $ buttonSharedClasses <> classes ] <&> iprops)
 
 buttonGroupClasses :: Array Halogen.HTML.ClassName
 buttonGroupClasses = Halogen.HTML.ClassName <$>
@@ -288,53 +286,53 @@ buttonGroupClasses = Halogen.HTML.ClassName <$>
   , "items-center"
   ]
 
-buttonLeft
-  :: ∀ p i
-   . Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i)
-  -> Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonLeft ::
+  forall p i.
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i) ->
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonLeft =
   buttonGroupBuilder $ buttonClasses <> leftClasses
 
-buttonLeft_
-  :: ∀ p i
-   . Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonLeft_ ::
+  forall p i.
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonLeft_ = buttonLeft []
 
 buttonMainClasses :: Array Halogen.HTML.ClassName
 buttonMainClasses = buttonSharedClasses <>
   ( Halogen.HTML.ClassName <$>
-    [ "rounded"
-    ]
+      [ "rounded"
+      ]
   )
 
-buttonPrimary
-  :: ∀ p i
-   . Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i)
-  -> Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonPrimary ::
+  forall p i.
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i) ->
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonPrimary =
   buttonBuilder buttonPrimaryClasses
 
-buttonPrimary_
-  :: ∀ p i
-   . Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonPrimary_ ::
+  forall p i.
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonPrimary_ = buttonPrimary []
 
-buttonPrimaryCenter
-  :: ∀ p i
-   . Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i)
-  -> Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonPrimaryCenter ::
+  forall p i.
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i) ->
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonPrimaryCenter =
   buttonGroupBuilder $ buttonPrimaryClasses <> centerClasses
 
-buttonPrimaryCenter_
-  :: ∀ p i
-   . Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonPrimaryCenter_ ::
+  forall p i.
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonPrimaryCenter_ = buttonPrimaryCenter []
 
 buttonPrimaryClasses :: Array Halogen.HTML.ClassName
@@ -346,46 +344,46 @@ buttonPrimaryClasses = Halogen.HTML.ClassName <$>
   , "text-white"
   ]
 
-buttonPrimaryLeft
-  :: ∀ p i
-   . Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i)
-  -> Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonPrimaryLeft ::
+  forall p i.
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i) ->
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonPrimaryLeft =
   buttonGroupBuilder $ buttonPrimaryClasses <> leftClasses
 
-buttonPrimaryLeft_
-  :: ∀ p i
-   . Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonPrimaryLeft_ ::
+  forall p i.
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonPrimaryLeft_ = buttonPrimaryLeft []
 
-buttonPrimaryRight
-  :: ∀ p i
-   . Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i)
-  -> Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonPrimaryRight ::
+  forall p i.
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i) ->
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonPrimaryRight =
   buttonGroupBuilder $ buttonPrimaryClasses <> rightClasses
 
-buttonPrimaryRight_
-  :: ∀ p i
-   . Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonPrimaryRight_ ::
+  forall p i.
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonPrimaryRight_ = buttonPrimaryRight []
 
-buttonRight
-  :: ∀ p i
-   . Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i)
-  -> Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonRight ::
+  forall p i.
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i) ->
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonRight =
   buttonGroupBuilder $ buttonClasses <> rightClasses
 
-buttonRight_
-  :: ∀ p i
-   . Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+buttonRight_ ::
+  forall p i.
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 buttonRight_ = buttonRight []
 
 buttonSharedClasses :: Array Halogen.HTML.ClassName
@@ -425,7 +423,7 @@ pill ::
     , props :: Array (IProp r i)
     , style :: PillStyle
     ) =>
-  Halogen.HTML.Elements.Node ( class :: String | r ) p i ->
+  Halogen.HTML.Elements.Node (class :: String | r) p i ->
   Record options ->
   Array (Halogen.HTML.HTML p i) ->
   Halogen.HTML.HTML p i
@@ -435,17 +433,17 @@ pill elem optionsRecord html =
       Nothing -> html
       Just (Left decorator) ->
         Data.Array.cons
-          ( Halogen.HTML.span 
-            [ Ocelot.HTML.Properties.css "pr-2" ]
-            [ decorator ]
-          ) 
+          ( Halogen.HTML.span
+              [ Ocelot.HTML.Properties.css "pr-2" ]
+              [ decorator ]
+          )
           html
       Just (Right decorator) ->
         Data.Array.snoc
           html
-          ( Halogen.HTML.span 
-            [ Ocelot.HTML.Properties.css "pl-2" ]
-            [ decorator ]
+          ( Halogen.HTML.span
+              [ Ocelot.HTML.Properties.css "pl-2" ]
+              [ decorator ]
           )
   where
   classes :: Array Halogen.HTML.ClassName
@@ -477,7 +475,7 @@ pill elem optionsRecord html =
 
 pill_ ::
   forall i r p.
-  Halogen.HTML.Elements.Node ( class :: String | r ) p i ->
+  Halogen.HTML.Elements.Node (class :: String | r) p i ->
   Array (Halogen.HTML.HTML p i) ->
   Halogen.HTML.HTML p i
 pill_ elem = pill elem {}
@@ -524,7 +522,7 @@ pillButton_ = pillButton {}
 
 pillClasses :: Array Halogen.HTML.ClassName
 pillClasses = Halogen.HTML.ClassName <$>
-  [ "bg-grey-97" 
+  [ "bg-grey-97"
   , "border"
   , "border-grey-70"
   , "flex"
@@ -533,7 +531,7 @@ pillClasses = Halogen.HTML.ClassName <$>
 
 pillPrimaryClasses :: Array Halogen.HTML.ClassName
 pillPrimaryClasses = Halogen.HTML.ClassName <$>
-  [ "bg-blue-88-a40" 
+  [ "bg-blue-88-a40"
   , "border"
   , "border-blue-75"
   ]

--- a/src/Clipboard.purs
+++ b/src/Clipboard.purs
@@ -23,22 +23,18 @@ import Web.HTML as Web.HTML
 import Web.HTML.Navigator as Web.HTML.Navigator
 import Web.HTML.Window as Web.HTML.Window
 
-type Slot
-  = Halogen.Slot Query Output
+type Slot = Halogen.Slot Query Output
 
-type Component m
-  = Halogen.Component Query Input Output m
+type Component m = Halogen.Component Query Input Output m
 
-type ComponentHTML m
-  = Halogen.ComponentHTML Action ChildSlot m
+type ComponentHTML m = Halogen.ComponentHTML Action ChildSlot m
 
-type ComponentM m
-  = Halogen.HalogenM State Action ChildSlot Output m
+type ComponentM m = Halogen.HalogenM State Action ChildSlot Output m
 
-type State
-  = { copied :: Boolean
-    , input :: Input
-    }
+type State =
+  { copied :: Boolean
+  , input :: Input
+  }
 
 data Action
   = Copy
@@ -46,14 +42,11 @@ data Action
 
 data Query (a :: Type)
 
-type Input
-  = { text :: String }
+type Input = { text :: String }
 
-type Output
-  = Void
+type Output = Void
 
-type ChildSlot
-  = () :: Row Type
+type ChildSlot = () :: Row Type
 
 component ::
   forall m.
@@ -138,7 +131,7 @@ renderDone =
   Ocelot.Button.button
     [ Halogen.HTML.Propetires.disabled true ]
     [ Ocelot.Block.Icon.success
-        [ Ocelot.HTML.Properties.css "text-green"]
+        [ Ocelot.HTML.Properties.css "text-green" ]
     , Halogen.HTML.span
         [ Ocelot.HTML.Properties.css "ml-2" ]
         [ Halogen.HTML.text "Copied" ]

--- a/src/Components/MultiInput/Component.purs
+++ b/src/Components/MultiInput/Component.purs
@@ -213,11 +213,11 @@ handleEditItem index = do
         $ measureTextWidth text
     void <<< Control.Monad.Maybe.Trans.lift
       $ updateItem index
-        ( \item -> case item of
-            Display _ -> Edit { inputBox: { text, width }, previous: text }
-            Edit _ -> item
-            New _ -> item
-        )
+          ( \item -> case item of
+              Display _ -> Edit { inputBox: { text, width }, previous: text }
+              Edit _ -> item
+              New _ -> item
+          )
     Control.Monad.Maybe.Trans.lift
       $ focusItem index
 
@@ -249,10 +249,10 @@ handleOnFocus index = do
     Just item -> case item of
       Display _ -> pure unit
       Edit { inputBox: { text } } -> do
-        Halogen.raise (On (ValueInput text ))
+        Halogen.raise (On (ValueInput text))
         Halogen.raise (On Focus)
-      New { inputBox: { text }} -> do
-        Halogen.raise (On (ValueInput text ))
+      New { inputBox: { text } } -> do
+        Halogen.raise (On (ValueInput text))
         Halogen.raise (On Focus)
 
 handleOnInput ::
@@ -265,22 +265,22 @@ handleOnInput index text = do
   minWidth <- Halogen.gets _.input.minWidth
   void
     $ updateItem index
-      ( \item -> case item of
-          Display _ -> item
-          Edit status -> Edit status { inputBox { text = text } }
-          New status -> New status { inputBox { text = text } }
-      )
+        ( \item -> case item of
+            Display _ -> item
+            Edit status -> Edit status { inputBox { text = text } }
+            New status -> New status { inputBox { text = text } }
+        )
   void $ Control.Monad.Maybe.Trans.runMaybeT do
     width <-
       Control.Monad.Maybe.Trans.MaybeT
         $ measureTextWidth text
     Control.Monad.Maybe.Trans.lift
       $ updateItem index
-        ( \item -> case item of
+          ( \item -> case item of
               Display _ -> item
               Edit status -> Edit status { inputBox { width = width } }
               New status -> New status { inputBox { width = max minWidth width } }
-        )
+          )
   Halogen.raise (On (ValueInput text))
 
 handleOnKeyDown ::
@@ -374,7 +374,7 @@ blurItem index = do
   void $ Control.Monad.Maybe.Trans.runMaybeT do
     htmlElement <-
       Control.Monad.Maybe.Trans.MaybeT
-      $ Halogen.getHTMLElementRef (inputRef index)
+        $ Halogen.getHTMLElementRef (inputRef index)
     Halogen.liftEffect
       $ Web.HTML.HTMLElement.blur htmlElement
 
@@ -387,12 +387,12 @@ calibratePlaceholderWidth = do
   void $ Control.Monad.Maybe.Trans.runMaybeT do
     width <-
       Control.Monad.Maybe.Trans.MaybeT
-      $ measureTextWidth state.placeholder.primary.text
+        $ measureTextWidth state.placeholder.primary.text
     Halogen.modify _ { placeholder { primary { width = width } } }
   void $ Control.Monad.Maybe.Trans.runMaybeT do
     width <-
       Control.Monad.Maybe.Trans.MaybeT
-      $ measureTextWidth state.placeholder.secondary.text
+        $ measureTextWidth state.placeholder.secondary.text
     Halogen.modify_ _ { placeholder { secondary { width = width } } }
 
 cancelEditing ::
@@ -429,19 +429,19 @@ commitEditing index = do
         Display _ -> pure unit
         Edit { inputBox: { text }, previous }
           | Data.String.null text -> do
-            removeItem index
-            raiseItemUpdated
+              removeItem index
+              raiseItemUpdated
           | otherwise -> do
-            void $ updateItem index (\_ -> Display { text })
-            Halogen.raise (ItemRemoved previous)
-            raiseItemUpdated
+              void $ updateItem index (\_ -> Display { text })
+              Halogen.raise (ItemRemoved previous)
+              raiseItemUpdated
         New { inputBox: { text } }
           | Data.String.null text -> pure unit
           | otherwise -> do
-            new <- updateItem index (\_ -> Display { text })
-            when (isLastIndex index new.items) do
-              appendNewItem
-            raiseItemUpdated
+              new <- updateItem index (\_ -> Display { text })
+              when (isLastIndex index new.items) do
+                appendNewItem
+              raiseItemUpdated
 
 focusItem ::
   forall m.
@@ -452,7 +452,7 @@ focusItem index = do
   void $ Control.Monad.Maybe.Trans.runMaybeT do
     htmlElement <-
       Control.Monad.Maybe.Trans.MaybeT
-      $ Halogen.getHTMLElementRef (inputRef index)
+        $ Halogen.getHTMLElementRef (inputRef index)
     Halogen.liftEffect
       $ Web.HTML.HTMLElement.focus htmlElement
 
@@ -495,13 +495,13 @@ removeItem index = do
           _
             { items =
                 Data.Array.deleteAt index old.items
-                # fromMaybe old.items
+                  # fromMaybe old.items
             }
       case getText item of
         Nothing -> pure unit
         Just text -> Halogen.raise (ItemRemoved text)
       when (Data.Array.null new.items) do
-          appendNewItem
+        appendNewItem
 
 selectItem ::
   forall m.
@@ -512,7 +512,7 @@ selectItem text = do
   old <- Halogen.get
   mWidth <- measureTextWidth text
   case
-    {index: _, width: _ }
+    { index: _, width: _ }
       <$> Data.Array.findIndex isEditable old.items
       <*> mWidth
     of
@@ -520,9 +520,9 @@ selectItem text = do
     Just { index, width } -> do
       void $ updateItem index
         ( \item -> case item of
-             Display _ -> item
-             Edit status -> Edit status { inputBox = { width, text } }
-             New status -> New status { inputBox = { width, text } }
+            Display _ -> item
+            Edit status -> Edit status { inputBox = { width, text } }
+            New status -> New status { inputBox = { width, text } }
         )
       commitEditing index
       when (isLastIndex index old.items) do
@@ -570,7 +570,7 @@ render ::
   ComponentHTML m
 render state =
   Halogen.HTML.div
-    [ Halogen.HTML.Properties.classes containerClasses  ]
+    [ Halogen.HTML.Properties.classes containerClasses ]
     [ Halogen.HTML.div
         [ Ocelot.HTML.Properties.css "flex flex-wrap items-start" ]
         (Data.FunctorWithIndex.mapWithIndex (renderItem state.placeholder) state.items)
@@ -670,10 +670,10 @@ renderAutoSizeInput placeholder index new inputBox =
   width :: Number
   width
     | Data.String.null inputBox.text && new =
-      if index == 0 then
-        placeholder.primary.width
-      else
-        placeholder.secondary.width
+        if index == 0 then
+          placeholder.primary.width
+        else
+          placeholder.secondary.width
     | otherwise = inputBox.width
 
 renderTextWidth ::

--- a/src/Components/MultiInput/TextWidth.purs
+++ b/src/Components/MultiInput/TextWidth.purs
@@ -34,21 +34,17 @@ type State =
   , text :: String
   }
 
-data Action
-  = Receive Input
+data Action = Receive Input
 
-data Query (a :: Type)
-  = GetWidth String (Number -> a)
+data Query (a :: Type) = GetWidth String (Number -> a)
 
 type Input =
   { renderText :: String -> Halogen.HTML.PlainHTML
   }
 
-type Output
-  = Void
+type Output = Void
 
-type ChildSlots
-  = () :: Row Type
+type ChildSlots = () :: Row Type
 
 component ::
   forall m.

--- a/src/Components/SearchBar.purs
+++ b/src/Components/SearchBar.purs
@@ -34,15 +34,13 @@ type Debouncer =
   , fiber :: Fiber Unit
   }
 
-
 data Action
   = Clear ME.MouseEvent
   | Search String
   | Open
   | Blur
 
-data Query (a :: Type)
-  = SetText String a
+data Query (a :: Type) = SetText String a
 
 type Slot = H.Slot Query Message
 
@@ -52,11 +50,10 @@ type Input' =
   , keepOpen :: Boolean
   }
 
-data Message
- = Searched String
+data Message = Searched String
 
 -- | The standard search bar
-component :: ∀ m. MonadAff m => H.Component Query Input Message m
+component :: forall m. MonadAff m => H.Component Query Input Message m
 component =
   H.mkComponent
     { initialState
@@ -65,18 +62,18 @@ component =
     }
 
   where
-    initialState :: Input -> State
-    initialState { debounceTime } =
-      { query: ""
-      , debouncer: Nothing
-      , debounceTime: fromMaybe (Milliseconds 0.0) debounceTime
-      , open: false
-      , keepOpen: false
-      }
+  initialState :: Input -> State
+  initialState { debounceTime } =
+    { query: ""
+    , debouncer: Nothing
+    , debounceTime: fromMaybe (Milliseconds 0.0) debounceTime
+    , open: false
+    , keepOpen: false
+    }
 
 -- | A search bar which allows the user to specify if it should
 -- | stay open when unfocused
-component' :: ∀ m. MonadAff m => H.Component Query Input' Message m
+component' :: forall m. MonadAff m => H.Component Query Input' Message m
 component' =
   H.mkComponent
     { initialState
@@ -85,16 +82,17 @@ component' =
     }
 
   where
-    initialState :: Input' -> State
-    initialState { debounceTime, keepOpen } =
-      { query: ""
-      , debouncer: Nothing
-      , debounceTime: fromMaybe (Milliseconds 0.0) debounceTime
-      , open: keepOpen
-      , keepOpen
-      }
+  initialState :: Input' -> State
+  initialState { debounceTime, keepOpen } =
+    { query: ""
+    , debouncer: Nothing
+    , debounceTime: fromMaybe (Milliseconds 0.0) debounceTime
+    , open: keepOpen
+    , keepOpen
+    }
 
-handleAction :: forall m.
+handleAction ::
+  forall m.
   MonadAff m =>
   Action ->
   H.HalogenM State Action () Message m Unit
@@ -136,9 +134,10 @@ handleAction = case _ of
           delay st.debounceTime
           AVar.put str var
 
-        H.modify_ _ { debouncer = Just { var, fiber: fiber' }}
+        H.modify_ _ { debouncer = Just { var, fiber: fiber' } }
 
-handleQuery :: forall m a.
+handleQuery ::
+  forall m a.
   MonadAff m =>
   Query a ->
   H.HalogenM State Action () Message m (Maybe a)
@@ -150,21 +149,24 @@ handleQuery = case _ of
     openIfHasQuery str
     pure $ Just a
 
-openIfHasQuery :: forall m.
+openIfHasQuery ::
+  forall m.
   MonadState State m =>
   String ->
   m Unit
 openIfHasQuery q =
   if null q then pure unit else H.modify_ _ { open = true }
 
-closeIfNullQuery :: forall m.
+closeIfNullQuery ::
+  forall m.
   MonadState State m =>
   String ->
   m Unit
 closeIfNullQuery q = do
   if null q then H.modify_ \st -> st { open = st.keepOpen } else pure unit
 
-render :: forall m.
+render ::
+  forall m.
   MonadAff m =>
   State ->
   H.ComponentHTML Action () m
@@ -174,82 +176,82 @@ render st@{ query, open } =
     , HE.onClick \_ -> Open
     ]
     [ HH.div
-      [ HP.classes $ iconClasses <> iconCondClasses ]
-      [ Icon.search_ ]
+        [ HP.classes $ iconClasses <> iconCondClasses ]
+        [ Icon.search_ ]
     , HH.div
-      [ css "flex-grow" ]
-      [ HH.input
-        [ HE.onValueInput Search
-        , HP.placeholder "Search"
-        , HP.value query
-        , HP.classes $ inputClasses <> inputCondClasses
-        , HE.onBlur \_ -> Blur
-        , HP.tabIndex 0
+        [ css "flex-grow" ]
+        [ HH.input
+            [ HE.onValueInput Search
+            , HP.placeholder "Search"
+            , HP.value query
+            , HP.classes $ inputClasses <> inputCondClasses
+            , HE.onBlur \_ -> Blur
+            , HP.tabIndex 0
+            ]
         ]
-      ]
     , HH.button
-      [ HE.onClick Clear
-      , HP.type_ HP.ButtonButton
-      , HP.classes $ buttonClasses <> buttonCondClasses <> hideClearClasses
-      ]
-      [ Icon.delete_ ]
+        [ HE.onClick Clear
+        , HP.type_ HP.ButtonButton
+        , HP.classes $ buttonClasses <> buttonCondClasses <> hideClearClasses
+        ]
+        [ Icon.delete_ ]
     ]
-   where
-     containerClasses = HH.ClassName <$>
-       [ "flex"
-       , "no-outline"
-       , "items-stretch"
-       , "transition-1/4"
-       , "border-b-2"
-       , "group"
-       ]
+  where
+  containerClasses = HH.ClassName <$>
+    [ "flex"
+    , "no-outline"
+    , "items-stretch"
+    , "transition-1/4"
+    , "border-b-2"
+    , "group"
+    ]
 
-     containerCondClasses =
-       ifOpen
-         [ "max-w-160", "border-blue-88" ]
-         [ "max-w-12", "border-transparent", "cursor-pointer" ]
+  containerCondClasses =
+    ifOpen
+      [ "max-w-160", "border-blue-88" ]
+      [ "max-w-12", "border-transparent", "cursor-pointer" ]
 
-     iconClasses = HH.ClassName <$>
-       [ "pr-3"
-       , "text-2xl"
-       , "group-hover:text-grey-50"
-       , "transition-1/4"
-       ]
+  iconClasses = HH.ClassName <$>
+    [ "pr-3"
+    , "text-2xl"
+    , "group-hover:text-grey-50"
+    , "transition-1/4"
+    ]
 
-     iconCondClasses =
-       ifOpen
-         [ "text-grey-50", "mb-0", "mt-0" ]
-         [ "text-grey-70", "-mb-1", "mt-1" ]
+  iconCondClasses =
+    ifOpen
+      [ "text-grey-50", "mb-0", "mt-0" ]
+      [ "text-grey-70", "-mb-1", "mt-1" ]
 
-     inputClasses = HH.ClassName <$>
-       [ "no-outline"
-       , "flex-1"
-       , "bg-transparent"
-       , "h-full"
-       , "transition-1/4"
-       ]
+  inputClasses = HH.ClassName <$>
+    [ "no-outline"
+    , "flex-1"
+    , "bg-transparent"
+    , "h-full"
+    , "transition-1/4"
+    ]
 
-     inputCondClasses =
-       ifOpen
-         [ "w-full" ]
-         [ "w-0" ]
+  inputCondClasses =
+    ifOpen
+      [ "w-full" ]
+      [ "w-0" ]
 
-     buttonClasses = HH.ClassName <$>
-       [ "no-outline"
-       , "text-grey-70"
-       , "hover:text-grey-50"
-       , "text-xs"
-       , "transition-1/4"
-       , "flex-shrink"
-       ]
+  buttonClasses = HH.ClassName <$>
+    [ "no-outline"
+    , "text-grey-70"
+    , "hover:text-grey-50"
+    , "text-xs"
+    , "transition-1/4"
+    , "flex-shrink"
+    ]
 
-     buttonCondClasses =
-       ifOpen
-         [ "opacity-100", "visible" ]
-         [ "opacity-0", "invisible" ]
+  buttonCondClasses =
+    ifOpen
+      [ "opacity-100", "visible" ]
+      [ "opacity-0", "invisible" ]
 
-     hideClearClasses = HH.ClassName <$>
-       if Data.String.null st.query then ["hidden"] else []
+  hideClearClasses = HH.ClassName <$>
+    if Data.String.null st.query then [ "hidden" ] else []
 
-     ifOpen openClasses closedClasses =
-       HH.ClassName <$> if open then openClasses else closedClasses
+  ifOpen openClasses closedClasses =
+    HH.ClassName <$> if open then openClasses else closedClasses

--- a/src/Data/DateTime.purs
+++ b/src/Data/DateTime.purs
@@ -19,7 +19,6 @@ import Data.Time.Duration (Days(..), Hours(..), Minutes(..), negateDuration)
 import Data.Tuple (Tuple(..), snd)
 import Partial.Unsafe (unsafePartial)
 
-
 ----------
 -- Defaults
 defaultTime :: Time
@@ -30,7 +29,7 @@ defaultDate = unsafeMkDate 2000 1 1
 
 -- Array of 23 hour intervals, and one 59 min one
 defaultTimeRange :: Array Time
-defaultTimeRange = hourRange defaultTime 23 <> [prevMinute defaultTime]
+defaultTimeRange = hourRange defaultTime 23 <> [ prevMinute defaultTime ]
 
 ----------
 -- Time Ranges
@@ -39,10 +38,9 @@ defaultTimeRange = hourRange defaultTime 23 <> [prevMinute defaultTime]
 hourRange :: Time -> Int -> Array Time
 hourRange start hrs = go start 0 []
   where
-    go cur count acc
-      | count == hrs = acc <> [cur]
-      | otherwise    = go (nextHour cur) (count + 1) (acc <> [cur])
-
+  go cur count acc
+    | count == hrs = acc <> [ cur ]
+    | otherwise = go (nextHour cur) (count + 1) (acc <> [ cur ])
 
 ----------
 -- Date Ranges
@@ -51,8 +49,8 @@ hourRange start hrs = go start 0 []
 monthRange :: Year -> Month -> Array Date
 monthRange y m = dateRange start end
   where
-    start = firstDateOfMonth y m
-    end   = lastDateOfMonth y m
+  start = firstDateOfMonth y m
+  end = lastDateOfMonth y m
 
 -- Provided two dates, generates the range (inclusive) between them.
 -- Note: Preserves ordering. If you provide a future then past date,
@@ -60,11 +58,10 @@ monthRange y m = dateRange start end
 dateRange :: Date -> Date -> Array Date
 dateRange = \s e -> go s e []
   where
-    go start end acc
-      | start == end = reverse $ [start] <> acc
-      | start >  end = reverse $ go end start acc
-      | otherwise    = go (nextDay start) end ([start] <> acc)
-
+  go start end acc
+    | start == end = reverse $ [ start ] <> acc
+    | start > end = reverse $ go end start acc
+    | otherwise = go (nextDay start) end ([ start ] <> acc)
 
 ----------
 -- Time Manipulation
@@ -74,7 +71,6 @@ nextHour = snd <<< T.adjust (Hours 1.0)
 prevMinute :: Time -> Time
 prevMinute = snd <<< T.adjust (negateDuration $ Minutes 1.0)
 
-
 ----------
 -- Conditional Selections
 
@@ -83,7 +79,6 @@ firstDateOfMonth y m = canonicalDate y m bottom
 
 lastDateOfMonth :: Year -> Month -> Date
 lastDateOfMonth y m = canonicalDate y m (lastDayOfMonth y m)
-
 
 ----------
 -- Round
@@ -103,8 +98,8 @@ prevDay = adjustDaysBy (-1.0)
 adjustDaysBy :: Number -> Date -> Date
 adjustDaysBy n = unsafePartial fromJust <<< next n
   where
-    next :: Number -> Date -> Maybe Date
-    next dur d = DT.date <$> (DT.adjust (Days dur) (toDateTime $ fromDate d))
+  next :: Number -> Date -> Maybe Date
+  next dur d = DT.date <$> (DT.adjust (Days dur) (toDateTime $ fromDate d))
 
 -- Months
 -- Note: Attempts to preserve the same day, but due to the use of
@@ -112,12 +107,12 @@ adjustDaysBy n = unsafePartial fromJust <<< next n
 nextMonth :: Date -> Date
 nextMonth d = case (month d) of
   December -> canonicalDate (unsafeSucc (year d)) January (day d)
-  _    -> canonicalDate (year d) (unsafeSucc (month d)) (day d)
+  _ -> canonicalDate (year d) (unsafeSucc (month d)) (day d)
 
 prevMonth :: Date -> Date
 prevMonth d = case (month d) of
   January -> canonicalDate (unsafePred (year d)) December (day d)
-  _   -> canonicalDate (year d) (unsafePred (month d)) (day d)
+  _ -> canonicalDate (year d) (unsafePred (month d)) (day d)
 
 -- Years
 -- Note: Attempts to preserve the same day, but due to the use of
@@ -130,12 +125,14 @@ prevYear :: Date -> Date
 prevYear d = canonicalDate (unsafePred (year d)) (month d) (day d)
 
 yearsForward :: Int -> Date -> Date
-yearsForward n d | n <= 0    = d
-                 | otherwise = yearsForward (n - 1) (nextYear d)
+yearsForward n d
+  | n <= 0 = d
+  | otherwise = yearsForward (n - 1) (nextYear d)
 
 yearsBackward :: Int -> Date -> Date
-yearsBackward n d | n <= 0   = d
-                  | otherwise = yearsBackward (n - 1) (prevYear d)
+yearsBackward n d
+  | n <= 0 = d
+  | otherwise = yearsBackward (n - 1) (prevYear d)
 
 extractYearMonth :: Date -> Tuple Year Month
 extractYearMonth d = Tuple (year d) (month d)
@@ -151,8 +148,7 @@ formatDate :: Date -> String
 formatDate = Formatter.format readableFormat <<< flip DateTime defaultTime
 
 readableFormat :: Formatter
-readableFormat
-  = Formatter.DayOfWeekNameShort
+readableFormat = Formatter.DayOfWeekNameShort
   : Formatter.Placeholder ", "
   : Formatter.MonthShort
   : Formatter.Placeholder " "
@@ -168,10 +164,10 @@ readableFormat
 -- you are providing is valid; they buy you some convenience.
 
 -- Pred & Succ
-unsafeSucc :: ∀ a. Enum a => a -> a
+unsafeSucc :: forall a. Enum a => a -> a
 unsafeSucc = unsafePartial fromJust <<< succ
 
-unsafePred :: ∀ a. Enum a => a -> a
+unsafePred :: forall a. Enum a => a -> a
 unsafePred = unsafePartial fromJust <<< pred
 
 -- Provide a year, month, and day to construct a date. Due to the
@@ -180,9 +176,9 @@ unsafePred = unsafePartial fromJust <<< pred
 unsafeMkDate :: Int -> Int -> Int -> Date
 unsafeMkDate y m d = canonicalDate year month day
   where
-    year  = unsafeMkYear y
-    month = unsafeMkMonth m
-    day   = unsafeMkDay d
+  year = unsafeMkYear y
+  month = unsafeMkMonth m
+  day = unsafeMkDay d
 
 unsafeMkYear :: Int -> Year
 unsafeMkYear = unsafePartial fromJust <<< toEnum
@@ -196,10 +192,10 @@ unsafeMkDay = unsafePartial fromJust <<< toEnum
 unsafeMkTime :: Int -> Int -> Int -> Int -> Time
 unsafeMkTime h m s ms = Time hour minute second millisecond
   where
-    hour        = unsafeMkHour h
-    minute      = unsafeMkMinute m
-    second      = unsafeMkSecond s
-    millisecond = unsafeMkMillisecond ms
+  hour = unsafeMkHour h
+  minute = unsafeMkMinute m
+  second = unsafeMkSecond s
+  millisecond = unsafeMkMillisecond ms
 
 unsafeMkHour :: Int -> Hour
 unsafeMkHour = unsafePartial fromJust <<< toEnum

--- a/src/Data/IntervalTree.purs
+++ b/src/Data/IntervalTree.purs
@@ -17,9 +17,9 @@ import Prelude
 import Data.Array as Data.Array
 import Data.FoldableWithIndex as Data.FoldableWithIndex
 import Data.Generic.Rep as Data.Generic.Rep
-import Data.Show.Generic as Data.Show.Generic
 import Data.Map as Data.Map
 import Data.Maybe (Maybe(..))
+import Data.Show.Generic as Data.Show.Generic
 import Data.Tuple as Data.Tuple
 
 type IntervalTree a = Data.Map.Map a IntervalPoint
@@ -67,39 +67,39 @@ insertInterval ::
 insertInterval old { start, end }
   | start >= end = old
   | otherwise = old # mergeStart >>> mergeEnd >>> clearBetween
-  where
-  mergeStart :: IntervalTree a -> IntervalTree a
-  mergeStart xs = case Data.Map.lookup start xs of
-    Nothing -> Data.Map.insert start StartPoint  xs
-    Just intervalPoint -> case intervalPoint of
-      StartPoint -> xs
-      EndPoint -> Data.Map.delete start xs
+      where
+      mergeStart :: IntervalTree a -> IntervalTree a
+      mergeStart xs = case Data.Map.lookup start xs of
+        Nothing -> Data.Map.insert start StartPoint xs
+        Just intervalPoint -> case intervalPoint of
+          StartPoint -> xs
+          EndPoint -> Data.Map.delete start xs
 
-  mergeEnd :: IntervalTree a -> IntervalTree a
-  mergeEnd xs = case Data.Map.lookup end xs of
-    Nothing -> Data.Map.insert end EndPoint xs
-    Just intervalPoint -> case intervalPoint of
-      StartPoint -> Data.Map.delete end xs
-      EndPoint -> xs
+      mergeEnd :: IntervalTree a -> IntervalTree a
+      mergeEnd xs = case Data.Map.lookup end xs of
+        Nothing -> Data.Map.insert end EndPoint xs
+        Just intervalPoint -> case intervalPoint of
+          StartPoint -> Data.Map.delete end xs
+          EndPoint -> xs
 
-  clearBetween :: IntervalTree a -> IntervalTree a
-  clearBetween xs =
-    Data.Map.submap Nothing (Just lowerBound) xs
-      `Data.Map.union` Data.Map.submap (Just upperBound) Nothing xs
+      clearBetween :: IntervalTree a -> IntervalTree a
+      clearBetween xs =
+        Data.Map.submap Nothing (Just lowerBound) xs
+          `Data.Map.union` Data.Map.submap (Just upperBound) Nothing xs
 
-  lowerBound :: a
-  lowerBound = case findGreatestLowerBound start old of
-    Nothing -> start
-    Just greatestLowerBound -> case greatestLowerBound.value of
-      StartPoint -> greatestLowerBound.key
-      EndPoint -> start
+      lowerBound :: a
+      lowerBound = case findGreatestLowerBound start old of
+        Nothing -> start
+        Just greatestLowerBound -> case greatestLowerBound.value of
+          StartPoint -> greatestLowerBound.key
+          EndPoint -> start
 
-  upperBound :: a
-  upperBound = case findLeastUpperBound end old of
-    Nothing -> end
-    Just leastUpperBound -> case leastUpperBound.value of
-      StartPoint -> end
-      EndPoint -> leastUpperBound.key
+      upperBound :: a
+      upperBound = case findLeastUpperBound end old of
+        Nothing -> end
+        Just leastUpperBound -> case leastUpperBound.value of
+          StartPoint -> end
+          EndPoint -> leastUpperBound.key
 
 -- | Get immediate interval around a point
 -- | O(log n)
@@ -169,7 +169,7 @@ toIntervals ::
 toIntervals = partitionsToIntervals <<< partitionIntervalTree
   where
   partitionsToIntervals ::
-    { start :: Array a , end :: Array a } ->
+    { start :: Array a, end :: Array a } ->
     Array { start :: a, end :: a }
   partitionsToIntervals partition =
     map (Data.Tuple.uncurry { start: _, end: _ })

--- a/src/Data/Tree.purs
+++ b/src/Data/Tree.purs
@@ -33,11 +33,11 @@ type ItemPath a = Array a
 
 type IndexPath = Array Int
 
-_selected :: ∀ a. Lens' (Node a) Boolean
+_selected :: forall a. Lens' (Node a) Boolean
 _selected = _Newtype <<< prop (SProxy :: SProxy "selected")
 
-_expanded :: ∀ a. Lens' (Node a) Boolean
+_expanded :: forall a. Lens' (Node a) Boolean
 _expanded = _Newtype <<< prop (SProxy :: SProxy "expanded")
 
-_children :: ∀ a. Lens' (Node a) (Array (Node a))
+_children :: forall a. Lens' (Node a) (Array (Node a))
 _children = _Newtype <<< prop (SProxy :: SProxy "children")

--- a/src/DateTimePicker.purs
+++ b/src/DateTimePicker.purs
@@ -1,4 +1,4 @@
-module Ocelot.DateTimePicker 
+module Ocelot.DateTimePicker
   ( Action
   , ChildSlots
   , Component
@@ -15,6 +15,7 @@ module Ocelot.DateTimePicker
   ) where
 
 import Prelude
+
 import Data.DateTime (Date, DateTime(..), Month, Time, Year)
 import Data.DateTime as Date.DateTime
 import Data.Foldable as Data.Foldable
@@ -131,8 +132,9 @@ handleQuery = case _ of
     void $ H.tell _datepicker unit $ DatePicker.SetDisabled disabled
     void $ H.tell _timepicker unit $ TimePicker.SetDisabled disabled
   SetSelection dateTime a -> Just a <$ do
-    let date' = dateTime <#> Date.DateTime.date
-        time' = dateTime <#> Date.DateTime.time
+    let
+      date' = dateTime <#> Date.DateTime.date
+      time' = dateTime <#> Date.DateTime.time
     void $ H.tell _datepicker unit $ DatePicker.SetSelection date'
     void $ H.tell _timepicker unit $ TimePicker.SetSelection time'
     H.modify_ _ { date = date', time = time' }
@@ -173,46 +175,45 @@ raiseSelectionChanged mInterval mDate mTime = case mInterval of
   mDateTime :: Maybe DateTime
   mDateTime = DateTime <$> mDate <*> mTime
 
-
 render :: forall m. MonadAff m => ComponentRender m
 render state =
   HH.div
     [ css "flex" ]
     [ HH.div
-      [ css "w-1/2 mr-2" ]
-      [ HH.slot _datepicker unit DatePicker.component
-        { disabled: state.disabled
-        , interval: do
-            interval <- state.interval
-            pure
-              { start: interval.start <#> Date.DateTime.date
-              , end: interval.end <#> Date.DateTime.date
-              }
-        , selection: state.date
-        , targetDate: state.targetDate
-        }
-        HandleDate
-      ]
+        [ css "w-1/2 mr-2" ]
+        [ HH.slot _datepicker unit DatePicker.component
+            { disabled: state.disabled
+            , interval: do
+                interval <- state.interval
+                pure
+                  { start: interval.start <#> Date.DateTime.date
+                  , end: interval.end <#> Date.DateTime.date
+                  }
+            , selection: state.date
+            , targetDate: state.targetDate
+            }
+            HandleDate
+        ]
     , HH.div
-      [ css "flex-1" ]
-      [ HH.slot _timepicker unit TimePicker.component
-        { disabled: state.disabled
-        , interval: do
-            interval <- state.interval
-            pure
-              { start:
-                  if (interval.start <#> Date.DateTime.date) == state.date then
-                    interval.start <#> Date.DateTime.time
-                  else
-                    Nothing
-              , end:
-                  if (interval.end <#> Date.DateTime.date) == state.date then
-                    interval.end <#> Date.DateTime.time
-                  else
-                    Nothing
-              }
-        , selection: state.time
-        }
-        HandleTime
-      ]
+        [ css "flex-1" ]
+        [ HH.slot _timepicker unit TimePicker.component
+            { disabled: state.disabled
+            , interval: do
+                interval <- state.interval
+                pure
+                  { start:
+                      if (interval.start <#> Date.DateTime.date) == state.date then
+                        interval.start <#> Date.DateTime.time
+                      else
+                        Nothing
+                  , end:
+                      if (interval.end <#> Date.DateTime.date) == state.date then
+                        interval.end <#> Date.DateTime.time
+                      else
+                        Nothing
+                  }
+            , selection: state.time
+            }
+            HandleTime
+        ]
     ]

--- a/src/Dropdown.purs
+++ b/src/Dropdown.purs
@@ -1,4 +1,4 @@
-module Ocelot.Dropdown 
+module Ocelot.Dropdown
   ( Action
   , ButtonBlock
   , ChildSlots
@@ -29,6 +29,7 @@ module Ocelot.Dropdown
   ) where
 
 import Prelude
+
 import Control.Comonad as Control.Comonad
 import Control.Comonad.Store as Control.Comonad.Store
 import DOM.HTML.Indexed as DOM.HTML.Indexed
@@ -55,55 +56,42 @@ data Action item m
   = PassingOutput (Output item)
   | ReceiveRender (Input item m)
 
-type ButtonBlock p i
-  = Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i)
-  -> Array (Halogen.HTML.HTML p i)
-  -> Halogen.HTML.HTML p i
+type ButtonBlock p i =
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLbutton i) ->
+  Array (Halogen.HTML.HTML p i) ->
+  Halogen.HTML.HTML p i
 
-type ChildSlots item 
-  = ( select :: Select.Slot (Query item) EmbeddedChildSlots (Output item) Unit
-    )
+type ChildSlots item =
+  ( select :: Select.Slot (Query item) EmbeddedChildSlots (Output item) Unit
+  )
 
-type Component item m 
-  = Halogen.Component (Query item) (Input item m) (Output item) m
+type Component item m = Halogen.Component (Query item) (Input item m) (Output item) m
 
-type ComponentHTML item m 
-  = Halogen.ComponentHTML (Action item m) (ChildSlots item) m
+type ComponentHTML item m = Halogen.ComponentHTML (Action item m) (ChildSlots item) m
 
-type ComponentM item m a 
-  = Halogen.HalogenM (StateStore item m) (Action item m) (ChildSlots item) (Output item) m a
+type ComponentM item m a = Halogen.HalogenM (StateStore item m) (Action item m) (ChildSlots item) (Output item) m a
 
-type ComponentRender item m 
-  = State item -> ComponentHTML item m
+type ComponentRender item m = State item -> ComponentHTML item m
 
-type CompositeAction
-  = Select.Action EmbeddedAction
+type CompositeAction = Select.Action EmbeddedAction
 
-type CompositeComponent item m 
-  = Halogen.Component (CompositeQuery item) (CompositeInput item) (Output item) m
+type CompositeComponent item m = Halogen.Component (CompositeQuery item) (CompositeInput item) (Output item) m
 
-type CompositeComponentHTML m 
-  = Halogen.ComponentHTML CompositeAction EmbeddedChildSlots m
+type CompositeComponentHTML m = Halogen.ComponentHTML CompositeAction EmbeddedChildSlots m
 
-type CompositeComponentM item m a 
-  = Halogen.HalogenM (CompositeState item) CompositeAction EmbeddedChildSlots (Output item) m a
+type CompositeComponentM item m a = Halogen.HalogenM (CompositeState item) CompositeAction EmbeddedChildSlots (Output item) m a
 
-type CompositeComponentRender item m 
-  = (CompositeState item) -> CompositeComponentHTML m
+type CompositeComponentRender item m = (CompositeState item) -> CompositeComponentHTML m
 
-type CompositeInput item 
-  = Select.Input (StateRow item)
+type CompositeInput item = Select.Input (StateRow item)
 
-type CompositeQuery item 
-  = Select.Query (Query item) EmbeddedChildSlots
+type CompositeQuery item = Select.Query (Query item) EmbeddedChildSlots
 
-type CompositeState item 
-  = Select.State (StateRow item)
+type CompositeState item = Select.State (StateRow item)
 
 type EmbeddedAction = Void
 
-type EmbeddedChildSlots
-  = () :: Row Type
+type EmbeddedChildSlots = () :: Row Type
 
 type Input item m =
   { disabled :: Boolean
@@ -123,8 +111,7 @@ data Query item a
 
 type Slot item id = Halogen.Slot (Query item) (Output item) id
 
-type Spec item m 
-  = Select.Spec (StateRow item) (Query item) EmbeddedAction EmbeddedChildSlots (CompositeInput item) (Output item) m
+type Spec item m = Select.Spec (StateRow item) (Query item) EmbeddedAction EmbeddedChildSlots (CompositeInput item) (Output item) m
 
 type State item = Record (StateRow item)
 
@@ -139,10 +126,10 @@ type StateStore item m = Control.Comonad.Store.Store (State item) (ComponentHTML
 ------------
 -- Component
 
-component
-  :: forall item m
-  . Effect.Aff.Class.MonadAff m
-  => Component item m
+component ::
+  forall item m.
+  Effect.Aff.Class.MonadAff m =>
+  Component item m
 component = Halogen.mkComponent
   { initialState
   , render: Control.Comonad.extract
@@ -157,40 +144,40 @@ component = Halogen.mkComponent
 
 _select = Proxy :: Proxy "select"
 
-defDropdown
-  :: ∀ item m
-  . Eq item
-  => (∀ p i. ButtonBlock p i)
-  -> Array (Halogen.HTML.Properties.IProp DOM.HTML.Indexed.HTMLbutton CompositeAction)
-  -> (item -> String)
-  -> String
-  -> CompositeComponentRender item m
+defDropdown ::
+  forall item m.
+  Eq item =>
+  (forall p i. ButtonBlock p i) ->
+  Array (Halogen.HTML.Properties.IProp DOM.HTML.Indexed.HTMLbutton CompositeAction) ->
+  (item -> String) ->
+  String ->
+  CompositeComponentRender item m
 defDropdown button props toString label st =
   Halogen.HTML.div [ Ocelot.HTML.Properties.css "relative" ] [ toggle, menu ]
   where
-    toggle =
-      Ocelot.Block.ItemContainer.dropdownButton
-        button
-        (toggleProps st.disabled props)
-        [ Halogen.HTML.text $ Data.Maybe.maybe label toString st.selectedItem ]
+  toggle =
+    Ocelot.Block.ItemContainer.dropdownButton
+      button
+      (toggleProps st.disabled props)
+      [ Halogen.HTML.text $ Data.Maybe.maybe label toString st.selectedItem ]
 
-    menu = Halogen.HTML.div
-      [ Halogen.HTML.Properties.classes containerClasses ]
-      [ Ocelot.Block.ItemContainer.dropdownContainer
+  menu = Halogen.HTML.div
+    [ Halogen.HTML.Properties.classes containerClasses ]
+    [ Ocelot.Block.ItemContainer.dropdownContainer
         []
         (Halogen.HTML.text <<< toString)
         ((==) st.selectedItem <<< Just)
         st.items
         st.highlightedIndex
-      ]
+    ]
 
-    containerClasses = case st.visibility of
-      Select.Off -> [ Halogen.HTML.ClassName "invisible" ]
-      Select.On -> []
+  containerClasses = case st.visibility of
+    Select.Off -> [ Halogen.HTML.ClassName "invisible" ]
+    Select.On -> []
 
 -- Embedded > handleMessage
-embeddedHandleMessage
-  :: forall item m. Effect.Aff.Class.MonadAff m => Select.Event -> CompositeComponentM item m Unit
+embeddedHandleMessage ::
+  forall item m. Effect.Aff.Class.MonadAff m => Select.Event -> CompositeComponentM item m Unit
 embeddedHandleMessage = case _ of
   Select.Selected idx -> do
     { items } <- Halogen.get
@@ -198,7 +185,8 @@ embeddedHandleMessage = case _ of
       Nothing -> pure unit
       Just item -> do
         Halogen.modify_
-          _ { visibility = Select.Off
+          _
+            { visibility = Select.Off
             , selectedItem = Just item
             }
         Halogen.raise $ Selected item
@@ -206,8 +194,8 @@ embeddedHandleMessage = case _ of
   _ -> pure unit
 
 -- Embedded > handleQuery
-embeddedHandleQuery
-  :: forall item m a. Effect.Aff.Class.MonadAff m => Query item a -> CompositeComponentM item m (Maybe a)
+embeddedHandleQuery ::
+  forall item m a. Effect.Aff.Class.MonadAff m => Query item a -> CompositeComponentM item m (Maybe a)
 embeddedHandleQuery = case _ of
   SetDisabled disabled a -> Just a <$ do
     Halogen.modify_ _ { disabled = disabled }
@@ -251,37 +239,37 @@ initialState :: forall item m. Effect.Aff.Class.MonadAff m => Input item m -> St
 initialState { disabled, items, render, selectedItem } =
   Control.Comonad.Store.store (renderAdapter render) { disabled, items, selectedItem }
 
-renderAdapter
-  :: forall item m
-  . Effect.Aff.Class.MonadAff m
-  => CompositeComponentRender item m
-  -> ComponentRender item m
+renderAdapter ::
+  forall item m.
+  Effect.Aff.Class.MonadAff m =>
+  CompositeComponentRender item m ->
+  ComponentRender item m
 renderAdapter render state =
   Halogen.HTML.slot _select unit (Select.component identity $ spec render)
     (embeddedInput state)
     PassingOutput
 
-spec
-  :: forall item m
-  . Effect.Aff.Class.MonadAff m
-  => CompositeComponentRender item m
-  -> Spec item m
+spec ::
+  forall item m.
+  Effect.Aff.Class.MonadAff m =>
+  CompositeComponentRender item m ->
+  Spec item m
 spec embeddedRender =
   Select.defaultSpec
-  { render = embeddedRender
-  , handleQuery = embeddedHandleQuery
-  , handleEvent = embeddedHandleMessage
-  }
+    { render = embeddedRender
+    , handleQuery = embeddedHandleQuery
+    , handleEvent = embeddedHandleMessage
+    }
 
-toggleProps
-  :: Boolean
-  -> Array (Halogen.HTML.Properties.IProp DOM.HTML.Indexed.HTMLbutton CompositeAction)
-  -> Array (Halogen.HTML.Properties.IProp DOM.HTML.Indexed.HTMLbutton CompositeAction)
-toggleProps disabled iprops = if disabled
-  then iprops'
+toggleProps ::
+  Boolean ->
+  Array (Halogen.HTML.Properties.IProp DOM.HTML.Indexed.HTMLbutton CompositeAction) ->
+  Array (Halogen.HTML.Properties.IProp DOM.HTML.Indexed.HTMLbutton CompositeAction)
+toggleProps disabled iprops =
+  if disabled then iprops'
   else Select.Setters.setToggleProps iprops'
   where
-  iprops' = 
+  iprops' =
     [ Halogen.HTML.Properties.disabled disabled
-    ] 
-    <&> iprops
+    ]
+      <&> iprops

--- a/src/FilePicker.purs
+++ b/src/FilePicker.purs
@@ -30,11 +30,11 @@ import Web.HTML.Event.DragEvent as Web.HTML.Event.DragEvent
 -- * multiple
 --   * true: allow selecting multiple files
 --   * false: only allow selecting a single file
-type Config
-  = { accept :: Maybe DOM.HTML.Indexed.InputAcceptType.InputAcceptType
-    , id :: String
-    , multiple :: Boolean
-    }
+type Config =
+  { accept :: Maybe DOM.HTML.Indexed.InputAcceptType.InputAcceptType
+  , id :: String
+  , multiple :: Boolean
+  }
 
 type Slot = Halogen.Slot Query Output
 
@@ -58,8 +58,7 @@ data Query (a :: Type)
 
 type Input = Unit
 
-data Output
-  = Selected (Array Web.File.File.File)
+data Output = Selected (Array Web.File.File.File)
 
 type ChildSlots = () :: Row Type
 
@@ -187,16 +186,16 @@ renderDropBox ::
   ComponentHTML m
 renderDropBox state
   | state.dragOver =
-    Halogen.HTML.div ipropDragOver
-      [ Halogen.HTML.div
-          [ Ocelot.HTMl.Properties.style <<< Foreign.Object.fromHomogeneous $
-            { "pointer-events": "none" } -- NOTE prevent event firing from children
-          ]
-          (renderContent state)
-      ]
+      Halogen.HTML.div ipropDragOver
+        [ Halogen.HTML.div
+            [ Ocelot.HTMl.Properties.style <<< Foreign.Object.fromHomogeneous $
+                { "pointer-events": "none" } -- NOTE prevent event firing from children
+            ]
+            (renderContent state)
+        ]
   | otherwise =
-    Halogen.HTML.div ipropIdle
-      (renderContent state)
+      Halogen.HTML.div ipropIdle
+        (renderContent state)
 
 ipropIdle :: Array (Halogen.HTML.Properties.IProp HTMLdiv Action)
 ipropIdle =
@@ -235,10 +234,10 @@ ipropDragOver =
   styleDragOver :: Foreign.Object.Object String
   styleDragOver =
     Foreign.Object.fromHomogeneous
-    { outline: "2px dashed #8f9eb3"
-    , "outline-offset": "-20px"
-    , transition: "outline-offset .15s ease-in-out, background-color .15s linear"
-    }
+      { outline: "2px dashed #8f9eb3"
+      , "outline-offset": "-20px"
+      , transition: "outline-offset .15s ease-in-out, background-color .15s linear"
+      }
 
 renderContent ::
   forall m.
@@ -249,7 +248,6 @@ renderContent state =
   , renderLabel state
   ]
 
-
 renderIcon ::
   forall m.
   ComponentHTML m
@@ -257,7 +255,7 @@ renderIcon =
   Halogen.HTML.div
     [ Ocelot.HTMl.Properties.css "text-grey-50 text-center w-full" ]
     [ Ocelot.Block.Icon.download
-      [ Ocelot.HTMl.Properties.css "text-5xl" ]
+        [ Ocelot.HTMl.Properties.css "text-5xl" ]
     ]
 
 renderInput ::
@@ -287,12 +285,12 @@ renderLabel state =
     , Halogen.HTML.Properties.for state.config.id
     ]
     [ Halogen.HTML.span
-      [ Ocelot.HTMl.Properties.css "group-hover:text-blue-88" ]
-      [ Halogen.HTML.text
-          if state.config.multiple then
-            "Choose file(s)"
-          else
-            "Choose a file"
-      ]
+        [ Ocelot.HTMl.Properties.css "group-hover:text-blue-88" ]
+        [ Halogen.HTML.text
+            if state.config.multiple then
+              "Choose file(s)"
+            else
+              "Choose a file"
+        ]
     , Halogen.HTML.text " or drag it here."
     ]

--- a/src/HTML/Properties.purs
+++ b/src/HTML/Properties.purs
@@ -15,7 +15,7 @@ import Data.Array (elem, foldl, nubByEq)
 import Data.Bifunctor (lmap, rmap)
 import Data.String (Pattern(..), null, split)
 import Data.String as Data.String
-import Data.String.CodeUnits (length, take, drop)
+import Data.String.CodeUnits (drop, length, take)
 import Data.Tuple (Tuple(..))
 import Foreign.Object as Foreign.Object
 import Halogen.HTML as HH
@@ -27,16 +27,16 @@ import Unsafe.Coerce (unsafeCoerce)
 
 type IProp r i = HH.IProp ("class" :: String | r) i
 
-testId
-  :: ∀ r i
-   . String
-  -> IProp r i
+testId ::
+  forall r i.
+  String ->
+  IProp r i
 testId = HP.attr (HH.AttrName "data-testid")
 
-css
-  :: ∀ r i
-   . String
-  -> IProp r i
+css ::
+  forall r i.
+  String ->
+  IProp r i
 css = HP.class_ <<< HH.ClassName
 
 style :: forall r i. Foreign.Object.Object String -> IProp r i
@@ -44,63 +44,59 @@ style =
   Halogen.HTML.Properties.attr (Halogen.HTML.AttrName "style")
     <<< Data.String.joinWith ";"
     <<< Foreign.Object.foldMap
-        (\key value -> [ key <> ":" <> value ])
+      (\key value -> [ key <> ":" <> value ])
 
-appendIProps
-  :: ∀ r i
-   . Array (IProp r i)
-  -> Array (IProp r i)
-  -> Array (IProp r i)
+appendIProps ::
+  forall r i.
+  Array (IProp r i) ->
+  Array (IProp r i) ->
+  Array (IProp r i)
 appendIProps ip ip' =
   iprops <> iprops' <> classNames
   where
-    (Tuple classes iprops) = extract ip
-    (Tuple classes' iprops') = extract ip'
-    classNames =
-      pure
+  (Tuple classes iprops) = extract ip
+  (Tuple classes' iprops') = extract ip'
+  classNames =
+    pure
       <<< HP.classes
-        $ HH.ClassName
-      <$> nubByEq
-          (\c c' -> classify c == classify c')
-          (classes' <> classes)
+      $ HH.ClassName
+          <$> nubByEq
+            (\c c' -> classify c == classify c')
+            (classes' <> classes)
 
 infixr 5 appendIProps as <&>
 
-extract
-  :: ∀ r i
-   . Array (IProp r i)
-  -> Tuple (Array String) (Array (IProp r i))
+extract ::
+  forall r i.
+  Array (IProp r i) ->
+  Tuple (Array String) (Array (IProp r i))
 extract =
   foldl f (Tuple [] [])
   where
-    f acc (HP.IProp (Property "className" className)) =
-      lmap (_ <> (split (Pattern " ") $ coerceClassName className)) acc
-    f acc iprop = rmap (_ <> [iprop]) acc
+  f acc (HP.IProp (Property "className" className)) =
+    lmap (_ <> (split (Pattern " ") $ coerceClassName className)) acc
+  f acc iprop = rmap (_ <> [ iprop ]) acc
 
-    coerceClassName :: PropValue -> String
-    coerceClassName = unsafeCoerce
+  coerceClassName :: PropValue -> String
+  coerceClassName = unsafeCoerce
 
-classify
-  :: String
-  -> String
+classify ::
+  String ->
+  String
 classify str
-  | startsWith "p" str && not null (classifySide $ drop 1 str)
-    = "padding" <-> classifySide (drop 1 str)
-  | startsWith "m" str && not null (classifySide $ drop 1 str)
-    = "margin" <-> classifySide (drop 1 str)
-  | startsWith "-m" str && not null (classifySide $ drop 2 str)
-    = "margin" <-> classifySide (drop 2 str)
+  | startsWith "p" str && not null (classifySide $ drop 1 str) = "padding" <-> classifySide (drop 1 str)
+  | startsWith "m" str && not null (classifySide $ drop 1 str) = "margin" <-> classifySide (drop 1 str)
+  | startsWith "-m" str && not null (classifySide $ drop 2 str) = "margin" <-> classifySide (drop 2 str)
   | startsWith "min-" str = "min" <-> classify (drop 4 str)
   | startsWith "max-" str = "max" <-> classify (drop 4 str)
   | startsWith "w-" str = "width"
   | startsWith "h-" str = "height"
-  | startsWith "overflow-" str && (classifyOverflow $ drop 9 str) /= drop 9 str
-    = "overflow" <-> (classifyOverflow $ drop 9 str)
+  | startsWith "overflow-" str && (classifyOverflow $ drop 9 str) /= drop 9 str = "overflow" <-> (classifyOverflow $ drop 9 str)
   | otherwise = str
 
-classifySide
-  :: String
-  -> String
+classifySide ::
+  String ->
+  String
 classifySide str
   | startsWith "t-" str = "top"
   | startsWith "r-" str = "right"
@@ -111,27 +107,27 @@ classifySide str
   | startsWith "-" str = "all"
   | otherwise = ""
 
-classifyOverflow
-  :: String
-  -> String
+classifyOverflow ::
+  String ->
+  String
 classifyOverflow str
   | startsWith "x-" str = "horizontal" <-> (classifyOverflow $ drop 2 str)
   | startsWith "y-" str = "vertical" <-> (classifyOverflow $ drop 2 str)
-  | elem str ["auto", "hidden", "visible", "scroll"] = ""
+  | elem str [ "auto", "hidden", "visible", "scroll" ] = ""
   | otherwise = str
 
-append'
-  :: String
-  -> String
-  -> String
+append' ::
+  String ->
+  String ->
+  String
 append' x "" = x
-append' x y  = x <> "-" <> y
+append' x y = x <> "-" <> y
 
 infixr 5 append' as <->
 
 -- | WARN: Not tested, written during 0.12 migration
-startsWith
-  :: String
-  -> String
-  -> Boolean
+startsWith ::
+  String ->
+  String ->
+  Boolean
 startsWith str0 str1 = str0 == (take (length str0) str1)

--- a/src/Interfaces/Dropdown/Interface.purs
+++ b/src/Interfaces/Dropdown/Interface.purs
@@ -1,6 +1,7 @@
 module Ocelot.Interface.Dropdown where
 
 import Prelude
+
 import Control.Promise (Promise, fromAff)
 import Data.Array (head)
 import Data.Maybe (Maybe, fromMaybe)
@@ -15,7 +16,7 @@ import Foreign.Object (Object, lookup)
 import Halogen.VDom.Driver (runUI)
 import Ocelot.Button (button)
 import Ocelot.Dropdown (Input, Output(..), Query(..), component, defDropdown)
-import Ocelot.Interface.Utilities (mkSubscription, Interface)
+import Ocelot.Interface.Utilities (Interface, mkSubscription)
 import Select (Visibility(..)) as Select
 import Web.HTML (HTMLElement)
 
@@ -42,12 +43,11 @@ type ExternalInput =
   , key :: String
   }
 
-
-externalInputToInput
-  :: ∀ m
-   . MonadAff m
-  => ExternalInput
-  -> Input (Object String) m
+externalInputToInput ::
+  forall m.
+  MonadAff m =>
+  ExternalInput ->
+  Input (Object String) m
 externalInputToInput { items, selectedItem, key, placeholder } =
   { disabled: false
   , items
@@ -64,9 +64,9 @@ mountDropdown = mkEffectFn2 \el ext -> do
   pure
     { subscribe: mkSubscription ioVar convertMessageToVariant
     , setItems: mkEffectFn1 \arr -> fromAff do
-       io <- AffAVar.read ioVar
-       io.query $ SetItems arr unit
+        io <- AffAVar.read ioVar
+        io.query $ SetItems arr unit
     , setSelected: mkEffectFn1 \arr -> fromAff do
-       io <- AffAVar.read ioVar
-       io.query $ SetSelection (head arr) unit
+        io <- AffAVar.read ioVar
+        io.query $ SetSelection (head arr) unit
     }

--- a/src/Interfaces/Typeahead/Interface.purs
+++ b/src/Interfaces/Typeahead/Interface.purs
@@ -3,6 +3,7 @@
 module Ocelot.Interface.Typeahead where
 
 import Prelude
+
 import Control.Promise (Promise)
 import Control.Promise as Promise
 import Data.Array (head)
@@ -27,9 +28,9 @@ import Halogen.VDom.Driver (runUI)
 import Html.Renderer.Halogen as Parser
 import Network.RemoteData (RemoteData(..))
 import Ocelot.Block.ItemContainer (boldMatches)
-import Ocelot.Typeahead (Component, Input, Insertable(..), Output(..), Query(..), defFilterFuzzy, defRenderContainer, multi, renderMulti, renderSingle, single, component, renderHeaderSearchDropdown, renderSearchDropdown, renderToolbarSearchDropdown)
 import Ocelot.HTML.Properties (css)
 import Ocelot.Interface.Utilities (Interface, mkSubscription)
+import Ocelot.Typeahead (Component, Input, Insertable(..), Output(..), Query(..), component, defFilterFuzzy, defRenderContainer, multi, renderHeaderSearchDropdown, renderMulti, renderSearchDropdown, renderSingle, renderToolbarSearchDropdown, single)
 import Partial.Unsafe (unsafePartial)
 import Prim.TypeError (class Warn, Text)
 import Web.HTML (HTMLElement)
@@ -65,7 +66,7 @@ convertSingleToMessageVariant :: forall action. Output action Maybe (Object Stri
 convertSingleToMessageVariant = case _ of
   Searched str -> inj (SProxy :: SProxy "searched") str
   Selected obj -> inj (SProxy :: SProxy "selected") obj
-  SelectionChanged _ (Just i) -> inj (SProxy :: SProxy "selectionChanged") [i]
+  SelectionChanged _ (Just i) -> inj (SProxy :: SProxy "selectionChanged") [ i ]
   SelectionChanged _ Nothing -> inj (SProxy :: SProxy "selectionChanged") []
   Emit _ -> inj (SProxy :: SProxy "emit") "emitted"
 
@@ -105,10 +106,10 @@ type DropdownInput =
 
 -- | An adapter to simplify types necessary in JS to control the typeahead
 -- | component. Items are specialized to Object String.
-typeaheadInputToSingleInput
-  :: ∀ m action
-   . TypeaheadInput
-  -> Input action Maybe (Object String) m
+typeaheadInputToSingleInput ::
+  forall m action.
+  TypeaheadInput ->
+  Input action Maybe (Object String) m
 typeaheadInputToSingleInput r =
   { items: Success r.items
   , insertable: if r.insertable then Insertable (Object.singleton r.key) else NotInsertable
@@ -123,14 +124,14 @@ typeaheadInputToSingleInput r =
       (defRenderContainer renderFuzzy)
   }
   where
-    renderFuzzy item@(Fuzzy x) = case Object.lookup r.imageSource x.original of
-      Just src -> span_ ([ img [HP.src src, css "align-text-top h-5 mr-1"] ] <> boldMatches r.key item)
-      Nothing -> span_ (boldMatches r.key item)
+  renderFuzzy item@(Fuzzy x) = case Object.lookup r.imageSource x.original of
+    Just src -> span_ ([ img [ HP.src src, css "align-text-top h-5 mr-1" ] ] <> boldMatches r.key item)
+    Nothing -> span_ (boldMatches r.key item)
 
-typeaheadInputToMultiInput
-  :: ∀ m action
-   . TypeaheadInput
-  -> Input action Array (Object String) m
+typeaheadInputToMultiInput ::
+  forall m action.
+  TypeaheadInput ->
+  Input action Array (Object String) m
 typeaheadInputToMultiInput r =
   { items: Success r.items
   , insertable: if r.insertable then Insertable (Object.singleton r.key) else NotInsertable
@@ -145,14 +146,14 @@ typeaheadInputToMultiInput r =
       (defRenderContainer renderFuzzy)
   }
   where
-    renderFuzzy item@(Fuzzy x) = case Object.lookup r.imageSource x.original of
-      Just src -> span_ ([ img [HP.src src, css "align-text-top h-5 mr-1"] ] <> boldMatches r.key item)
-      Nothing -> span_ (boldMatches r.key item)
+  renderFuzzy item@(Fuzzy x) = case Object.lookup r.imageSource x.original of
+    Just src -> span_ ([ img [ HP.src src, css "align-text-top h-5 mr-1" ] ] <> boldMatches r.key item)
+    Nothing -> span_ (boldMatches r.key item)
 
-dropdownInputToSingleInput
-  :: ∀ m action
-   . DropdownInput
-  -> Input action Maybe (Object String) m
+dropdownInputToSingleInput ::
+  forall m action.
+  DropdownInput ->
+  Input action Maybe (Object String) m
 dropdownInputToSingleInput r =
   { items: Success r.items
   , insertable: NotInsertable
@@ -164,13 +165,13 @@ dropdownInputToSingleInput r =
   , render
   }
   where
-    renderFuzzy = span_ <<< boldMatches r.key
+  renderFuzzy = span_ <<< boldMatches r.key
 
-    render pst = renderSearchDropdown
-      r.resetLabel
-      (Parser.render [] $ r.labelHTML (fromMaybe r.defaultLabel (Object.lookup r.key =<< pst.selected)))
-      renderFuzzy
-      pst
+  render pst = renderSearchDropdown
+    r.resetLabel
+    (Parser.render [] $ r.labelHTML (fromMaybe r.defaultLabel (Object.lookup r.key =<< pst.selected)))
+    renderFuzzy
+    pst
 
 mountMultiTypeahead :: EffectFn2 HTMLElement TypeaheadInput (Interface MessageVariant QueryRow)
 mountMultiTypeahead = mkEffectFn2 \el ext -> do
@@ -209,11 +210,11 @@ mountSingleTypeahead = mkSingleTypeaheadMounter single typeaheadInputToSingleInp
 mountDropdownTypeahead :: EffectFn2 HTMLElement DropdownInput (Interface MessageVariant QueryRow)
 mountDropdownTypeahead = mkSingleTypeaheadMounter single' dropdownInputToSingleInput
 
-mkSingleTypeaheadMounter
-  :: ∀ input action
-   . Component action Maybe (Object String) Aff
-  -> (input -> Input action Maybe (Object String) Aff)
-  -> EffectFn2 HTMLElement input (Interface MessageVariant QueryRow)
+mkSingleTypeaheadMounter ::
+  forall input action.
+  Component action Maybe (Object String) Aff ->
+  (input -> Input action Maybe (Object String) Aff) ->
+  EffectFn2 HTMLElement input (Interface MessageVariant QueryRow)
 mkSingleTypeaheadMounter component inputTransformer = mkEffectFn2 \el ext -> do
   ioVar <- AVar.empty
   launchAff_ do
@@ -243,7 +244,7 @@ mkSingleTypeaheadMounter component inputTransformer = mkEffectFn2 \el ext -> do
         io.query $ Reset unit
     }
 
-single' :: ∀ action item. Eq item => Component action Maybe item Aff
+single' :: forall action item. Eq item => Component action Maybe item Aff
 single' = component
   { runSelect: const <<< Just
   , runRemove: const (const Nothing)
@@ -260,11 +261,11 @@ type SearchDropdownInput =
   , key :: String
   }
 
-searchDropdownInputToHeaderSingleInput
-  :: ∀ m action
-   . Warn (Text "This function is deprecated")
-  => SearchDropdownInput
-  -> Input action Maybe (Object String) m
+searchDropdownInputToHeaderSingleInput ::
+  forall m action.
+  Warn (Text "This function is deprecated") =>
+  SearchDropdownInput ->
+  Input action Maybe (Object String) m
 searchDropdownInputToHeaderSingleInput r =
   { items: Success r.items
   , insertable: NotInsertable
@@ -280,16 +281,16 @@ searchDropdownInputToHeaderSingleInput r =
       renderFuzzy
   }
   where
-    renderFuzzy = span_ <<< boldMatches r.key
+  renderFuzzy = span_ <<< boldMatches r.key
 
-    renderLabel item =
-      HH.text (fromMaybe "" $ Object.lookup r.key item)
+  renderLabel item =
+    HH.text (fromMaybe "" $ Object.lookup r.key item)
 
-searchDropdownInputToToolbarSingleInput
-  :: ∀ m action
-   . Warn (Text "This function is deprecated")
-  => SearchDropdownInput
-  -> Input action Maybe (Object String) m
+searchDropdownInputToToolbarSingleInput ::
+  forall m action.
+  Warn (Text "This function is deprecated") =>
+  SearchDropdownInput ->
+  Input action Maybe (Object String) m
 searchDropdownInputToToolbarSingleInput r =
   { items: Success r.items
   , insertable: NotInsertable
@@ -307,11 +308,10 @@ searchDropdownInputToToolbarSingleInput r =
       renderFuzzy
   }
   where
-    renderFuzzy = span_ <<< boldMatches r.key
+  renderFuzzy = span_ <<< boldMatches r.key
 
-    renderLabel item =
-      HH.text (fromMaybe "" $ Object.lookup r.key item)
-
+  renderLabel item =
+    HH.text (fromMaybe "" $ Object.lookup r.key item)
 
 mountHeaderTypeahead :: EffectFn2 HTMLElement SearchDropdownInput (Interface MessageVariant QueryRow)
 mountHeaderTypeahead = mkSingleTypeaheadMounter single' searchDropdownInputToHeaderSingleInput

--- a/src/Interfaces/Utilities.purs
+++ b/src/Interfaces/Utilities.purs
@@ -14,7 +14,7 @@ import Halogen.Subscription as Halogen.Subscription
 -- | A row containing the 'subscribe' function from Halogen so it
 -- | may be used to subscribe to the message variant in JS.
 type WithHalogen out r =
-  ( subscribe :: EffectFn1 (EffectFn1 out Unit) (Effect Unit) | r )
+  (subscribe :: EffectFn1 (EffectFn1 out Unit) (Effect Unit) | r)
 
 -- | A record containing the various queries available to be
 -- | triggered in JS and the various messages that may be passed
@@ -25,11 +25,11 @@ type Interface messages queries =
 -- | A helper to construct a coroutine for the `subscribe` function, allowing
 -- | JS callers to consume a stream of outputs from the component. For now this
 -- | is specialized to Aff.
-mkSubscription
-  :: ∀ f o o'
-   . AffAVar.AVar (HalogenIO f o Aff)
-  -> (o -> o')
-  -> EffectFn1 (EffectFn1 o' Unit) (Effect Unit)
+mkSubscription ::
+  forall f o o'.
+  AffAVar.AVar (HalogenIO f o Aff) ->
+  (o -> o') ->
+  EffectFn1 (EffectFn1 o' Unit) (Effect Unit)
 mkSubscription ioVar convertMessage = mkEffectFn1 \cb -> do
   fiber <- launchAff do
     io <- AffAVar.read ioVar

--- a/src/Parts/Modal.purs
+++ b/src/Parts/Modal.purs
@@ -24,26 +24,26 @@ import Web.UIEvent.KeyboardEvent.EventTypes as KET
 -- Eval Partials
 
 -- A function that will register an event source on the window
-initializeWith
-  :: ∀ state action slots output m
-   . MonadAff m
-  => (KE.KeyboardEvent -> Maybe action)
-  -> H.HalogenM state action slots output m H.SubscriptionId
+initializeWith ::
+  forall state action slots output m.
+  MonadAff m =>
+  (KE.KeyboardEvent -> Maybe action) ->
+  H.HalogenM state action slots output m H.SubscriptionId
 initializeWith toAction = do
   document <- H.liftEffect $ document =<< window
   H.subscribe
     $ ES.eventListener
-      KET.keydown
-      (HTMLDocument.toEventTarget document)
-      (toAction <=< KE.fromEvent)
+        KET.keydown
+        (HTMLDocument.toEventTarget document)
+        (toAction <=< KE.fromEvent)
 
-whenClose
-  :: ∀ state action slots output m
-   . MonadAff m
-  => KE.KeyboardEvent
-  -> H.SubscriptionId
-  -> H.HalogenM state action slots output m Unit
-  -> H.HalogenM state action slots output m Unit
+whenClose ::
+  forall state action slots output m.
+  MonadAff m =>
+  KE.KeyboardEvent ->
+  H.SubscriptionId ->
+  H.HalogenM state action slots output m Unit ->
+  H.HalogenM state action slots output m Unit
 whenClose ev sid close =
   when (KE.code ev == "Escape") do
     H.unsubscribe sid
@@ -54,27 +54,26 @@ whenClose ev sid close =
 
 -- Modals already come with the ClickOutside event baked in, while
 -- end users are responsible for handling it somehow.
-modal
-  :: ∀ action slots m
-   . action
-  -> Array (HH.IProp HTMLdiv action)
-  -> Array (H.ComponentHTML action slots m)
-  -> H.ComponentHTML action slots m
+modal ::
+  forall action slots m.
+  action ->
+  Array (HH.IProp HTMLdiv action) ->
+  Array (H.ComponentHTML action slots m) ->
+  H.ComponentHTML action slots m
 modal _ iprops html =
   HH.div
     [ HP.classes backgroundClasses ]
     [ HH.div
-        ( [ HP.classes modalClasses ] <&> iprops )
+        ([ HP.classes modalClasses ] <&> iprops)
         html
     ]
 
-modal_
-  :: ∀ action slots m
-   . action
-  -> Array (H.ComponentHTML action slots m)
-  -> H.ComponentHTML action slots m
+modal_ ::
+  forall action slots m.
+  action ->
+  Array (H.ComponentHTML action slots m) ->
+  H.ComponentHTML action slots m
 modal_ query = modal query []
-
 
 -----------
 -- Blocks
@@ -118,20 +117,20 @@ bodyClasses = HH.ClassName <$>
   , "rounded-b"
   ]
 
-body
-  :: ∀ p i
-   . Array (HH.IProp HTMLdiv i)
-  -> Array (HH.HTML p i)
-  -> HH.HTML p i
+body ::
+  forall p i.
+  Array (HH.IProp HTMLdiv i) ->
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 body iprops html =
   HH.div
-    ( [ HP.classes bodyClasses ] <&> iprops )
+    ([ HP.classes bodyClasses ] <&> iprops)
     html
 
-body_
-  :: ∀ p i
-   . Array (HH.HTML p i)
-  -> HH.HTML p i
+body_ ::
+  forall p i.
+  Array (HH.HTML p i) ->
+  HH.HTML p i
 body_ = body []
 
 headerClasses :: Array HH.ClassName
@@ -158,22 +157,22 @@ innerHeaderClasses = HH.ClassName <$>
   , "flex"
   ]
 
-header
-  :: ∀ p i
-   . HeaderProps p i
-  -> HH.HTML p i
+header ::
+  forall p i.
+  HeaderProps p i ->
+  HH.HTML p i
 header props =
   HH.div
     [ HP.classes headerClasses ]
     [ HH.header
-      [ HP.classes outerHeaderClasses ]
-      ( [ HH.div
-        [ HP.classes innerHeaderClasses ]
-          [ Format.subHeading
-            [ css "mb-0" ]
-            props.title
+        [ HP.classes outerHeaderClasses ]
+        ( [ HH.div
+              [ HP.classes innerHeaderClasses ]
+              [ Format.subHeading
+                  [ css "mb-0" ]
+                  props.title
+              ]
           ]
-        ]
-        <> props.buttons
-      )
+            <> props.buttons
+        )
     ]

--- a/src/Parts/Panel.purs
+++ b/src/Parts/Panel.purs
@@ -35,9 +35,9 @@ initializeWith toAction = do
   document <- Halogen.liftEffect $ Web.HTML.Window.document =<< Web.HTML.window
   Halogen.subscribe
     $ Halogen.Query.Event.eventListener
-      Web.UIEvent.KeyboardEvent.EventTypes.keydown
-      (Web.HTML.HTMLDocument.toEventTarget document)
-      (toAction <=< Web.UIEvent.KeyboardEvent.fromEvent)
+        Web.UIEvent.KeyboardEvent.EventTypes.keydown
+        (Web.HTML.HTMLDocument.toEventTarget document)
+        (toAction <=< Web.UIEvent.KeyboardEvent.fromEvent)
 
 whenClose ::
   forall state action slots output m.
@@ -219,7 +219,7 @@ body ::
   Halogen.HTML.HTML p i
 body iprops html =
   Halogen.HTML.div
-    ( [ Halogen.HTML.Properties.classes bodyClasses ] <&> iprops )
+    ([ Halogen.HTML.Properties.classes bodyClasses ] <&> iprops)
     html
 
 body_ ::
@@ -263,14 +263,14 @@ header props =
   Halogen.HTML.div
     [ Halogen.HTML.Properties.classes headerClasses ]
     [ Halogen.HTML.header
-      [ Halogen.HTML.Properties.classes outerHeaderClasses ]
-      ( [ Halogen.HTML.div
-        [ Halogen.HTML.Properties.classes innerHeaderClasses ]
-          [ Ocelot.Block.Format.subHeading
-            [ Ocelot.HTML.Properties.css "mb-0" ]
-            props.title
+        [ Halogen.HTML.Properties.classes outerHeaderClasses ]
+        ( [ Halogen.HTML.div
+              [ Halogen.HTML.Properties.classes innerHeaderClasses ]
+              [ Ocelot.Block.Format.subHeading
+                  [ Ocelot.HTML.Properties.css "mb-0" ]
+                  props.title
+              ]
           ]
-        ]
-        <> props.buttons
-      )
+            <> props.buttons
+        )
     ]

--- a/src/Slider/Render.purs
+++ b/src/Slider/Render.purs
@@ -33,13 +33,13 @@ axisContainer ::
   } ->
   Array (Halogen.HTML.HTML p a) ->
   Halogen.HTML.HTML p a
-axisContainer { betweenThumbAndAxis, betweenTopAndThumb, thumbRadius }  =
+axisContainer { betweenThumbAndAxis, betweenTopAndThumb, thumbRadius } =
   Halogen.Svg.Elements.g
     [ Halogen.Svg.Attributes.transform
-      [ Halogen.Svg.Attributes.Translate
-        thumbRadius
-        (betweenTopAndThumb + thumbRadius * 2.0 + betweenThumbAndAxis)
-      ]
+        [ Halogen.Svg.Attributes.Translate
+            thumbRadius
+            (betweenTopAndThumb + thumbRadius * 2.0 + betweenThumbAndAxis)
+        ]
     ]
 
 axis ::
@@ -63,7 +63,7 @@ axisLabel label x =
   Halogen.Svg.Elements.text
     [ Halogen.Svg.Attributes.text_anchor Halogen.Svg.Attributes.AnchorMiddle
     , Halogen.Svg.Attributes.transform
-      [ Halogen.Svg.Attributes.Translate x 0.0 ]
+        [ Halogen.Svg.Attributes.Translate x 0.0 ]
     ]
     [ Halogen.HTML.text label ]
 
@@ -90,10 +90,10 @@ frame { axisHeight, betweenThumbAndAxis, betweenTopAndThumb, frameWidth, margin,
         <> iprops
     )
     [ Halogen.Svg.Elements.g
-      [ Halogen.Svg.Attributes.transform
-        [ Halogen.Svg.Attributes.Translate margin margin ]
-      ]
-      html
+        [ Halogen.Svg.Attributes.transform
+            [ Halogen.Svg.Attributes.Translate margin margin ]
+        ]
+        html
     ]
   where
   viewBoxHeight :: Number
@@ -118,7 +118,7 @@ interval { trackRadius, trackWidth } percent iprops =
     ( [ Halogen.Svg.Attributes.height (trackRadius * 2.0)
       , Halogen.Svg.Attributes.width (trackWidth * (percent.end.percent - percent.start.percent) / 100.0)
       , Halogen.Svg.Attributes.transform
-        [ Halogen.Svg.Attributes.Translate (trackWidth * percent.start.percent / 100.0) 0.0 ]
+          [ Halogen.Svg.Attributes.Translate (trackWidth * percent.start.percent / 100.0) 0.0 ]
       ]
         <> iprops
     )
@@ -133,7 +133,7 @@ markContainer ::
 markContainer { trackRadius } =
   Halogen.Svg.Elements.g
     [ Halogen.Svg.Attributes.transform
-      [ Halogen.Svg.Attributes.Translate 0.0 trackRadius ]
+        [ Halogen.Svg.Attributes.Translate 0.0 trackRadius ]
     ]
 
 mark ::
@@ -149,7 +149,7 @@ mark { trackRadius, trackWidth } { percent } iprops =
   Halogen.Svg.Elements.circle
     ( [ Halogen.Svg.Attributes.r trackRadius
       , Halogen.Svg.Attributes.transform
-        [ Halogen.Svg.Attributes.Translate (trackWidth * percent / 100.0) 0.0 ]
+          [ Halogen.Svg.Attributes.Translate (trackWidth * percent / 100.0) 0.0 ]
       ]
         <> iprops
     )
@@ -165,10 +165,10 @@ thumbContainer ::
 thumbContainer { betweenTopAndThumb, thumbRadius } =
   Halogen.Svg.Elements.g
     [ Halogen.Svg.Attributes.transform
-      [ Halogen.Svg.Attributes.Translate
-        thumbRadius
-        (betweenTopAndThumb + thumbRadius)
-      ]
+        [ Halogen.Svg.Attributes.Translate
+            thumbRadius
+            (betweenTopAndThumb + thumbRadius)
+        ]
     ]
 
 thumb ::
@@ -186,7 +186,7 @@ thumb { trackWidth, thumbRadius } { percent } iprops =
       , Halogen.Svg.Attributes.fill (pure (Halogen.Svg.Attributes.RGB 255 255 255))
       , Halogen.Svg.Attributes.stroke (pure (Halogen.Svg.Attributes.RGB 0 0 0))
       , Halogen.Svg.Attributes.transform
-        [ Halogen.Svg.Attributes.Translate (trackWidth * percent / 100.0) 0.0 ]
+          [ Halogen.Svg.Attributes.Translate (trackWidth * percent / 100.0) 0.0 ]
       ]
         <> iprops
     )
@@ -203,7 +203,7 @@ trackContainer ::
 trackContainer { betweenTopAndThumb, thumbRadius, trackRadius } =
   Halogen.Svg.Elements.g
     [ Halogen.Svg.Attributes.transform
-      [ Halogen.Svg.Attributes.Translate thumbRadius (betweenTopAndThumb + thumbRadius - trackRadius) ]
+        [ Halogen.Svg.Attributes.Translate thumbRadius (betweenTopAndThumb + thumbRadius - trackRadius) ]
     ]
 
 track ::
@@ -236,5 +236,4 @@ pixelToPercent { frameWidth, margin, thumbRadius, trackWidth } x = { percent }
 
   percent :: Number
   percent = x.px * scale / trackWidth * 100.0
-
 

--- a/src/Typeahead.purs
+++ b/src/Typeahead.purs
@@ -69,6 +69,7 @@ import Data.Foldable as Data.Foldable
 import Data.Fuzzy as Data.Fuzzy
 import Data.Maybe (Maybe(..))
 import Data.Maybe as Data.Maybe
+import Data.Monoid as Data.Monoid
 import Data.Rational ((%))
 import Data.String as Data.String
 import Data.Time.Duration as Data.Time.Duration
@@ -970,9 +971,10 @@ renderSingle iprops renderItem renderContainer st =
               )
               st.selected
         , Ocelot.Block.Input.borderRight
-            [ Halogen.HTML.Properties.classes $ linkClasses disabled
-            , Halogen.HTML.Events.onClick Select.ToggleClick
-            ]
+            ( [ Halogen.HTML.Properties.classes $ linkClasses disabled ]
+                <> Data.Monoid.guard (not disabled)
+                  [ Halogen.HTML.Events.onClick Select.ToggleClick ]
+            )
             [ Halogen.HTML.text "Change" ]
         ]
     , Ocelot.Block.Input.inputGroup

--- a/src/Typeahead.purs
+++ b/src/Typeahead.purs
@@ -58,6 +58,7 @@ module Ocelot.Typeahead
   ) where
 
 import Prelude
+
 import Control.Alternative as Control.Alternative
 import Control.Comonad as Control.Comonad
 import Control.Comonad.Store as Control.Comonad.Store
@@ -106,52 +107,40 @@ type ChildSlots action f item =
   ( select :: Select.Slot (Query f item) EmbeddedChildSlots (Output action f item) Unit
   )
 
-type Component action f item m
-  = Halogen.Component (Query f item) (Input action f item m) (Output action f item) m
+type Component action f item m = Halogen.Component (Query f item) (Input action f item m) (Output action f item) m
 
-type ComponentHTML action f item m
-  = Halogen.ComponentHTML (Action action f item m) (ChildSlots action f item) m
+type ComponentHTML action f item m = Halogen.ComponentHTML (Action action f item m) (ChildSlots action f item) m
 
-type ComponentRender action f item m
-  = State f item m -> ComponentHTML action f item m
+type ComponentRender action f item m = State f item m -> ComponentHTML action f item m
 
-type ComponentM action f item m a
-  = Halogen.HalogenM (StateStore action f item m) (Action action f item m) (ChildSlots action f item) (Output action f item) m a
+type ComponentM action f item m a = Halogen.HalogenM (StateStore action f item m) (Action action f item m) (ChildSlots action f item) (Output action f item) m a
 
-type CompositeAction action f item m
-  = Select.Action (EmbeddedAction action f item m)
+type CompositeAction action f item m = Select.Action (EmbeddedAction action f item m)
 
-type CompositeComponent action f item m
-  = Halogen.Component (CompositeQuery f item) (CompositeInput f item m) (Output action f item) m
+type CompositeComponent action f item m = Halogen.Component (CompositeQuery f item) (CompositeInput f item m) (Output action f item) m
 
-type CompositeComponentHTML action f item m
-  = Halogen.ComponentHTML (CompositeAction action f item m) EmbeddedChildSlots m
+type CompositeComponentHTML action f item m = Halogen.ComponentHTML (CompositeAction action f item m) EmbeddedChildSlots m
 
-type CompositeComponentM action f item m a
-  = Halogen.HalogenM (CompositeState f item m) (CompositeAction action f item m) EmbeddedChildSlots (Output action f item) m a
+type CompositeComponentM action f item m a = Halogen.HalogenM (CompositeState f item m) (CompositeAction action f item m) EmbeddedChildSlots (Output action f item) m a
 
-type CompositeComponentRender action f item m
-  = (CompositeState f item m) -> CompositeComponentHTML action f item m
+type CompositeComponentRender action f item m = (CompositeState f item m) -> CompositeComponentHTML action f item m
 
-type CompositeInput f item m
-  = Select.Input (StateRow f item m)
+type CompositeInput f item m = Select.Input (StateRow f item m)
 
-type CompositeQuery f item
-  = Select.Query (Query f item) EmbeddedChildSlots
+type CompositeQuery f item = Select.Query (Query f item) EmbeddedChildSlots
 
-type CompositeState f item m
-  = Select.State (StateRow f item m)
+type CompositeState f item m = Select.State (StateRow f item m)
 
-type DefaultAsyncTypeaheadInput item m
-  = { itemToObject :: item -> Foreign.Object.Object String
-    , renderFuzzy :: Data.Fuzzy.Fuzzy item -> Halogen.HTML.PlainHTML
-    , async :: String -> m (Network.RemoteData.RemoteData String (Array item))
-    }
+type DefaultAsyncTypeaheadInput item m =
+  { itemToObject :: item -> Foreign.Object.Object String
+  , renderFuzzy :: Data.Fuzzy.Fuzzy item -> Halogen.HTML.PlainHTML
+  , async :: String -> m (Network.RemoteData.RemoteData String (Array item))
+  }
 
-type DefaultSyncTypeaheadInput item
-  = { itemToObject :: item -> Foreign.Object.Object String
-    , renderFuzzy :: Data.Fuzzy.Fuzzy item -> Halogen.HTML.PlainHTML
-    }
+type DefaultSyncTypeaheadInput item =
+  { itemToObject :: item -> Foreign.Object.Object String
+  , renderFuzzy :: Data.Fuzzy.Fuzzy item -> Halogen.HTML.PlainHTML
+  }
 
 data EmbeddedAction action (f :: Type -> Type) item (m :: Type -> Type)
   = HandleMultiInput Ocelot.Components.MultiInput.Component.Output
@@ -160,31 +149,31 @@ data EmbeddedAction action (f :: Type -> Type) item (m :: Type -> Type)
   | Remove item
   | RemoveAll
 
-type EmbeddedChildSlots
-  = ( multiInput :: Ocelot.Components.MultiInput.Component.Slot Unit
-    )
+type EmbeddedChildSlots =
+  ( multiInput :: Ocelot.Components.MultiInput.Component.Slot Unit
+  )
 
-type Input action f item m
-  = { async :: Maybe (String -> m (Network.RemoteData.RemoteData String (Array item)))
-    , debounceTime :: Maybe Data.Time.Duration.Milliseconds
-    , disabled :: Boolean
-    , insertable :: Insertable item
-    , itemToObject :: item -> Foreign.Object.Object String
-    , items :: Network.RemoteData.RemoteData String (Array item)
-    , keepOpen :: Boolean
-    , render :: CompositeComponentRender action f item m
-    }
+type Input action f item m =
+  { async :: Maybe (String -> m (Network.RemoteData.RemoteData String (Array item)))
+  , debounceTime :: Maybe Data.Time.Duration.Milliseconds
+  , disabled :: Boolean
+  , insertable :: Insertable item
+  , itemToObject :: item -> Foreign.Object.Object String
+  , items :: Network.RemoteData.RemoteData String (Array item)
+  , keepOpen :: Boolean
+  , render :: CompositeComponentRender action f item m
+  }
 
 data Insertable item
   = NotInsertable
   | Insertable (String -> item)
 
-type Operations f item
-  = { runSelect :: item -> f item -> f item
-    , runRemove :: item -> f item -> f item
-    , runFilterFuzzy :: Array (Data.Fuzzy.Fuzzy item) -> Array (Data.Fuzzy.Fuzzy item)
-    , runFilterItems :: Array item -> f item -> Array item
-    }
+type Operations f item =
+  { runSelect :: item -> f item -> f item
+  , runRemove :: item -> f item -> f item
+  , runFilterFuzzy :: Array (Data.Fuzzy.Fuzzy item) -> Array (Data.Fuzzy.Fuzzy item)
+  , runFilterItems :: Array item -> f item -> Array item
+  }
 
 data Output action (f :: Type -> Type) item
   = Searched String
@@ -208,42 +197,38 @@ data SelectionCause
 
 derive instance eqSelectionCause :: Eq SelectionCause
 
-type Slot action f item id
-  = Halogen.Slot (Query f item) (Output action f item) id
+type Slot action f item id = Halogen.Slot (Query f item) (Output action f item) id
 
-type Spec action f item m
-  = Select.Spec (StateRow f item m) (Query f item) (EmbeddedAction action f item m) EmbeddedChildSlots (CompositeInput f item m) (Output action f item) m
+type Spec action f item m = Select.Spec (StateRow f item m) (Query f item) (EmbeddedAction action f item m) EmbeddedChildSlots (CompositeInput f item m) (Output action f item) m
 
-type State f item m
-  = Record (StateRow f item m)
+type State f item m = Record (StateRow f item m)
 
-type StateRow f item m
-  = ( items :: Network.RemoteData.RemoteData String (Array item) -- NOTE pst.items, Parent(Typeahead)
-    , insertable :: Insertable item
-    , keepOpen :: Boolean
-    , itemToObject :: item -> Foreign.Object.Object String
-    , async :: Maybe (String -> m (Network.RemoteData.RemoteData String (Array item)))
-    , disabled :: Boolean
-    , ops :: Operations f item
-    , config :: { debounceTime :: Maybe Data.Time.Duration.Milliseconds }
-    , selected :: f item
-    , fuzzyItems :: Array (Data.Fuzzy.Fuzzy item) -- NOTE cst.items, Child(Select)
-    )
+type StateRow f item m =
+  ( items :: Network.RemoteData.RemoteData String (Array item) -- NOTE pst.items, Parent(Typeahead)
+  , insertable :: Insertable item
+  , keepOpen :: Boolean
+  , itemToObject :: item -> Foreign.Object.Object String
+  , async :: Maybe (String -> m (Network.RemoteData.RemoteData String (Array item)))
+  , disabled :: Boolean
+  , ops :: Operations f item
+  , config :: { debounceTime :: Maybe Data.Time.Duration.Milliseconds }
+  , selected :: f item
+  , fuzzyItems :: Array (Data.Fuzzy.Fuzzy item) -- NOTE cst.items, Child(Select)
+  )
 
-type StateStore action f item m
-  = Control.Comonad.Store.Store (State f item m) (ComponentHTML action f item m)
+type StateStore action f item m = Control.Comonad.Store.Store (State f item m) (ComponentHTML action f item m)
 
 -------------
 -- Components
 
-component
-  :: forall action f item m
-  . Control.Alternative.Plus f
-  => Data.Foldable.Foldable f
-  => Eq item
-  => Effect.Aff.Class.MonadAff m
-  => Operations f item
-  -> Component action f item m
+component ::
+  forall action f item m.
+  Control.Alternative.Plus f =>
+  Data.Foldable.Foldable f =>
+  Eq item =>
+  Effect.Aff.Class.MonadAff m =>
+  Operations f item ->
+  Component action f item m
 component ops = Halogen.mkComponent
   { initialState: initialState ops
   , render: Control.Comonad.extract
@@ -253,11 +238,11 @@ component ops = Halogen.mkComponent
       }
   }
 
-single
-  :: forall action item m
-  . Eq item
-  => Effect.Aff.Class.MonadAff m
-  => Component action Maybe item m
+single ::
+  forall action item m.
+  Eq item =>
+  Effect.Aff.Class.MonadAff m =>
+  Component action Maybe item m
 single = component
   { runSelect: const <<< Just
   , runRemove: const (const Nothing)
@@ -280,12 +265,11 @@ singleHighlightOnly = component
   , runFilterItems: \items -> Data.Maybe.maybe items (\item -> Data.Array.filter (_ /= item) items)
   }
 
-
-multi
-  :: forall action item m
-  . Eq item
-  => Effect.Aff.Class.MonadAff m
-  => Component action Array item m
+multi ::
+  forall action item m.
+  Eq item =>
+  Effect.Aff.Class.MonadAff m =>
+  Component action Array item m
 multi = component
   { runSelect: (:)
   , runRemove: Data.Array.filter <<< (/=)
@@ -308,13 +292,13 @@ multiHighlightOnly = component
   , runFilterItems: Data.Array.difference
   }
 
-asyncSingle
-  :: ∀ action item m
-   . Eq item
-  => Effect.Aff.Class.MonadAff m
-  => DefaultAsyncTypeaheadInput item m
-  -> Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action Maybe item m))
-  -> Input action Maybe item m
+asyncSingle ::
+  forall action item m.
+  Eq item =>
+  Effect.Aff.Class.MonadAff m =>
+  DefaultAsyncTypeaheadInput item m ->
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action Maybe item m)) ->
+  Input action Maybe item m
 asyncSingle { async, itemToObject, renderFuzzy } props =
   { async: Just async
   , debounceTime: Just $ Data.Time.Duration.Milliseconds 300.0
@@ -329,13 +313,13 @@ asyncSingle { async, itemToObject, renderFuzzy } props =
       (defRenderContainer renderFuzzy)
   }
 
-asyncMulti
-  :: ∀ action item m
-   . Eq item
-  => Effect.Aff.Class.MonadAff m
-  => DefaultAsyncTypeaheadInput item m
-  -> Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action Array item m))
-  -> Input action Array item m
+asyncMulti ::
+  forall action item m.
+  Eq item =>
+  Effect.Aff.Class.MonadAff m =>
+  DefaultAsyncTypeaheadInput item m ->
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action Array item m)) ->
+  Input action Array item m
 asyncMulti { async, itemToObject, renderFuzzy } props =
   { async: Just async
   , debounceTime: Just $ Data.Time.Duration.Milliseconds 300.0
@@ -350,14 +334,14 @@ asyncMulti { async, itemToObject, renderFuzzy } props =
       (defRenderContainer renderFuzzy)
   }
 
-asyncMultiInput
-  :: ∀ action item m
-  . Eq item
-  => Effect.Aff.Class.MonadAff m
-  => DefaultAsyncTypeaheadInput item m
-  -> Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action Array item m))
-  -> Ocelot.Components.MultiInput.Component.Input
-  -> Input action Array item m
+asyncMultiInput ::
+  forall action item m.
+  Eq item =>
+  Effect.Aff.Class.MonadAff m =>
+  DefaultAsyncTypeaheadInput item m ->
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action Array item m)) ->
+  Ocelot.Components.MultiInput.Component.Input ->
+  Input action Array item m
 asyncMultiInput { async, itemToObject, renderFuzzy } props input =
   { async: Just async
   , debounceTime: Just $ Data.Time.Duration.Milliseconds 300.0
@@ -371,13 +355,13 @@ asyncMultiInput { async, itemToObject, renderFuzzy } props input =
       (defRenderContainer renderFuzzy)
   }
 
-syncSingle
-  :: ∀ action item m
-   . Eq item
-  => Effect.Aff.Class.MonadAff m
-  => DefaultSyncTypeaheadInput item
-  -> Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action Maybe item m))
-  -> Input action Maybe item m
+syncSingle ::
+  forall action item m.
+  Eq item =>
+  Effect.Aff.Class.MonadAff m =>
+  DefaultSyncTypeaheadInput item ->
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action Maybe item m)) ->
+  Input action Maybe item m
 syncSingle { itemToObject, renderFuzzy } props =
   { async: Nothing
   , debounceTime: Nothing
@@ -392,14 +376,14 @@ syncSingle { itemToObject, renderFuzzy } props =
       (defRenderContainer renderFuzzy)
   }
 
-syncMultiInput
-  :: ∀ action item m
-  . Eq item
-  => Effect.Aff.Class.MonadAff m
-  => DefaultSyncTypeaheadInput item
-  -> Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action Array item m))
-  -> Ocelot.Components.MultiInput.Component.Input
-  -> Input action Array item m
+syncMultiInput ::
+  forall action item m.
+  Eq item =>
+  Effect.Aff.Class.MonadAff m =>
+  DefaultSyncTypeaheadInput item ->
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action Array item m)) ->
+  Ocelot.Components.MultiInput.Component.Input ->
+  Input action Array item m
 syncMultiInput { itemToObject, renderFuzzy } props input =
   { async: Nothing
   , debounceTime: Nothing
@@ -413,14 +397,13 @@ syncMultiInput { itemToObject, renderFuzzy } props input =
       (defRenderContainer renderFuzzy)
   }
 
-
-syncMulti
-  :: ∀ action item m
-   . Eq item
-  => Effect.Aff.Class.MonadAff m
-  => DefaultSyncTypeaheadInput item
-  -> Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action Array item m))
-  -> Input action Array item m
+syncMulti ::
+  forall action item m.
+  Eq item =>
+  Effect.Aff.Class.MonadAff m =>
+  DefaultSyncTypeaheadInput item ->
+  Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action Array item m)) ->
+  Input action Array item m
 syncMulti { itemToObject, renderFuzzy } props =
   { async: Nothing
   , debounceTime: Nothing
@@ -442,20 +425,21 @@ _multiInput = Proxy :: Proxy "multiInput"
 
 _select = Proxy :: Proxy "select"
 
-applyInsertable
-  :: forall item
-  . (item -> Data.Fuzzy.Fuzzy item)
-  -> Insertable item
-  -> String
-  -> Array (Data.Fuzzy.Fuzzy item)
-  -> Array (Data.Fuzzy.Fuzzy item)
+applyInsertable ::
+  forall item.
+  (item -> Data.Fuzzy.Fuzzy item) ->
+  Insertable item ->
+  String ->
+  Array (Data.Fuzzy.Fuzzy item) ->
+  Array (Data.Fuzzy.Fuzzy item)
 applyInsertable _ _ "" items = items
 applyInsertable match insertable text items = case insertable of
   NotInsertable -> items
-  Insertable mkItem | Data.Array.length (Data.Array.filter isExactMatch items) > 0 -> items
-                    | otherwise -> (match $ mkItem text) : items
+  Insertable mkItem
+    | Data.Array.length (Data.Array.filter isExactMatch items) > 0 -> items
+    | otherwise -> (match $ mkItem text) : items
   where
-    isExactMatch (Data.Fuzzy.Fuzzy { distance }) = distance == Data.Fuzzy.Distance 0 0 0 0 0 0
+  isExactMatch (Data.Fuzzy.Fuzzy { distance }) = distance == Data.Fuzzy.Distance 0 0 0 0 0 0
 
 defFilterFuzzy ::
   forall item.
@@ -466,10 +450,10 @@ defFilterFuzzy =
   Data.Array.sort
     <<< Data.Array.filter (\(Data.Fuzzy.Fuzzy { ratio }) -> ratio > (2 % 3))
 
-defRenderContainer
-  :: ∀ action f item m
-   . (Data.Fuzzy.Fuzzy item -> Halogen.HTML.PlainHTML)
-  -> CompositeComponentRender action f item m
+defRenderContainer ::
+  forall action f item m.
+  (Data.Fuzzy.Fuzzy item -> Halogen.HTML.PlainHTML) ->
+  CompositeComponentRender action f item m
 defRenderContainer renderFuzzy st =
   Ocelot.Block.ItemContainer.itemContainer st.highlightedIndex (renderFuzzy <$> st.fuzzyItems) []
 
@@ -489,13 +473,13 @@ disabledClasses = Halogen.HTML.ClassName <$>
   , "px-3"
   ]
 
-embeddedHandleAction
-  :: forall action f item m
-  . Eq item
-  => Control.Alternative.Plus f
-  => Effect.Aff.Class.MonadAff m
-  => EmbeddedAction action f item m
-  -> CompositeComponentM action f item m Unit
+embeddedHandleAction ::
+  forall action f item m.
+  Eq item =>
+  Control.Alternative.Plus f =>
+  Effect.Aff.Class.MonadAff m =>
+  EmbeddedAction action f item m ->
+  CompositeComponentM action f item m Unit
 embeddedHandleAction = case _ of
   HandleMultiInput output -> embeddedHandleMultiInput output
   Initialize -> do
@@ -503,20 +487,21 @@ embeddedHandleAction = case _ of
   Remove item -> embeddedRemove item
   RemoveAll -> do
     st <- Halogen.modify \st ->
-      st { selected = Control.Alternative.empty :: f item
-         , visibility = Select.Off
-         }
+      st
+        { selected = Control.Alternative.empty :: f item
+        , visibility = Select.Off
+        }
     Halogen.raise $ SelectionChanged RemovalQuery st.selected
     synchronize
   Raise action -> do
     Halogen.raise $ Emit action
 
-embeddedHandleMessage
-  :: forall action f item m
-   . Eq item
-  => Effect.Aff.Class.MonadAff m
-  => Select.Event
-  -> CompositeComponentM action f item m Unit
+embeddedHandleMessage ::
+  forall action f item m.
+  Eq item =>
+  Effect.Aff.Class.MonadAff m =>
+  Select.Event ->
+  CompositeComponentM action f item m Unit
 embeddedHandleMessage = case _ of
   Select.Selected idx -> embeddedHandleSelected true idx
   -- Perform a new search, fetching data if Async.
@@ -534,13 +519,13 @@ embeddedHandleMessage = case _ of
     synchronize
   _ -> pure unit
 
-embeddedHandleSelected
-  :: forall action f item m
-  . Eq item
-  => Effect.Aff.Class.MonadAff m
-  => Boolean
-  -> Int
-  -> CompositeComponentM action f item m Unit
+embeddedHandleSelected ::
+  forall action f item m.
+  Eq item =>
+  Effect.Aff.Class.MonadAff m =>
+  Boolean ->
+  Int ->
+  CompositeComponentM action f item m Unit
 embeddedHandleSelected updateMultiInput idx = do
   { fuzzyItems } <- Halogen.get
   case fuzzyItems !! idx of
@@ -550,7 +535,7 @@ embeddedHandleSelected updateMultiInput idx = do
       when (not st.keepOpen) do
         Halogen.modify_ _ { visibility = Select.Off }
       when updateMultiInput do
-        case Data.Array.head (Foreign.Object.values (st.itemToObject item )) of
+        case Data.Array.head (Foreign.Object.values (st.itemToObject item)) of
           Nothing -> pure unit
           Just text -> do
             void $ Halogen.tell _multiInput unit
@@ -559,13 +544,13 @@ embeddedHandleSelected updateMultiInput idx = do
       Halogen.raise $ Selected item
       synchronize
 
-embeddedHandleMultiInput
-  :: forall action f item m
-  . Control.Alternative.Plus f
-  => Eq item
-  => Effect.Aff.Class.MonadAff m
-  => Ocelot.Components.MultiInput.Component.Output
-  -> CompositeComponentM action f item m Unit
+embeddedHandleMultiInput ::
+  forall action f item m.
+  Control.Alternative.Plus f =>
+  Eq item =>
+  Effect.Aff.Class.MonadAff m =>
+  Ocelot.Components.MultiInput.Component.Output ->
+  CompositeComponentM action f item m Unit
 embeddedHandleMultiInput = case _ of
   Ocelot.Components.MultiInput.Component.ItemsUpdated _ -> pure unit
   Ocelot.Components.MultiInput.Component.ItemRemoved text -> do
@@ -605,14 +590,14 @@ embeddedHandleMultiInput = case _ of
       Select.handleAction embeddedHandleAction embeddedHandleMessage
         $ Select.Search text
 
-embeddedHandleQuery
-  :: forall action f item m a
-  . Control.Alternative.Plus f
-  => Data.Foldable.Foldable f
-  => Eq item
-  => Effect.Aff.Class.MonadAff m
-  => Query f item a
-  -> CompositeComponentM action f item m (Maybe a)
+embeddedHandleQuery ::
+  forall action f item m a.
+  Control.Alternative.Plus f =>
+  Data.Foldable.Foldable f =>
+  Eq item =>
+  Effect.Aff.Class.MonadAff m =>
+  Query f item a ->
+  CompositeComponentM action f item m (Maybe a)
 embeddedHandleQuery = case _ of
   GetSelected reply -> do
     { selected } <- Halogen.get
@@ -661,12 +646,12 @@ embeddedInput { items, selected, insertable, keepOpen, itemToObject, ops, async,
   , selected
   }
 
-embeddedRemove
-  :: forall action f item m
-  . Eq item
-  => Effect.Aff.Class.MonadAff m
-  => item
-  -> CompositeComponentM action f item m Unit
+embeddedRemove ::
+  forall action f item m.
+  Eq item =>
+  Effect.Aff.Class.MonadAff m =>
+  item ->
+  CompositeComponentM action f item m Unit
 embeddedRemove item = do
   st <- Halogen.modify \st -> st { selected = st.ops.runRemove item st.selected }
   Halogen.raise $ SelectionChanged RemovalQuery st.selected
@@ -707,25 +692,25 @@ getNewItems' st =
     <<< fuzzyItems
     <<< flip st.runFilterItems st.selected
   where
-    matcher :: item -> Data.Fuzzy.Fuzzy item
-    matcher = Data.Fuzzy.match true st.itemToObject st.search
+  matcher :: item -> Data.Fuzzy.Fuzzy item
+  matcher = Data.Fuzzy.match true st.itemToObject st.search
 
-    fuzzyItems :: Array item -> Array (Data.Fuzzy.Fuzzy item)
-    fuzzyItems = map matcher
+  fuzzyItems :: Array item -> Array (Data.Fuzzy.Fuzzy item)
+  fuzzyItems = map matcher
 
-    applyInsert :: Array (Data.Fuzzy.Fuzzy item) -> Array (Data.Fuzzy.Fuzzy item)
-    applyInsert = applyInsertable matcher st.insertable st.search
+  applyInsert :: Array (Data.Fuzzy.Fuzzy item) -> Array (Data.Fuzzy.Fuzzy item)
+  applyInsert = applyInsertable matcher st.insertable st.search
 
 -- NOTE re-raise output messages from the embedded component
 -- NOTE update Dropdown render function if it relies on external state
-handleAction
-  :: forall action f item m
-  . Control.Alternative.Plus f
-  => Data.Foldable.Foldable f
-  => Eq item
-  => Effect.Aff.Class.MonadAff m
-  => Action action f item m
-  -> ComponentM action f item m Unit
+handleAction ::
+  forall action f item m.
+  Control.Alternative.Plus f =>
+  Data.Foldable.Foldable f =>
+  Eq item =>
+  Effect.Aff.Class.MonadAff m =>
+  Action action f item m ->
+  ComponentM action f item m Unit
 handleAction = case _ of
   PassingOutput output ->
     Halogen.raise output
@@ -749,142 +734,140 @@ handleQuery = case _ of
   SetDisabled disabled a -> Just a <$ do
     Halogen.tell _select unit (Select.Query <<< SetDisabled disabled)
 
+initialState ::
+  forall action f item m.
+  Control.Alternative.Plus f =>
+  Data.Foldable.Foldable f =>
+  Eq item =>
+  Effect.Aff.Class.MonadAff m =>
+  Operations f item ->
+  Input action f item m ->
+  StateStore action f item m
 initialState
-  :: forall action f item m
-  . Control.Alternative.Plus f
-  => Data.Foldable.Foldable f
-  => Eq item
-  => Effect.Aff.Class.MonadAff m
-  => Operations f item
-  -> Input action f item m
-  -> StateStore action f item m
-initialState ops
-  { items, insertable, keepOpen, itemToObject, async, debounceTime, render, disabled }
-  = Control.Comonad.Store.store (renderAdapter render)
-      { async
-      , config: {debounceTime}
-      , disabled
-      , fuzzyItems: []
-      , insertable
-      , itemToObject
-      , items
-      , keepOpen
-      , ops
-      , selected: Control.Alternative.empty :: f item
-      }
+  ops
+  { items, insertable, keepOpen, itemToObject, async, debounceTime, render, disabled } = Control.Comonad.Store.store (renderAdapter render)
+  { async
+  , config: { debounceTime }
+  , disabled
+  , fuzzyItems: []
+  , insertable
+  , itemToObject
+  , items
+  , keepOpen
+  , ops
+  , selected: Control.Alternative.empty :: f item
+  }
 
-inputProps
-  :: ∀ action f item m
-   . Boolean
-  -> Array (Halogen.HTML.Properties.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action f item m))
-  -> Array (Halogen.HTML.Properties.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action f item m))
-inputProps disabled iprops = if disabled
-  then iprops'
+inputProps ::
+  forall action f item m.
+  Boolean ->
+  Array (Halogen.HTML.Properties.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action f item m)) ->
+  Array (Halogen.HTML.Properties.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action f item m))
+inputProps disabled iprops =
+  if disabled then iprops'
   else Select.Setters.setInputProps iprops'
   where
-    iprops' =
-      [ Halogen.HTML.Properties.disabled disabled
-      , Halogen.HTML.Properties.autocomplete false
-      , Ocelot.HTML.Properties.css "focus:next:text-blue-88"
-      ]
+  iprops' =
+    [ Halogen.HTML.Properties.disabled disabled
+    , Halogen.HTML.Properties.autocomplete false
+    , Ocelot.HTML.Properties.css "focus:next:text-blue-88"
+    ]
       <&> iprops
 
-isDisabled :: ∀ i. Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLinput i) -> Boolean
+isDisabled :: forall i. Array (Halogen.HTML.IProp DOM.HTML.Indexed.HTMLinput i) -> Boolean
 isDisabled = Data.Array.foldr f false
   where
-    f (Halogen.HTML.Properties.IProp (Halogen.HTML.Core.Property "disabled" disabled))
-      | coercePropValue disabled == true = (||) true
-    f _ = (||) false
+  f (Halogen.HTML.Properties.IProp (Halogen.HTML.Core.Property "disabled" disabled))
+    | coercePropValue disabled == true = (||) true
+  f _ = (||) false
 
-    coercePropValue :: Halogen.HTML.Core.PropValue -> Boolean
-    coercePropValue = Unsafe.Coerce.unsafeCoerce
+  coercePropValue :: Halogen.HTML.Core.PropValue -> Boolean
+  coercePropValue = Unsafe.Coerce.unsafeCoerce
 
 linkClasses :: Boolean -> Array Halogen.HTML.ClassName
-linkClasses = if _
-  then Halogen.HTML.ClassName <$> [ "text-grey-70", "no-underline", "font-medium" ]
+linkClasses =
+  if _ then Halogen.HTML.ClassName <$> [ "text-grey-70", "no-underline", "font-medium" ]
   else Ocelot.Block.Format.linkClasses
 
-renderAdapter
-  :: forall action f item m
-  . Control.Alternative.Plus f
-  => Data.Foldable.Foldable f
-  => Eq item
-  => Effect.Aff.Class.MonadAff m
-  => CompositeComponentRender action f item m
-  -> ComponentRender action f item m
+renderAdapter ::
+  forall action f item m.
+  Control.Alternative.Plus f =>
+  Data.Foldable.Foldable f =>
+  Eq item =>
+  Effect.Aff.Class.MonadAff m =>
+  CompositeComponentRender action f item m ->
+  ComponentRender action f item m
 renderAdapter render state =
   Halogen.HTML.slot _select unit (Select.component identity $ spec render)
     (embeddedInput state)
     PassingOutput
 
-renderError :: ∀ p i. Boolean -> Halogen.HTML.HTML p i
+renderError :: forall p i. Boolean -> Halogen.HTML.HTML p i
 renderError error =
   Ocelot.Block.Conditional.conditional error
     [ Ocelot.HTML.Properties.css "flex items-center mt-1" ]
     [ Ocelot.Block.Icon.error
-      [ Ocelot.HTML.Properties.css "text-2xl text-yellow" ]
+        [ Ocelot.HTML.Properties.css "text-2xl text-yellow" ]
     , Halogen.HTML.p
-      [ Ocelot.HTML.Properties.css "ml-3 text-grey-50 font-light" ]
-      [ Halogen.HTML.text "Some data could not be retrieved here." ]
+        [ Ocelot.HTML.Properties.css "ml-3 text-grey-50 font-light" ]
+        [ Halogen.HTML.text "Some data could not be retrieved here." ]
     ]
 
-renderHeaderSearchDropdown
-  :: ∀ action item m
-   . Eq item
-  => String
-  -> String
-  -> (item -> Halogen.HTML.PlainHTML)
-  -> (Data.Fuzzy.Fuzzy item -> Halogen.HTML.PlainHTML)
-  -> CompositeComponentRender action Maybe item m
+renderHeaderSearchDropdown ::
+  forall action item m.
+  Eq item =>
+  String ->
+  String ->
+  (item -> Halogen.HTML.PlainHTML) ->
+  (Data.Fuzzy.Fuzzy item -> Halogen.HTML.PlainHTML) ->
+  CompositeComponentRender action Maybe item m
 renderHeaderSearchDropdown defaultLabel resetLabel renderItem renderFuzzy st =
   renderSearchDropdown resetLabel label renderFuzzy st
   where
-    label = Halogen.HTML.span
-      [ Ocelot.HTML.Properties.css "text-white text-3xl font-thin cursor-pointer whitespace-no-wrap" ]
-      [ Data.Maybe.maybe (Halogen.HTML.text defaultLabel) (Halogen.HTML.fromPlainHTML <<< renderItem) st.selected
-      , Ocelot.Block.Icon.collapse [ Ocelot.HTML.Properties.css "ml-3 text-xl text-grey-50 align-middle" ]
-      ]
+  label = Halogen.HTML.span
+    [ Ocelot.HTML.Properties.css "text-white text-3xl font-thin cursor-pointer whitespace-no-wrap" ]
+    [ Data.Maybe.maybe (Halogen.HTML.text defaultLabel) (Halogen.HTML.fromPlainHTML <<< renderItem) st.selected
+    , Ocelot.Block.Icon.collapse [ Ocelot.HTML.Properties.css "ml-3 text-xl text-grey-50 align-middle" ]
+    ]
 
-renderMulti
-  :: ∀ action item m
-  . Array (Halogen.HTML.Properties.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action Array item m))
-  -> (item -> Halogen.HTML.PlainHTML)
-  -> CompositeComponentRender action Array item m
-  -> CompositeComponentRender action Array item m
+renderMulti ::
+  forall action item m.
+  Array (Halogen.HTML.Properties.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action Array item m)) ->
+  (item -> Halogen.HTML.PlainHTML) ->
+  CompositeComponentRender action Array item m ->
+  CompositeComponentRender action Array item m
 renderMulti iprops renderItem renderContainer st =
   Halogen.HTML.div
     [ Ocelot.HTML.Properties.css "relative" ]
-    [ if (not disabled && not Data.Array.null st.selected)
-        then
-          Halogen.HTML.a
-            [ Ocelot.HTML.Properties.css "absolute -mt-7 pin-r underline text-grey-70 cursor-pointer"
-            , Halogen.HTML.Events.onClick \_ -> Select.Action $ RemoveAll
-            ]
-            [ Halogen.HTML.text "Remove All" ]
-        else
-          Halogen.HTML.text ""
+    [ if (not disabled && not Data.Array.null st.selected) then
+        Halogen.HTML.a
+          [ Ocelot.HTML.Properties.css "absolute -mt-7 pin-r underline text-grey-70 cursor-pointer"
+          , Halogen.HTML.Events.onClick \_ -> Select.Action $ RemoveAll
+          ]
+          [ Halogen.HTML.text "Remove All" ]
+      else
+        Halogen.HTML.text ""
     , Ocelot.Block.ItemContainer.selectionContainer $ st.selected <#>
-        if disabled
-          then
-            Halogen.HTML.fromPlainHTML <<< renderItem
-          else
-            \selected ->
-              Ocelot.Block.ItemContainer.selectionGroup
-                renderItem
-                []
-                [ Halogen.HTML.Events.onClick \_ -> Select.Action $ Remove selected ]
-                selected
+        if disabled then
+          Halogen.HTML.fromPlainHTML <<< renderItem
+        else
+          \selected ->
+            Ocelot.Block.ItemContainer.selectionGroup
+              renderItem
+              []
+              [ Halogen.HTML.Events.onClick \_ -> Select.Action $ Remove selected ]
+              selected
     , Ocelot.Block.Input.inputGroup_
-      [ Ocelot.Block.Input.inputCenter $ inputProps disabled iprops
-      , Ocelot.Block.Input.addonLeft_
-        [ Ocelot.Block.Icon.search_ ]
-      , Ocelot.Block.Input.addonCenter
-        [ Ocelot.HTML.Properties.css $ if Network.RemoteData.isLoading st.items then "" else "offscreen" ]
-        [ spinner ]
-      , Ocelot.Block.Input.borderRight
-        [ Halogen.HTML.Properties.classes $ linkClasses disabled ]
-        [ Halogen.HTML.text "Browse" ]
-      ]
+        [ Ocelot.Block.Input.inputCenter $ inputProps disabled iprops
+        , Ocelot.Block.Input.addonLeft_
+            [ Ocelot.Block.Icon.search_ ]
+        , Ocelot.Block.Input.addonCenter
+            [ Ocelot.HTML.Properties.css $ if Network.RemoteData.isLoading st.items then "" else "offscreen" ]
+            [ spinner ]
+        , Ocelot.Block.Input.borderRight
+            [ Halogen.HTML.Properties.classes $ linkClasses disabled ]
+            [ Halogen.HTML.text "Browse" ]
+        ]
     , Ocelot.Block.Conditional.conditional (st.visibility == Select.On)
         [ Ocelot.HTML.Properties.css "relative block" ]
         [ renderContainer st ]
@@ -893,12 +876,12 @@ renderMulti iprops renderItem renderContainer st =
   where
   disabled = st.disabled
 
-renderMultiInput
-  :: ∀ action item m
-  . Effect.Aff.Class.MonadAff m
-  => Ocelot.Components.MultiInput.Component.Input
-  -> CompositeComponentRender action Array item m
-  -> CompositeComponentRender action Array item m
+renderMultiInput ::
+  forall action item m.
+  Effect.Aff.Class.MonadAff m =>
+  Ocelot.Components.MultiInput.Component.Input ->
+  CompositeComponentRender action Array item m ->
+  CompositeComponentRender action Array item m
 renderMultiInput input renderContainer st =
   Halogen.HTML.div
     [ Ocelot.HTML.Properties.css "relative" ]
@@ -912,32 +895,31 @@ renderMultiInput input renderContainer st =
     , renderError $ Network.RemoteData.isFailure st.items
     ]
 
-renderSearchDropdown
-  :: ∀ action f item m
-   . Eq item
-  => Data.Foldable.Foldable f
-  => String
-  -> Halogen.HTML.PlainHTML
-  -> (Data.Fuzzy.Fuzzy item -> Halogen.HTML.PlainHTML)
-  -> CompositeComponentRender action f item m
+renderSearchDropdown ::
+  forall action f item m.
+  Eq item =>
+  Data.Foldable.Foldable f =>
+  String ->
+  Halogen.HTML.PlainHTML ->
+  (Data.Fuzzy.Fuzzy item -> Halogen.HTML.PlainHTML) ->
+  CompositeComponentRender action f item m
 renderSearchDropdown resetLabel label renderFuzzy st =
   Halogen.HTML.label
     [ Ocelot.HTML.Properties.css "relative" ]
     [ Halogen.HTML.fromPlainHTML label
     , Halogen.HTML.div
-      [ Halogen.HTML.Properties.classes
-        $ Halogen.HTML.ClassName "min-w-80" :
-          if st.visibility == Select.Off
-            then [ Halogen.HTML.ClassName "offscreen" ]
-            else []
-      ]
-      [ Ocelot.Block.ItemContainer.dropdownContainer
-        [ renderInput, renderReset ]
-        renderFuzzy
-        isSelected
-        st.fuzzyItems
-        st.highlightedIndex
-      ]
+        [ Halogen.HTML.Properties.classes
+            $ Halogen.HTML.ClassName "min-w-80" :
+                if st.visibility == Select.Off then [ Halogen.HTML.ClassName "offscreen" ]
+                else []
+        ]
+        [ Ocelot.Block.ItemContainer.dropdownContainer
+            [ renderInput, renderReset ]
+            renderFuzzy
+            isSelected
+            st.fuzzyItems
+            st.highlightedIndex
+        ]
     ]
   where
   isSelected :: Data.Fuzzy.Fuzzy item -> Boolean
@@ -947,7 +929,7 @@ renderSearchDropdown resetLabel label renderFuzzy st =
       [ Ocelot.HTML.Properties.css "m-4 border-b-2 border-blue-88 pb-2 flex" ]
       [ Ocelot.Block.Icon.search [ Ocelot.HTML.Properties.css "mr-4 text-xl text-grey-70" ]
       , Halogen.HTML.input
-        $ inputProps false [ Ocelot.HTML.Properties.css "no-outline w-full", Halogen.HTML.Properties.placeholder "Search" ]
+          $ inputProps false [ Ocelot.HTML.Properties.css "no-outline w-full", Halogen.HTML.Properties.placeholder "Search" ]
       ]
 
   renderReset =
@@ -956,55 +938,55 @@ renderSearchDropdown resetLabel label renderFuzzy st =
       [ Halogen.HTML.Events.onClick \_ -> Select.Action $ RemoveAll
       ]
       [ Halogen.HTML.text resetLabel ]
-      ( Data.Foldable.null st.selected )
+      (Data.Foldable.null st.selected)
       false
 
-renderSingle
-  :: ∀ action item m
-  . Array (Halogen.HTML.Properties.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action Maybe item m))
-  -> (item -> Halogen.HTML.PlainHTML)
-  -> CompositeComponentRender action Maybe item m
-  -> CompositeComponentRender action Maybe item m
+renderSingle ::
+  forall action item m.
+  Array (Halogen.HTML.Properties.IProp DOM.HTML.Indexed.HTMLinput (CompositeAction action Maybe item m)) ->
+  (item -> Halogen.HTML.PlainHTML) ->
+  CompositeComponentRender action Maybe item m ->
+  CompositeComponentRender action Maybe item m
 renderSingle iprops renderItem renderContainer st =
   Halogen.HTML.div_
     [ Ocelot.Block.Input.inputGroup' Halogen.HTML.div
-      [ Ocelot.HTML.Properties.css $ if showSelected then "" else "offscreen" ]
-      [ if disabled
-          then
+        [ Ocelot.HTML.Properties.css $ if showSelected then "" else "offscreen" ]
+        [ if disabled then
             Data.Maybe.maybe (Halogen.HTML.text "")
               ( \selected -> Halogen.HTML.div
-                [ Halogen.HTML.Properties.classes disabledClasses ]
-                [ Halogen.HTML.fromPlainHTML $ renderItem selected ]
+                  [ Halogen.HTML.Properties.classes disabledClasses ]
+                  [ Halogen.HTML.fromPlainHTML $ renderItem selected ]
               )
-            st.selected
+              st.selected
           else
             Data.Maybe.maybe (Halogen.HTML.text "")
-            ( \selected -> Halogen.HTML.div
-              [ Halogen.HTML.Properties.classes Ocelot.Block.Input.mainLeftClasses ]
-              [ Ocelot.Block.ItemContainer.selectionGroup renderItem
-                [ Halogen.HTML.Events.onClick Select.ToggleClick ]
-                [ Halogen.HTML.Events.onClick \_ -> Select.Action $ Remove selected ]
-                selected
-              ])
-            st.selected
-      , Ocelot.Block.Input.borderRight
-        [ Halogen.HTML.Properties.classes $ linkClasses disabled
-        , Halogen.HTML.Events.onClick Select.ToggleClick
+              ( \selected -> Halogen.HTML.div
+                  [ Halogen.HTML.Properties.classes Ocelot.Block.Input.mainLeftClasses ]
+                  [ Ocelot.Block.ItemContainer.selectionGroup renderItem
+                      [ Halogen.HTML.Events.onClick Select.ToggleClick ]
+                      [ Halogen.HTML.Events.onClick \_ -> Select.Action $ Remove selected ]
+                      selected
+                  ]
+              )
+              st.selected
+        , Ocelot.Block.Input.borderRight
+            [ Halogen.HTML.Properties.classes $ linkClasses disabled
+            , Halogen.HTML.Events.onClick Select.ToggleClick
+            ]
+            [ Halogen.HTML.text "Change" ]
         ]
-        [ Halogen.HTML.text "Change" ]
-      ]
     , Ocelot.Block.Input.inputGroup
-      [ Ocelot.HTML.Properties.css $ if showSelected then "offscreen" else "" ]
-      [ Ocelot.Block.Input.inputCenter $ inputProps disabled iprops
-      , Ocelot.Block.Input.addonLeft_
-        [ Ocelot.Block.Icon.search_ ]
-      , Ocelot.Block.Input.addonCenter
-        [ Ocelot.HTML.Properties.css $ if Network.RemoteData.isLoading st.items then "" else "offscreen" ]
-        [ spinner ]
-      , Ocelot.Block.Input.borderRight
-        [ Halogen.HTML.Properties.classes $ linkClasses disabled ]
-        [ Halogen.HTML.text "Browse" ]
-      ]
+        [ Ocelot.HTML.Properties.css $ if showSelected then "offscreen" else "" ]
+        [ Ocelot.Block.Input.inputCenter $ inputProps disabled iprops
+        , Ocelot.Block.Input.addonLeft_
+            [ Ocelot.Block.Icon.search_ ]
+        , Ocelot.Block.Input.addonCenter
+            [ Ocelot.HTML.Properties.css $ if Network.RemoteData.isLoading st.items then "" else "offscreen" ]
+            [ spinner ]
+        , Ocelot.Block.Input.borderRight
+            [ Halogen.HTML.Properties.classes $ linkClasses disabled ]
+            [ Halogen.HTML.text "Browse" ]
+        ]
     , Ocelot.Block.Conditional.conditional (st.visibility == Select.On)
         [ Ocelot.HTML.Properties.css "relative block" ]
         [ renderContainer st ]
@@ -1014,33 +996,34 @@ renderSingle iprops renderItem renderContainer st =
   disabled = st.disabled
   showSelected = Data.Maybe.isJust st.selected && st.visibility == Select.Off
 
-renderToolbarSearchDropdown
-  :: ∀ action f item m
-   . Eq item
-  => Data.Foldable.Foldable f
-  => String
-  -> (f item -> Halogen.HTML.PlainHTML)
-  -> (Data.Fuzzy.Fuzzy item -> Halogen.HTML.PlainHTML)
-  -> CompositeComponentRender action f item m
+renderToolbarSearchDropdown ::
+  forall action f item m.
+  Eq item =>
+  Data.Foldable.Foldable f =>
+  String ->
+  (f item -> Halogen.HTML.PlainHTML) ->
+  (Data.Fuzzy.Fuzzy item -> Halogen.HTML.PlainHTML) ->
+  CompositeComponentRender action f item m
 renderToolbarSearchDropdown resetLabel renderText renderFuzzy st =
   renderSearchDropdown resetLabel label renderFuzzy st
   where
-    label = Ocelot.Block.ItemContainer.dropdownButton
-      Halogen.HTML.span
-      [ Halogen.HTML.Properties.classes
-        $ Halogen.HTML.ClassName "whitespace-no-wrap"
-        : Ocelot.Button.buttonMainClasses
-        <> Ocelot.Button.buttonClearClasses
-      ]
-      [ (Halogen.HTML.fromPlainHTML <<< renderText) st.selected ]
+  label = Ocelot.Block.ItemContainer.dropdownButton
+    Halogen.HTML.span
+    [ Halogen.HTML.Properties.classes
+        $
+          Halogen.HTML.ClassName "whitespace-no-wrap"
+            : Ocelot.Button.buttonMainClasses
+            <> Ocelot.Button.buttonClearClasses
+    ]
+    [ (Halogen.HTML.fromPlainHTML <<< renderText) st.selected ]
 
-replaceSelected
-  :: forall action f item m
-  . Data.Foldable.Foldable f
-  => Eq item
-  => Effect.Aff.Class.MonadAff m
-  => f item
-  -> CompositeComponentM action f item m Unit
+replaceSelected ::
+  forall action f item m.
+  Data.Foldable.Foldable f =>
+  Eq item =>
+  Effect.Aff.Class.MonadAff m =>
+  f item ->
+  CompositeComponentM action f item m Unit
 replaceSelected selected = do
   st <- Halogen.modify _ { selected = selected }
   Halogen.tell _multiInput unit
@@ -1052,31 +1035,31 @@ replaceSelected selected = do
   Halogen.raise $ SelectionChanged ReplacementQuery st.selected
   synchronize
 
-spec
-  :: forall action f item m
-  . Control.Alternative.Plus f
-  => Data.Foldable.Foldable f
-  => Eq item
-  => Effect.Aff.Class.MonadAff m
-  => CompositeComponentRender action f item m
-  -> Spec action f item m
+spec ::
+  forall action f item m.
+  Control.Alternative.Plus f =>
+  Data.Foldable.Foldable f =>
+  Eq item =>
+  Effect.Aff.Class.MonadAff m =>
+  CompositeComponentRender action f item m ->
+  Spec action f item m
 spec embeddedRender =
   Select.defaultSpec
-  { render = embeddedRender
-  , handleAction = embeddedHandleAction
-  , handleQuery = embeddedHandleQuery
-  , handleEvent = embeddedHandleMessage
-  , initialize = embeddedInitialize
-  }
+    { render = embeddedRender
+    , handleAction = embeddedHandleAction
+    , handleQuery = embeddedHandleQuery
+    , handleEvent = embeddedHandleMessage
+    , initialize = embeddedInitialize
+    }
 
-spinner :: ∀ p i. Halogen.HTML.HTML p i
+spinner :: forall p i. Halogen.HTML.HTML p i
 spinner = Ocelot.Block.Loading.spinner [ Ocelot.HTML.Properties.css "w-6 text-blue-88" ]
 
-synchronize
-  :: forall action f item m
-  . Eq item
-  => Effect.Aff.Class.MonadAff m
-  => CompositeComponentM action f item m Unit
+synchronize ::
+  forall action f item m.
+  Eq item =>
+  Effect.Aff.Class.MonadAff m =>
+  CompositeComponentM action f item m Unit
 synchronize = do
   st <- Halogen.get
   case getNewItems st of
@@ -1084,12 +1067,14 @@ synchronize = do
       Halogen.modify_ _ { fuzzyItems = items }
     Network.RemoteData.Failure _ -> do
       Halogen.modify_
-        _ { visibility = Select.Off
+        _
+          { visibility = Select.Off
           , fuzzyItems = []
           }
     Network.RemoteData.NotAsked -> do
       Halogen.modify_
-        _ { visibility = Select.Off
+        _
+          { visibility = Select.Off
           , fuzzyItems = []
           }
     Network.RemoteData.Loading -> do

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,6 +1,7 @@
 module Test.Main where
 
 import Prelude
+
 import Effect (Effect)
 import Test.Ocelot.Data.Currency as Test.Ocelot.Data.Currency
 import Test.Ocelot.Data.IntervalTree as Test.Ocelot.Data.IntervalTree

--- a/test/Test/Data/Currency.purs
+++ b/test/Test/Data/Currency.purs
@@ -2,9 +2,9 @@ module Test.Ocelot.Data.Currency (suite) where
 
 import Prelude
 
-import Ocelot.Data.Currency (Cents(..), formatCentsToStrDollars, parseCentsFromDollarStr, parseCentsFromMicroDollars)
 import Data.BigInt as BigInt
 import Data.Maybe (Maybe(..))
+import Ocelot.Data.Currency (Cents(..), formatCentsToStrDollars, parseCentsFromDollarStr, parseCentsFromMicroDollars)
 import Test.QuickCheck ((===))
 import Test.Unit as Test.Unit
 import Test.Unit.Assert as Test.Unit.Assert
@@ -14,53 +14,63 @@ suite :: Test.Unit.TestSuite
 suite = do
   Test.Unit.suite "parsers" do
     Test.Unit.test "parseCentsFromMicroDollars" do
-      let expect = Just $ Cents $ BigInt.fromInt 1234
-          result = parseCentsFromMicroDollars 12340000.0
+      let
+        expect = Just $ Cents $ BigInt.fromInt 1234
+        result = parseCentsFromMicroDollars 12340000.0
       Test.Unit.Assert.equal expect result
 
     Test.Unit.test "parseCentsFromDollarStr NULL" do
-      let expect = Nothing
-          result = parseCentsFromDollarStr "NULL"
+      let
+        expect = Nothing
+        result = parseCentsFromDollarStr "NULL"
       Test.Unit.Assert.equal expect result
 
     Test.Unit.test "parseCentsFromDollarStr 12.34" do
-      let expect = Just $ Cents $ BigInt.fromInt 1234
-          result = parseCentsFromDollarStr "12.34"
+      let
+        expect = Just $ Cents $ BigInt.fromInt 1234
+        result = parseCentsFromDollarStr "12.34"
       Test.Unit.Assert.equal expect result
 
     Test.Unit.test "parseCentsFromDollarStr 1234" do
-      let expect = Just $ Cents $ BigInt.fromInt 123400
-          result = parseCentsFromDollarStr "1234"
+      let
+        expect = Just $ Cents $ BigInt.fromInt 123400
+        result = parseCentsFromDollarStr "1234"
       Test.Unit.Assert.equal expect result
 
     Test.Unit.test "parseCentsFromDollarStr 1234.00" do
-      let expect = Just $ Cents $ BigInt.fromInt 123400
-          result = parseCentsFromDollarStr "1234.00"
+      let
+        expect = Just $ Cents $ BigInt.fromInt 123400
+        result = parseCentsFromDollarStr "1234.00"
       Test.Unit.Assert.equal expect result
 
     Test.Unit.test "parseCentsFromDollarStr 123.4" do
-      let expect = Just $ Cents $ BigInt.fromInt 12340
-          result = parseCentsFromDollarStr "123.4"
+      let
+        expect = Just $ Cents $ BigInt.fromInt 12340
+        result = parseCentsFromDollarStr "123.4"
       Test.Unit.Assert.equal expect result
 
     Test.Unit.test "parseCentsFromDollarStr 1,234" do
-      let expect = Just $ Cents $ BigInt.fromInt 123400
-          result = parseCentsFromDollarStr "1,234"
+      let
+        expect = Just $ Cents $ BigInt.fromInt 123400
+        result = parseCentsFromDollarStr "1,234"
       Test.Unit.Assert.equal expect result
 
     Test.Unit.test "parseCentsFromDollarStr 1,234.00" do
-      let expect = Just $ Cents $ BigInt.fromInt 123400
-          result = parseCentsFromDollarStr "1,234.00"
+      let
+        expect = Just $ Cents $ BigInt.fromInt 123400
+        result = parseCentsFromDollarStr "1,234.00"
       Test.Unit.Assert.equal expect result
 
     Test.Unit.test "parseCentsFromDollarStr 1,234." do
-      let expect = Just $ Cents $ BigInt.fromInt 123400
-          result = parseCentsFromDollarStr "1,234."
+      let
+        expect = Just $ Cents $ BigInt.fromInt 123400
+        result = parseCentsFromDollarStr "1,234."
       Test.Unit.Assert.equal expect result
 
     Test.Unit.test "parseCentsFromDollarStr -1,234.50" do
-      let expect = Just $ Cents $ BigInt.fromInt (-123450)
-          result = parseCentsFromDollarStr "-1,234.50"
+      let
+        expect = Just $ Cents $ BigInt.fromInt (-123450)
+        result = parseCentsFromDollarStr "-1,234.50"
       Test.Unit.Assert.equal expect result
 
     Test.Unit.test "formatCentsToStrDollars 0.00" do

--- a/test/Test/Data/IntervalTree.purs
+++ b/test/Test/Data/IntervalTree.purs
@@ -65,9 +65,9 @@ insertIntervalTests =
         expected :: Ocelot.Data.IntervalTree.IntervalTree Int
         expected =
           Data.Map.fromFoldable
-          [ 1 /\ Ocelot.Data.IntervalTree.StartPoint
-          , 7 /\ Ocelot.Data.IntervalTree.EndPoint
-          ]
+            [ 1 /\ Ocelot.Data.IntervalTree.StartPoint
+            , 7 /\ Ocelot.Data.IntervalTree.EndPoint
+            ]
 
         actual :: Ocelot.Data.IntervalTree.IntervalTree Int
         actual = Ocelot.Data.IntervalTree.insertInterval intervalTree interval
@@ -195,13 +195,13 @@ findLeastUpperBoundTests =
       intervalTree :: Ocelot.Data.IntervalTree.IntervalTree Int
       intervalTree =
         Data.Map.fromFoldable
-        [ 1 /\ Ocelot.Data.IntervalTree.StartPoint
-        , 4 /\ Ocelot.Data.IntervalTree.EndPoint
-        , 8 /\ Ocelot.Data.IntervalTree.StartPoint
-        , 10 /\ Ocelot.Data.IntervalTree.EndPoint
-        , 12 /\ Ocelot.Data.IntervalTree.StartPoint
-        , 15 /\ Ocelot.Data.IntervalTree.EndPoint
-        ]
+          [ 1 /\ Ocelot.Data.IntervalTree.StartPoint
+          , 4 /\ Ocelot.Data.IntervalTree.EndPoint
+          , 8 /\ Ocelot.Data.IntervalTree.StartPoint
+          , 10 /\ Ocelot.Data.IntervalTree.EndPoint
+          , 12 /\ Ocelot.Data.IntervalTree.StartPoint
+          , 15 /\ Ocelot.Data.IntervalTree.EndPoint
+          ]
     Test.Unit.test "Just" do
       let
         -- (1 4) (8 10) (12 15)

--- a/test/Test/HTML/Properties.purs
+++ b/test/Test/HTML/Properties.purs
@@ -18,21 +18,22 @@ suite =
   Test.Unit.suite "Ocelot.HTML.Properties" do
     Test.Unit.suite "appendIProps" do
       Test.Unit.test "right side overrides left side" do
-        let ipropsA = [ css "m-10 p-10 px-5 pb-12 min-w-80 w-full shadow overflow-hidden" ]
-            ipropsB = [ css "p-5 pb-10 min-w-100 overflow-auto h-full" ]
-            (Tuple results _) = extract (ipropsA <&> ipropsB)
-            results' = Set.fromFoldable results
-            expected = Set.fromFoldable
-              [ "m-10"
-              , "p-5"
-              , "px-5"
-              , "pb-10"
-              , "min-w-100"
-              , "w-full"
-              , "shadow"
-              , "overflow-auto"
-              , "h-full"
-              ]
+        let
+          ipropsA = [ css "m-10 p-10 px-5 pb-12 min-w-80 w-full shadow overflow-hidden" ]
+          ipropsB = [ css "p-5 pb-10 min-w-100 overflow-auto h-full" ]
+          (Tuple results _) = extract (ipropsA <&> ipropsB)
+          results' = Set.fromFoldable results
+          expected = Set.fromFoldable
+            [ "m-10"
+            , "p-5"
+            , "px-5"
+            , "pb-10"
+            , "min-w-100"
+            , "w-full"
+            , "shadow"
+            , "overflow-auto"
+            , "h-full"
+            ]
         Test.Unit.Assert.equal expected results'
 
       Test.Unit.test "appendIProps profile" do
@@ -45,14 +46,16 @@ suite =
         -- milliseconds to run
         start <- Effect.Class.liftEffect Effect.Now.now
         _ <- Test.Unit.Console.log $ "Start time: " <> show start
-        let ipropsA = [ css "m-10 p-10 px-5 pb-12 min-w-80 w-full shadow overflow-hidden" ]
-            ipropsB = [ css "p-5 pb-10 min-w-100 overflow-auto h-full" ]
-            go x acc
-              | x <= 0     = acc
-              | otherwise  = go (x - 1) (ipropsA <&> ipropsB)
-            _ = go 10000 []
+        let
+          ipropsA = [ css "m-10 p-10 px-5 pb-12 min-w-80 w-full shadow overflow-hidden" ]
+          ipropsB = [ css "p-5 pb-10 min-w-100 overflow-auto h-full" ]
+          go x acc
+            | x <= 0 = acc
+            | otherwise = go (x - 1) (ipropsA <&> ipropsB)
+          _ = go 10000 []
         end <- Effect.Class.liftEffect Effect.Now.now
         _ <- Test.Unit.Console.log $ "End time: " <> show end
-        let (Milliseconds start') = unInstant start
-            (Milliseconds end')   = unInstant end
-        Test.Unit.Console.log $ "Total ellapsed time: (Milliseconds " <> ( show $ end' - start' ) <> ")"
+        let
+          (Milliseconds start') = unInstant start
+          (Milliseconds end') = unInstant end
+        Test.Unit.Console.log $ "Total ellapsed time: (Milliseconds " <> (show $ end' - start') <> ")"

--- a/test/Test/TimePicker.purs
+++ b/test/Test/TimePicker.purs
@@ -1,6 +1,7 @@
 module Test.Ocelot.TimePicker (suite) where
 
 import Prelude
+
 import Data.Maybe (Maybe(..))
 import Data.Time as Data.Time
 import Ocelot.Data.DateTime as Ocelot.Data.DateTime

--- a/test/Test/Typeahead.purs
+++ b/test/Test/Typeahead.purs
@@ -1,6 +1,7 @@
 module Test.Ocelot.Typeahead (suite) where
 
 import Prelude
+
 import Data.Array as Data.Array
 import Data.Fuzzy as Data.Fuzzy
 import Data.Maybe (Maybe(..))
@@ -10,7 +11,7 @@ import Foreign.Object as Foreign.Object
 import Ocelot.Typeahead as Ocelot.Typeahead
 import Test.Unit as Test.Unit
 import Test.Unit.Assert as Test.Unit.Assert
-  
+
 suite :: Test.Unit.TestSuite
 suite =
   Test.Unit.suite "Ocelot.Typeahead" do
@@ -19,46 +20,46 @@ suite =
         let
           actual =
             Ocelot.Typeahead.getNewItems'
-              { insertable: Ocelot.Typeahead.NotInsertable 
+              { insertable: Ocelot.Typeahead.NotInsertable
               , itemToObject: Foreign.Object.fromHomogeneous <<< { name: _ }
               , runFilterFuzzy: Ocelot.Typeahead.defFilterFuzzy
-              , runFilterItems: Data.Array.difference 
+              , runFilterItems: Data.Array.difference
               , search: "foo"
-              , selected: ["foo", "bar"]
+              , selected: [ "foo", "bar" ]
               }
-              ["foo", "boof", "fooboo", "food", "baz"]
+              [ "foo", "boof", "fooboo", "food", "baz" ]
 
-          expected = ["food", "fooboo"]
+          expected = [ "food", "fooboo" ]
         unfuzzyTestResults { actual, expected }
       Test.Unit.test "filters out selected Maybe item and poor matches, and sorts results" do
         let
           actual =
             Ocelot.Typeahead.getNewItems'
-              { insertable: Ocelot.Typeahead.NotInsertable 
+              { insertable: Ocelot.Typeahead.NotInsertable
               , itemToObject: Foreign.Object.fromHomogeneous <<< { name: _ }
               , runFilterFuzzy: Ocelot.Typeahead.defFilterFuzzy
               , runFilterItems: \items -> Data.Maybe.maybe items (\item -> Data.Array.filter (_ /= item) items)
               , search: "foo"
               , selected: Just "foo"
               }
-              ["foo", "boof", "fooboo", "food", "baz"]
+              [ "foo", "boof", "fooboo", "food", "baz" ]
 
-          expected = ["food", "fooboo"]
+          expected = [ "food", "fooboo" ]
         unfuzzyTestResults { actual, expected }
       Test.Unit.test "doesn't filter poor matches or sort results" do
         let
           actual =
             Ocelot.Typeahead.getNewItems'
-              { insertable: Ocelot.Typeahead.NotInsertable 
+              { insertable: Ocelot.Typeahead.NotInsertable
               , itemToObject: Foreign.Object.fromHomogeneous <<< { name: _ }
               , runFilterFuzzy: identity
-              , runFilterItems: Data.Array.difference 
+              , runFilterItems: Data.Array.difference
               , search: "foo"
-              , selected: ["foo", "bar"]
+              , selected: [ "foo", "bar" ]
               }
-              ["foo", "food", "boof", "fooboo", "baz"]
+              [ "foo", "food", "boof", "fooboo", "baz" ]
 
-          expected = ["food", "boof", "fooboo", "baz"]
+          expected = [ "food", "boof", "fooboo", "baz" ]
         unfuzzyTestResults { actual, expected }
       Test.Unit.test "inserts search to results without a perfect match" do
         let
@@ -69,26 +70,26 @@ suite =
               , runFilterFuzzy: Ocelot.Typeahead.defFilterFuzzy
               , runFilterItems: \items _ -> items
               , search: "foo"
-              , selected: Nothing 
+              , selected: Nothing
               }
-              ["food"]
+              [ "food" ]
 
-          expected = ["foo", "food"]
+          expected = [ "foo", "food" ]
         unfuzzyTestResults { actual, expected }
       Test.Unit.test "doesn't insert search into non-empty results" do
         let
-          actual  =
+          actual =
             Ocelot.Typeahead.getNewItems'
               { insertable: Ocelot.Typeahead.Insertable identity
               , itemToObject: Foreign.Object.fromHomogeneous <<< { name: _ }
               , runFilterFuzzy: Ocelot.Typeahead.defFilterFuzzy
               , runFilterItems: \items _ -> items
               , search: "foo"
-              , selected: Nothing 
+              , selected: Nothing
               }
-              ["foo", "food"]
+              [ "foo", "food" ]
 
-          expected = ["foo", "food"]
+          expected = [ "foo", "food" ]
         unfuzzyTestResults { actual, expected }
 
 unfuzzyTestResults ::

--- a/yarn.lock
+++ b/yarn.lock
@@ -1510,9 +1510,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001286:
-  version "1.0.30001302"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001302.tgz#da57ce61c51177ef3661eeed7faef392d3790aaa"
-  integrity sha512-YYTMO+tfwvgUN+1ZnRViE53Ma1S/oETg+J2lISsqi/ZTNThj3ZYBOKP2rHwJc37oCsPqAzJ3w2puZHn0xlLPPw==
+  version "1.0.30001445"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001445.tgz"
+  integrity sha512-8sdQIdMztYmzfTMO6KfLny878Ln9c2M0fc7EH60IjlP4Dc4PiCy7K2Vl3ITmWgOyPgVQKa5x+UP/KqFsxj4mBg==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -4399,6 +4399,11 @@ purescript@0.14.9:
   integrity sha512-r0J2JX/QuKYBSj8LDDYKQAY+tz/RtIm9erHrqWV7Y8RpUc6TZu14AxWcnSrohbBcEXImY/o0pMpouZrUeyriKQ==
   dependencies:
     purescript-installer "^0.2.0"
+
+purs-tidy@0.9.2:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/purs-tidy/-/purs-tidy-0.9.2.tgz#b67e4a18ee3125edb4562cd5e3244dafe747cfdd"
+  integrity sha512-v7Do4E9Tx2OqEhJXKl5tJxjRcmDilMObm0+XgYphpbMelkUQ+CfhtetIk294byhaL18OpEHqmO6BUkyNCBJDpQ==
 
 qs@~6.5.2:
   version "6.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4393,10 +4393,10 @@ purescript-psa@0.8.2:
   resolved "https://registry.yarnpkg.com/purescript-psa/-/purescript-psa-0.8.2.tgz#ee20c40f02cd0c5ed6dd3dd93ef02d9c466f17bc"
   integrity sha512-4Olf0aQQrNCfcDLXQI3gJgINEQ+3U+4QPLmQ2LHX2L/YOXSwM7fOGIUs/wMm/FQnwERUyQmHKQTJKB4LIjE2fg==
 
-purescript@0.14.4:
-  version "0.14.4"
-  resolved "https://registry.yarnpkg.com/purescript/-/purescript-0.14.4.tgz#16096b589a5c81aa5813c805dc16c0b9f5b7a854"
-  integrity sha512-9Lq2qvyVkQoKUBSNOEBKIJjtD5sDwThurSt3SRdtSseaA03p1Fk7VxbUr9HV/gHLVZPIkOhPtjvZGUNs5U2PDA==
+purescript@0.14.9:
+  version "0.14.9"
+  resolved "https://registry.yarnpkg.com/purescript/-/purescript-0.14.9.tgz#fc4700aa66fb878a20b8bc33cc00919a34b9da48"
+  integrity sha512-r0J2JX/QuKYBSj8LDDYKQAY+tz/RtIm9erHrqWV7Y8RpUc6TZu14AxWcnSrohbBcEXImY/o0pMpouZrUeyriKQ==
   dependencies:
     purescript-installer "^0.2.0"
 


### PR DESCRIPTION
## What does this pull request do?

Before, when a single-value Typeahead is disabled, one can still change the selection by clicking on `Change` button to open the item container and then make a selection there. Fixed by not registering `ToggleClick` action on the `Change` button (a `span` styled as a button which doesn't support `disabled` prop) when the Typeahead is disabled.

## How should this be manually tested?

- [x] `make`
- [x] open `dist/index.html` and go to Typeahead tab (`#typeaheads`)
- [x] scroll down to `Typeaheads - State Variants` section, second example on the left, and click on the `Change` button
  - nothing should happen
  - you can check the broken behavior in [current UI Guide](https://citizennet.github.io/purescript-ocelot/#typeaheads) for comparison

<img src="https://user-images.githubusercontent.com/18127498/213300055-04def4af-9e4c-4f79-b358-df617b7d4fe6.png" width=400px />
